### PR TITLE
Stability Fix - Obscure sw travel crash fix

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/tile/Tile.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/tile/Tile.java
@@ -61,7 +61,7 @@ public class Tile implements SafeCloseable, Filterable, CellLookup {
         int relChunkX = this.chunkSize.border() + this.chunkSize.mask(chunkX);
         int relChunkZ = this.chunkSize.border() + this.chunkSize.mask(chunkZ);
         int index = this.chunkSize.indexOf(relChunkX, relChunkZ);
-        return this.computeChunk(index, chunkX, chunkZ);
+        return this.computeChunk(index, relChunkX, relChunkZ);
 	}
 	
     public void iterate(Cell.Visitor visitor) {


### PR DESCRIPTION
Probably fixes https://github.com/ETcodehome/ReTerraForged/issues/41

***

The specific circumstance that triggers this is natural terrain generation while exploring deep into negative X/Z coordinates (e.g., flying South-West).

Here is the step-by-step mathematical breakdown of exactly how the game accidentally calculated -2559520.
1. The Setup: Deep Negative Exploration

You are flying around, and the game needs to generate a new block for the world at the absolute coordinates of X: -160 and Z: -13330.

Because of the upstream constructor bug we found in Tile.java, the Chunk object was initialized using absolute coordinates instead of tile-relative coordinates. This means the chunk saved its origin variables like this:

    regionBlockX = -160

    regionBlockZ = -13344 (Chunks are 16 blocks wide, and -13344 is the start of the chunk containing -13330)

2. The Request: Looking up the Block

The terrain carver asks the Chunk for the data at (-160, -13330). The getCell method runs:
Java

public Cell getCell(int blockX, int blockZ) {
    int relX = this.regionBlockX + (blockX & 0xF);
    int relZ = this.regionBlockZ + (blockZ & 0xF);
    // ...

First, it uses a bitwise AND (& 0xF) to find the local block position inside that specific 16x16 chunk.

    -160 & 15 = 0

    -13330 & 15 = 14

Next, it adds those local offsets to the contaminated region variables:

    relX = -160 + 0 = -160

    relZ = -13344 + 14 = -13330

3. The Explosion: The Array Index Formula

Now the code has to convert those 2D coordinates (-160, -13330) into a single 1D array index to fetch the data from the 36864-length cache array.

It uses the standard flattening formula (where the tile width is 192 blocks):
index=(relZ×192)+relX

Plug in our poisoned variables:
index=(−13330×192)+(−160)
index=−2559360−160
index=−2559520

The game asks Java to look at position -2559520 inside the array. Since arrays start at 0, the JVM immediately throws the ArrayIndexOutOfBoundsException and the server dies.
What Should Have Happened

If the chunk had been initialized properly, regionBlockX and regionBlockZ would have stored the distance from the edge of the local tile (a number between 0 and 176), not the absolute world.

If this chunk was the 3rd chunk from the top-left of the tile, regionBlockZ would have simply been 32.

    relZ = 32 + 14 = 46

    relX = 32 + 0 = 32

The array lookup would have been:
index=(46×192)+32=8864

8864 is a perfectly safe index inside the 36864-length array, and the game would have continued generating your rivers without skipping a beat.