### PR TITLE
Fix custom trees

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/registries/RTFRegistries.java
+++ b/common/src/main/java/raccoonman/reterraforged/registries/RTFRegistries.java
@@ -27,7 +27,7 @@ public class RTFRegistries {
 	public static final ResourceKey<Registry<MapCodec<? extends StructureRule>>> STRUCTURE_RULE_TYPE = createKey("worldgen/structure_rule_type");
 
 	public static final ResourceKey<Registry<Noise>> NOISE = createKey("worldgen/noise");
-	public static final ResourceKey<Registry<BiomeModifier>> BIOME_MODIFIER = createKey("biome_modifier");
+	public static final ResourceKey<Registry<BiomeModifier>> BIOME_MODIFIER = createKey("neoforge:biome_modifier");
 	public static final ResourceKey<Registry<StructureRule>> STRUCTURE_RULE = createKey("worldgen/structure_rule");
 
 	@Deprecated

--- a/neoforge/src/main/java/raccoonman/reterraforged/neoforge/RTFNeoForge.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/neoforge/RTFNeoForge.java
@@ -1,39 +1,57 @@
 package raccoonman.reterraforged.neoforge;
 
+import com.mojang.serialization.MapCodec;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.data.PackOutput;
 import net.minecraft.data.metadata.PackMetadataGenerator;
 import net.minecraft.network.chat.Component;
 import net.neoforged.api.distmarker.Dist;
-import net.neoforged.fml.ModContainer;
-import net.neoforged.neoforge.data.event.GatherDataEvent;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLEnvironment;
+import net.neoforged.neoforge.common.world.BiomeModifier;
+import net.neoforged.neoforge.data.event.GatherDataEvent;
+import net.neoforged.neoforge.registries.DeferredRegister;
+import net.neoforged.neoforge.registries.NeoForgeRegistries;
 import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.client.data.RTFLanguageProvider;
 import raccoonman.reterraforged.client.data.RTFTranslationKeys;
 import raccoonman.reterraforged.platform.neoforge.RegistryUtilImpl;
+import raccoonman.reterraforged.world.worldgen.biome.modifier.neoforge.AddModifier;
+import raccoonman.reterraforged.world.worldgen.biome.modifier.neoforge.ReplaceModifier;
 
 @Mod("reterraforged")
 public class RTFNeoForge {
 
-    public RTFNeoForge(IEventBus modEventBus, ModContainer container) {
-    	RTFCommon.bootstrap();
+	public RTFNeoForge(IEventBus modEventBus, ModContainer container) {
+		RTFCommon.bootstrap();
 
-    	if (FMLEnvironment.dist == Dist.CLIENT) {
-    		modEventBus.addListener(RTFNeoForgeClient::registerPresetEditors);
-    	}
-    	modEventBus.addListener(RTFNeoForge::gatherData);
-    	RegistryUtilImpl.register(modEventBus);
-    }
-    
-    private static void gatherData(GatherDataEvent event) {
-    	boolean includeClient = true; //event.includeClient();
-    	DataGenerator generator = event.getGenerator();
-    	PackOutput output = generator.getPackOutput();
+		// Register RTF's biome modifier codec types into NeoForge's own serialiser
+		// registry so NeoForge can decode neoforge/biome_modifier/*.json at runtime.
+		// RTFBuiltInRegistries.BIOME_MODIFIER_TYPE (forge:biome_modifier_serializers)
+		// is RTF's internal dispatch registry used by BiomeModifier.DIRECT_CODEC for
+		// data-gen and Fabric; it is separate and both registries must be populated.
+		DeferredRegister<MapCodec<? extends BiomeModifier>> biomeModifierSerializers =
+				DeferredRegister.create(NeoForgeRegistries.Keys.BIOME_MODIFIER_SERIALIZERS, RTFCommon.MOD_ID);
+		biomeModifierSerializers.register("add",     () -> AddModifier.CODEC);
+		biomeModifierSerializers.register("replace", () -> ReplaceModifier.CODEC);
+		biomeModifierSerializers.register(modEventBus);
 
-    	generator.addProvider(includeClient, new RTFLanguageProvider.EnglishUS(output));
-    	generator.addProvider(includeClient, PackMetadataGenerator.forFeaturePack(output, Component.translatable(RTFTranslationKeys.METADATA_DESCRIPTION)));
-    }
+		if (FMLEnvironment.dist == Dist.CLIENT) {
+			modEventBus.addListener(RTFNeoForgeClient::registerPresetEditors);
+		}
+		modEventBus.addListener(RTFNeoForge::gatherData);
+		RegistryUtilImpl.register(modEventBus);
+	}
+
+	private static void gatherData(GatherDataEvent event) {
+		boolean includeClient = true;
+		DataGenerator generator = event.getGenerator();
+		PackOutput output = generator.getPackOutput();
+
+		generator.addProvider(includeClient, new RTFLanguageProvider.EnglishUS(output));
+		generator.addProvider(includeClient, PackMetadataGenerator.forFeaturePack(
+				output, Component.translatable(RTFTranslationKeys.METADATA_DESCRIPTION)));
+	}
 }

--- a/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/AddModifier.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/AddModifier.java
@@ -20,7 +20,7 @@ import raccoonman.reterraforged.neoforge.mixin.MixinBiomeGenerationSettingsPlain
 import raccoonman.reterraforged.world.worldgen.biome.modifier.Filter;
 import raccoonman.reterraforged.world.worldgen.biome.modifier.Order;
 
-record AddModifier(Order order, GenerationStep.Decoration step, Optional<Filter> biomes, HolderSet<PlacedFeature> features) implements ForgeBiomeModifier {
+public record AddModifier(Order order, GenerationStep.Decoration step, Optional<Filter> biomes, HolderSet<PlacedFeature> features) implements ForgeBiomeModifier {
 	public static final MapCodec<AddModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
 		Order.CODEC.fieldOf("order").forGetter(AddModifier::order),
 		GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(AddModifier::step),

--- a/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/ReplaceModifier.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/ReplaceModifier.java
@@ -1,9 +1,6 @@
 package raccoonman.reterraforged.world.worldgen.biome.modifier.neoforge;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import com.mojang.serialization.MapCodec;
 
@@ -21,31 +18,33 @@ import net.neoforged.neoforge.common.world.BiomeModifier;
 import net.neoforged.neoforge.common.world.ModifiableBiomeInfo.BiomeInfo;
 import raccoonman.reterraforged.neoforge.mixin.MixinBiomeGenerationSettingsPlainsBuilder;
 
-record ReplaceModifier(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) implements ForgeBiomeModifier {
+public record ReplaceModifier(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) implements ForgeBiomeModifier {
 	public static final MapCodec<ReplaceModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
 		GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(ReplaceModifier::step),
 		Biome.LIST_CODEC.optionalFieldOf("biomes").forGetter(ReplaceModifier::biomes),
 		Codec.unboundedMap(ResourceKey.codec(Registries.PLACED_FEATURE), PlacedFeature.CODEC).fieldOf("replacements").forGetter(ReplaceModifier::replacements)
 	).apply(instance, ReplaceModifier::new));
-	
+
 	@Override
 	public void modify(Holder<Biome> biome, BiomeModifier.Phase phase, BiomeInfo.Builder builder) {
-		if(phase == BiomeModifier.Phase.AFTER_EVERYTHING) {
-			if(builder.getGenerationSettings() instanceof MixinBiomeGenerationSettingsPlainsBuilder builderAccessor) {
-				if(this.biomes.isPresent() && !this.biomes.get().contains(biome)) {
+		if (phase == BiomeModifier.Phase.AFTER_EVERYTHING) {
+			if (builder.getGenerationSettings() instanceof MixinBiomeGenerationSettingsPlainsBuilder builderAccessor) {
+				if (this.biomes.isPresent() && !this.biomes.get().contains(biome)) {
 					return;
 				}
-				
+
 				List<List<Holder<PlacedFeature>>> featureSteps = builderAccessor.getFeatures();
 				int index = this.step.ordinal();
-	
+
 				while (index >= featureSteps.size()) {
 					featureSteps.add(Collections.emptyList());
 				}
 
-				featureSteps.get(index).replaceAll((f) -> {
-					return f.unwrapKey().map(this.replacements::get).orElse(f);
-				});
+				// Copy to a new mutable list, then set it back
+				List<Holder<PlacedFeature>> replaced = new ArrayList<>(featureSteps.get(index));
+				replaced.replaceAll((f) -> f.unwrapKey().map(this.replacements::get).orElse(f));
+				featureSteps.set(index, replaced);
+
 			} else {
 				throw new IllegalStateException();
 			}


### PR DESCRIPTION
Custom biome decorators were broken in migration from forge -> Neoforge. This pr fixes them by updating the replacemodifier implementation and the underlying registry naming (determining folder output structure) so that Neoforge loads them correctly.