### PR TITLE
Prevent preview flicker

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -40,6 +40,9 @@ public class Preview2D extends Button {
     public static final int SIZE = (1 << 4) << FACTOR;
     private static final float[] LEGEND_SCALES = { 1, 0.9F, 0.75F, 0.6F };
 
+    // Static cache to hold pixels between UI page transitions to prevent black flickering
+    private static int[] LAST_SUCCESSFUL_PIXELS = null;
+
     private final PresetEditorPage page;
     private final DynamicTexture texture = new DynamicTexture(new NativeImage(SIZE, SIZE, false));
     private final ResourceLocation textureId = Minecraft.getInstance().getTextureManager().register(RTFCommon.MOD_ID + "-preview-framebuffer", this.texture);
@@ -87,7 +90,16 @@ public class Preview2D extends Button {
 
         NativeImage pixels = this.texture.getPixels();
         if (pixels != null) {
-            pixels.fillRect(0, 0, SIZE, SIZE, 0xFF000000);
+            // If we have cached pixels from a previous page view, populate immediately to hide the loading window
+            if (LAST_SUCCESSFUL_PIXELS != null && LAST_SUCCESSFUL_PIXELS.length == SIZE * SIZE) {
+                for (int bz = 0; bz < SIZE; bz++) {
+                    for (int bx = 0; bx < SIZE; bx++) {
+                        pixels.setPixelRGBA(bx, bz, LAST_SUCCESSFUL_PIXELS[bz * SIZE + bx]);
+                    }
+                }
+            } else {
+                pixels.fillRect(0, 0, SIZE, SIZE, 0xFF000000);
+            }
             this.texture.upload();
         }
     }
@@ -188,6 +200,13 @@ public class Preview2D extends Button {
                 NativeImage pixels = this.texture.getPixels();
                 if (pixels != null && result.pixelData != null) {
                     int tileWidth = this.tile.getBlockSize().size();
+
+                    // Maintain global static cache frame arrays
+                    if (LAST_SUCCESSFUL_PIXELS == null || LAST_SUCCESSFUL_PIXELS.length != result.pixelData.length) {
+                        LAST_SUCCESSFUL_PIXELS = new int[result.pixelData.length];
+                    }
+                    System.arraycopy(result.pixelData, 0, LAST_SUCCESSFUL_PIXELS, 0, result.pixelData.length);
+
                     for (int bz = 0; bz < tileWidth; bz++) {
                         for (int bx = 0; bx < tileWidth; bx++) {
                             pixels.setPixelRGBA(bx, bz, result.pixelData[bz * tileWidth + bx]);
@@ -250,7 +269,8 @@ public class Preview2D extends Button {
         int xPos = this.getX();
         int yPos = this.getY();
 
-        if (this.tile == null) {
+        // Render the image if we have local tile data OR static background frame history ready to display
+        if (this.tile == null && LAST_SUCCESSFUL_PIXELS == null) {
             guiGraphics.fill(xPos, yPos, xPos + this.width, yPos + this.height, 0xFF000000);
         } else {
             RenderSystem.enableBlend();

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -40,6 +40,11 @@ public class Preview3D extends Button {
 
     public static RenderMode currentMode = RenderMode.BIOME_TYPE;
 
+    // Static cache fields to bridge across instances during page preset updates
+    private static Tile LAST_GLOBAL_TILE = null;
+    private static int LAST_GLOBAL_CENTER_X = 0;
+    private static int LAST_GLOBAL_CENTER_Z = 0;
+
     private PresetEditorPage page;
     private Tile tile;
     private int centerX, centerZ;
@@ -166,6 +171,12 @@ public class Preview3D extends Button {
                 this.tile = result.tile;
                 this.centerX = result.centerX;
                 this.centerZ = result.centerZ;
+
+                // Sync context parameters out to global tracking pointers
+                LAST_GLOBAL_TILE = result.tile;
+                LAST_GLOBAL_CENTER_X = result.centerX;
+                LAST_GLOBAL_CENTER_Z = result.centerZ;
+
                 this.legendValues[3] = getSpawnCoords();
                 this.needsTextureRefresh = true;
 
@@ -181,7 +192,8 @@ public class Preview3D extends Button {
     }
 
     private void rebuildTexture() {
-        if (this.tile == null || this.width <= 0 || this.height <= 0) return;
+        Tile activeTile = this.tile != null ? this.tile : LAST_GLOBAL_TILE;
+        if (activeTile == null || this.width <= 0 || this.height <= 0) return;
 
         if (this.textureCache == null || this.textureCache.getPixels().getWidth() != this.width || this.textureCache.getPixels().getHeight() != this.height) {
             if (this.textureCache != null) {
@@ -209,7 +221,7 @@ public class Preview3D extends Button {
         WorldSettings.Properties properties = this.page.preset.getPreset().world().properties;
         Levels levels = new Levels(properties.terrainScaler(), properties.seaLevel);
 
-        int tileSize = this.tile.getBlockSize().size();
+        int tileSize = activeTile.getBlockSize().size();
         float rawBlockW = (float) this.width / (float) tileSize * 0.85f;
         int halfW = Math.max(1, (int) (rawBlockW / 2.0f));
         int halfH = Math.max(1, halfW / 2);
@@ -224,7 +236,7 @@ public class Preview3D extends Button {
 
         for (int iz = 0; iz < tileSize; iz++) {
             for (int ix = 0; ix < tileSize; ix++) {
-                Cell cell = this.tile.lookup(ix, iz);
+                Cell cell = activeTile.lookup(ix, iz);
                 int color = mode.getColor(cell, levels);
 
                 int r = (color >> 16) & 0xFF;
@@ -333,8 +345,11 @@ public class Preview3D extends Button {
         int x = this.getX();
         int y = this.getY();
 
-        if (this.needsTextureRefresh || this.textureCache == null) {
-            this.rebuildTexture();
+        // Check if either local tile or fallback history data exists to drive structural generation
+        if (this.tile != null || LAST_GLOBAL_TILE != null) {
+            if (this.needsTextureRefresh || this.textureCache == null) {
+                this.rebuildTexture();
+            }
         }
 
         if (this.cacheLocation != null) {
@@ -369,14 +384,18 @@ public class Preview3D extends Button {
 
         if (props.spawnType == SpawnType.USER_SELECTED || props.spawnType == SpawnType.CONTINENT_CENTER) {
             int zoomValue = this.getZoom();
-            int tileSize = this.tile != null ? this.tile.getBlockSize().size() : 0;
+            Tile activeTile = this.tile != null ? this.tile : LAST_GLOBAL_TILE;
+            int tileSize = activeTile != null ? activeTile.getBlockSize().size() : 0;
 
             if (tileSize > 0) {
-                int ix = NoiseUtil.round(((float)(props.spawnX - this.centerX) / zoomValue) + (tileSize / 2.0f));
-                int iz = NoiseUtil.round(((float)(props.spawnZ - this.centerZ) / zoomValue) + (tileSize / 2.0f));
+                int activeCX = this.tile != null ? this.centerX : LAST_GLOBAL_CENTER_X;
+                int activeCZ = this.tile != null ? this.centerZ : LAST_GLOBAL_CENTER_Z;
+
+                int ix = NoiseUtil.round(((float)(props.spawnX - activeCX) / zoomValue) + (tileSize / 2.0f));
+                int iz = NoiseUtil.round(((float)(props.spawnZ - activeCZ) / zoomValue) + (tileSize / 2.0f));
 
                 if (ix >= 0 && ix < tileSize && iz >= 0 && iz < tileSize) {
-                    Cell cell = this.tile.lookup(ix, iz);
+                    Cell cell = activeTile.lookup(ix, iz);
 
                     float rawBlockW = (float) this.width / (float) tileSize * 0.85f;
                     int halfW = Math.max(1, (int) (rawBlockW / 2.0f));
@@ -422,12 +441,13 @@ public class Preview3D extends Button {
     }
 
     private boolean updateLegend(int mx, int my) {
-        if (this.tile != null) {
+        Tile activeTile = this.tile != null ? this.tile : LAST_GLOBAL_TILE;
+        if (activeTile != null) {
             int left = this.getX();
             int top = this.getY();
 
             int zoomValue = this.getZoom();
-            int tileSize = this.tile.getBlockSize().size();
+            int tileSize = activeTile.getBlockSize().size();
 
             int totalWidth = Math.max(1, tileSize * zoomValue);
             int totalHeight = Math.max(1, tileSize * zoomValue);
@@ -461,17 +481,20 @@ public class Preview3D extends Button {
                     this.lastHoveredIx = ix;
                     this.lastHoveredIz = iz;
 
-                    Cell cell = this.tile.lookup(ix, iz);
+                    Cell cell = activeTile.lookup(ix, iz);
                     this.legendValues[1] = getTerrainName(cell);
                     this.legendValues[2] = getBiomeName(cell);
-                    this.legendValues[3] = getSpawnCoords();
+
+                    int activeCX = this.tile != null ? this.centerX : LAST_GLOBAL_CENTER_X;
+                    int activeCZ = this.tile != null ? this.centerZ : LAST_GLOBAL_CENTER_Z;
+                    this.legendValues[3] = getSpawnCoords(activeCX, activeCZ);
 
                     int worldOffsetX = (ix - (tileSize / 2)) * zoomValue;
                     int worldOffsetZ = (iz - (tileSize / 2)) * zoomValue;
 
-                    this.hoveredCoords = (this.centerX + worldOffsetX) + ":" + (this.centerZ + worldOffsetZ);
-                    this.hoveredCoordX = this.centerX + worldOffsetX;
-                    this.hoveredCoordZ = this.centerZ + worldOffsetZ;
+                    this.hoveredCoords = (activeCX + worldOffsetX) + ":" + (activeCZ + worldOffsetZ);
+                    this.hoveredCoordX = activeCX + worldOffsetX;
+                    this.hoveredCoordZ = activeCZ + worldOffsetZ;
                 }
                 return true;
             } else {
@@ -544,12 +567,18 @@ public class Preview3D extends Button {
     }
 
     private String getSpawnCoords() {
+        int activeCX = this.tile != null ? this.centerX : LAST_GLOBAL_CENTER_X;
+        int activeCZ = this.tile != null ? this.centerZ : LAST_GLOBAL_CENTER_Z;
+        return getSpawnCoords(activeCX, activeCZ);
+    }
+
+    private String getSpawnCoords(int cx, int cz) {
         WorldSettings.Properties props = this.page.preset.getPreset().world().properties;
         if (props.spawnType == SpawnType.USER_SELECTED) {
             return "x" + props.spawnX + " z" + props.spawnZ;
         }
         if (props.spawnType == SpawnType.CONTINENT_CENTER || props.spawnType == SpawnType.ISLANDS) {
-            return "~x" + this.centerX + " ~z" + this.centerZ;
+            return "~x" + cx + " ~z" + cz;
         }
         return "x0 z0";
     }


### PR DESCRIPTION
Prevent preview flicker when changing world gen customization page by caching last result.