### PR TITLE
Tag fixes

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,3 +38,9 @@ subprojects {
         }
     }
 }
+
+processResources {
+    filesMatching("pack.mcmeta") {
+        expand project.properties
+    }
+}

--- a/common/src/main/resources/data/reterraforged/tags/block/clay.json
+++ b/common/src/main/resources/data/reterraforged/tags/block/clay.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:clay"
+  ]
+}

--- a/common/src/main/resources/data/reterraforged/tags/block/erodible.json
+++ b/common/src/main/resources/data/reterraforged/tags/block/erodible.json
@@ -1,0 +1,11 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:snow_block",
+    "minecraft:powder_snow",
+    "minecraft:gravel"
+  ],
+  "values_from_tags": [
+    "minecraft:dirt"
+  ]
+}

--- a/common/src/main/resources/data/reterraforged/tags/block/rock.json
+++ b/common/src/main/resources/data/reterraforged/tags/block/rock.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:stone",
+    "minecraft:granite",
+    "minecraft:andesite",
+    "minecraft:diorite"
+  ]
+}

--- a/common/src/main/resources/data/reterraforged/tags/block/sediment.json
+++ b/common/src/main/resources/data/reterraforged/tags/block/sediment.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:sand",
+    "minecraft:gravel"
+  ]
+}

--- a/common/src/main/resources/data/reterraforged/tags/block/soil.json
+++ b/common/src/main/resources/data/reterraforged/tags/block/soil.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "minecraft:dirt",
+    "minecraft:coarse_dirt"
+  ]
+}

--- a/common/src/main/resources/pack.mcmeta
+++ b/common/src/main/resources/pack.mcmeta
@@ -3,6 +3,6 @@
     "description": {
       "translate": "reterraforged.metadata.description"
     },
-    "pack_format": 48
+    "pack_format": 34
   }
 }


### PR DESCRIPTION
Minor adjustments to tags.

I'm not confident the existing tag system was tagging blocks in a way everything recognised correctly.

With these changes beaches now regularly spawn, trees are dense, gravel, coarse dirt etc regularly decorates. originally caught because fabric was whinging it couldn't find reterraforged:erodible etc

after:

<img width="2580" height="1382" alt="image" src="https://github.com/user-attachments/assets/b727a272-5baf-41a8-ab47-9ed05456e5a2" />

<img width="2579" height="1391" alt="image" src="https://github.com/user-attachments/assets/4f9bd53a-5848-4ccc-99b5-096467870469" />

<img width="3322" height="1513" alt="image" src="https://github.com/user-attachments/assets/dbaccc7a-b0ed-49a7-b37c-dd35ab0bdf4f" />

<img width="2579" height="1385" alt="image" src="https://github.com/user-attachments/assets/55dfee33-1d75-4827-b7db-57188c8f7d03" />

<img width="2569" height="1374" alt="image" src="https://github.com/user-attachments/assets/432abfde-7270-4a31-95d1-6db82bcd0673" />

