### PR TITLE
Split water from strata

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinSurfaceSystem.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinSurfaceSystem.java
@@ -33,6 +33,7 @@ import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.RTFRandomState;
 import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
+import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSettings;
 import raccoonman.reterraforged.world.worldgen.surface.RTFSurfaceSystem;
 import raccoonman.reterraforged.world.worldgen.surface.rule.StrataRule;
 
@@ -93,9 +94,10 @@ class MixinSurfaceSystem {
 				int globalZ = chunkPos.getMinBlockZ() + localZ;
 
 				raccoonman.reterraforged.world.worldgen.cell.Cell cell = reader.getCell(localX, localZ);
+				boolean isWaterCell = (cell.terrain.isRiver() || cell.terrain.isLake() || cell.terrain.isWetland()) && cell.riverWaterLevel > 0;
+				int scaledY = levels.scale(cell.height);
 
-				if ((cell.terrain.isRiver() || cell.terrain.isLake() || cell.terrain.isWetland()) && cell.riverWaterLevel > 0) {
-					int scaledY = levels.scale(cell.height);
+				if (isWaterCell) {
 					int waterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanLevel);
 
 					if (waterY < levels.scale(levels.water)) waterY = levels.scale(levels.water);
@@ -117,14 +119,18 @@ class MixinSurfaceSystem {
 							var neighborReader = neighborTile.getChunkReader(nx >> 4, nz >> 4);
 							var neighborCell = neighborReader.getCell(nx & 0xF, nz & 0xF);
 
-							int nWaterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + levels.water);
-							if (nWaterY < levels.scale(levels.water)) nWaterY = levels.scale(levels.water);
+							// Only consider the neighbor's water height if it is actually a water cell
+							boolean nIsWaterCell = (neighborCell.terrain.isRiver() || neighborCell.terrain.isLake() || neighborCell.terrain.isWetland()) && neighborCell.riverWaterLevel > 0;
+							if (nIsWaterCell) {
+								int nWaterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + levels.water);
+								if (nWaterY < levels.scale(levels.water)) nWaterY = levels.scale(levels.water);
 
-							if (nWaterY < waterY) {
-								isTransitionColumn = true;
-								lowestNeighborWaterY = Math.min(lowestNeighborWaterY, nWaterY);
-								if (waterY - nWaterY > 1) {
-									multiBlockDrop = true;
+								if (nWaterY < waterY) {
+									isTransitionColumn = true;
+									lowestNeighborWaterY = Math.min(lowestNeighborWaterY, nWaterY);
+									if (waterY - nWaterY > 1) {
+										multiBlockDrop = true;
+									}
 								}
 							}
 						}
@@ -162,11 +168,63 @@ class MixinSurfaceSystem {
 							}
 							else {
 								chunk.setBlockState(pos, water, false);
-								// Standard water in the middle of a lake doesn't usually need updates,
-								// but marking the top surface ensures edges flow cleanly if bordering air.
 								if (isTopBlock) {
 									chunk.markPosForPostprocessing(pos);
 								}
+							}
+						}
+					}
+				} else {
+
+					// GASKET LOGIC
+					int oceanY = levels.scale(levels.water);
+
+					// Only run gasket logic if this land cell is above ocean level
+					if (scaledY >= oceanY) {
+
+						// GASKET LOGIC: Soft fade using riverMask
+						int maxNeighborWaterY = scaledY;
+						float maxRiverMask = 0.0F;
+
+						// Check neighbors for water and record the strongest mask influence
+						int[] dx = {0, 0, 1, -1};
+						int[] dz = {-1, 1, 0, 0};
+						for (int i = 0; i < 4; i++) {
+							int nx = globalX + dx[i];
+							int nz = globalZ + dz[i];
+							var neighborTile = genCtx.cache.provideAtChunk(nx >> 4, nz >> 4);
+							var neighborReader = neighborTile.getChunkReader(nx >> 4, nz >> 4);
+							var neighborCell = neighborReader.getCell(nx & 0xF, nz & 0xF);
+
+							if ((neighborCell.terrain.isRiver() || neighborCell.terrain.isLake())) {
+								int nWaterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + oceanLevel);
+								if (nWaterY > maxNeighborWaterY) {
+									maxNeighborWaterY = nWaterY;
+									maxRiverMask = neighborCell.riverMask; // Capture the mask strength
+								}
+							}
+						}
+
+						// If in river zone and lower than water table, we shouldn't be.
+						int waterTableCeil = levels.scale(ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanLevel);
+						boolean isInRiverZone = cell.riverZone == RiverCarverSettings.RiverZone.Banks
+								|| cell.riverZone == RiverCarverSettings.RiverZone.ValleyFloor
+								|| cell.riverZone == RiverCarverSettings.RiverZone.ValleyFadeout;
+						boolean isLowerThanWaterTable = scaledY < waterTableCeil;
+						boolean isAboveOcean = scaledY > oceanY;
+
+						if (isInRiverZone && isLowerThanWaterTable && isAboveOcean)  {
+							for (int wy = scaledY + 1; wy <= waterTableCeil; wy++) {
+								pos.set(globalX, wy, globalZ);
+								chunk.setBlockState(pos, stone, false);
+							}
+						}
+
+						// If a neighboring water block is higher than our terrain, build a stone pillar up to match it.
+						if (maxNeighborWaterY > scaledY) {
+							for (int wy = scaledY + 1; wy <= maxNeighborWaterY; wy++) {
+								pos.set(globalX, wy, globalZ);
+								chunk.setBlockState(pos, stone, false);
 							}
 						}
 					}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinSurfaceSystem.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinSurfaceSystem.java
@@ -8,17 +8,31 @@ import java.util.function.Function;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeManager;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.levelgen.NoiseChunk;
 import net.minecraft.world.level.levelgen.PositionalRandomFactory;
 import net.minecraft.world.level.levelgen.RandomState;
+import net.minecraft.world.level.levelgen.SurfaceRules;
 import net.minecraft.world.level.levelgen.SurfaceSystem;
+import net.minecraft.world.level.levelgen.WorldGenerationContext;
 import raccoonman.reterraforged.RTFCommon;
+import raccoonman.reterraforged.world.worldgen.GeneratorContext;
+import raccoonman.reterraforged.world.worldgen.RTFRandomState;
+import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
 import raccoonman.reterraforged.world.worldgen.surface.RTFSurfaceSystem;
 import raccoonman.reterraforged.world.worldgen.surface.rule.StrataRule;
 
@@ -28,20 +42,136 @@ class MixinSurfaceSystem {
 	private static final ResourceLocation GEOLOGY_RANDOM = RTFCommon.location("geology");
 	private RandomState randomState;
 	private Map<ResourceLocation, List<List<StrataRule.Layer>>> strata;
-	
+
 	@Inject(
-		at = @At("TAIL"),
-		method = "<init>"
+			at = @At("TAIL"),
+			method = "<init>"
 	)
-    public void SurfaceSystem(RandomState randomState, BlockState blockState, int i, PositionalRandomFactory positionalRandomFactory, CallbackInfo callback) {
-    	this.randomState = randomState;
-    	this.strata = new ConcurrentHashMap<>();
+	public void SurfaceSystem(RandomState randomState, BlockState blockState, int i, PositionalRandomFactory positionalRandomFactory, CallbackInfo callback) {
+		this.randomState = randomState;
+		this.strata = new ConcurrentHashMap<>();
 	}
-	
+
+	// INJECT AT HEAD to carve out rivers and lakes before surface rules run
+	@Inject(
+			method = "buildSurface",
+			at = @At("HEAD")
+	)
+	private void onBuildSurface(RandomState randomState, BiomeManager biomeManager, Registry<Biome> biomes, boolean useLegacyRandom, WorldGenerationContext context, final ChunkAccess chunk, NoiseChunk noiseChunk, SurfaceRules.RuleSource ruleSource, CallbackInfo ci) {
+		if ((Object) randomState instanceof RTFRandomState rtfRandomState) {
+			GeneratorContext genCtx = rtfRandomState.generatorContext();
+			if (genCtx != null) {
+				this.reterraforged$placeRiverWater(chunk, biomeManager, genCtx);
+			}
+		}
+	}
+
 	public List<List<StrataRule.Layer>> reterraforged$RTFSurfaceSystem$getOrCreateStrata(ResourceLocation name, Function<RandomSource, List<List<StrataRule.Layer>>> strata) {
 		return this.strata.computeIfAbsent(name, (k) -> {
 			PositionalRandomFactory factory = this.randomState.getOrCreateRandomFactory(GEOLOGY_RANDOM);
 			return strata.apply(factory.fromHashOf(k));
 		});
+	}
+
+	@Unique
+	private void reterraforged$placeRiverWater(ChunkAccess chunk, BiomeManager biomeManager, GeneratorContext genCtx) {
+		var chunkPos = chunk.getPos();
+		var tile = genCtx.cache.provideAtChunk(chunkPos.x, chunkPos.z);
+		var reader = tile.getChunkReader(chunkPos.x, chunkPos.z);
+		var levels = genCtx.generator.getHeightmap().levels();
+
+		float oceanLevel = levels.water;
+		BlockPos.MutableBlockPos pos = new BlockPos.MutableBlockPos();
+		BlockState water = Blocks.WATER.defaultBlockState();
+		BlockState flowingWater = water.setValue(BlockStateProperties.LEVEL, 1);
+		BlockState stone = Blocks.STONE.defaultBlockState();
+
+		// Iterate over the 16x16 chunk exactly once
+		for (int localX = 0; localX < 16; localX++) {
+			for (int localZ = 0; localZ < 16; localZ++) {
+				int globalX = chunkPos.getMinBlockX() + localX;
+				int globalZ = chunkPos.getMinBlockZ() + localZ;
+
+				raccoonman.reterraforged.world.worldgen.cell.Cell cell = reader.getCell(localX, localZ);
+
+				if ((cell.terrain.isRiver() || cell.terrain.isLake() || cell.terrain.isWetland()) && cell.riverWaterLevel > 0) {
+					int scaledY = levels.scale(cell.height);
+					int waterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanLevel);
+
+					if (waterY < levels.scale(levels.water)) waterY = levels.scale(levels.water);
+
+					if (waterY > scaledY) {
+						boolean isTransitionColumn = false;
+						boolean multiBlockDrop = false;
+						int lowestNeighborWaterY = waterY;
+
+						int[] dx = {0, 0, 1, -1};
+						int[] dz = {-1, 1, 0, 0};
+
+						// Check neighbors to determine if we are an edge/waterfall
+						for (int i = 0; i < 4; i++) {
+							int nx = globalX + dx[i];
+							int nz = globalZ + dz[i];
+
+							var neighborTile = genCtx.cache.provideAtChunk(nx >> 4, nz >> 4);
+							var neighborReader = neighborTile.getChunkReader(nx >> 4, nz >> 4);
+							var neighborCell = neighborReader.getCell(nx & 0xF, nz & 0xF);
+
+							int nWaterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + levels.water);
+							if (nWaterY < levels.scale(levels.water)) nWaterY = levels.scale(levels.water);
+
+							if (nWaterY < waterY) {
+								isTransitionColumn = true;
+								lowestNeighborWaterY = Math.min(lowestNeighborWaterY, nWaterY);
+								if (waterY - nWaterY > 1) {
+									multiBlockDrop = true;
+								}
+							}
+						}
+
+						// adjust this column to be averaged so it makes the waterfalls more natural like.
+						if (isTransitionColumn && multiBlockDrop) {
+							scaledY = (scaledY + lowestNeighborWaterY) / 2;
+						}
+
+						// Build the water column in our OWN chunk down to the needed depth
+						for (int wy = scaledY + 1; wy <= waterY; wy++) {
+							boolean isTopBlock = wy == waterY;
+							pos.set(globalX, wy, globalZ);
+
+							if (isTopBlock && isTransitionColumn && multiBlockDrop) {
+								chunk.setBlockState(pos, water, false);
+								chunk.markPosForPostprocessing(pos);
+							}
+							else if (isTopBlock && isTransitionColumn && !multiBlockDrop) {
+								if (biomeManager.getBiome(pos).value().coldEnoughToSnow(pos)) {
+									// Place Ice instead of liquid water to keep frozen rivers continuous
+									chunk.setBlockState(pos, Blocks.ICE.defaultBlockState(), false);
+								} else {
+									chunk.setBlockState(pos, flowingWater, false);
+								}
+							}
+							else if (!isTopBlock && multiBlockDrop) {
+								// If we are dropping multiple blocks, fill the gap down to the lowest neighbor with water instead of stone
+								if (wy > lowestNeighborWaterY) {
+									chunk.setBlockState(pos, flowingWater, false);
+									chunk.markPosForPostprocessing(pos);
+								} else {
+									chunk.setBlockState(pos, stone, false);
+								}
+							}
+							else {
+								chunk.setBlockState(pos, water, false);
+								// Standard water in the middle of a lake doesn't usually need updates,
+								// but marking the top surface ensures edges flow cleanly if bordering air.
+								if (isTopBlock) {
+									chunk.markPosForPostprocessing(pos);
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/surface/rule/RTFSurfaceRules.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/surface/rule/RTFSurfaceRules.java
@@ -22,6 +22,6 @@ public class RTFSurfaceRules {
 	}
 	
 	public static void register(String name, MapCodec<? extends SurfaceRules.RuleSource> value) {
-		RegistryUtil.register(BuiltInRegistries.MATERIAL_RULE, name, value); //TODO: Convert to MapCodec
+		RegistryUtil.register(BuiltInRegistries.MATERIAL_RULE, name, value);
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/surface/rule/StrataRule.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/surface/rule/StrataRule.java
@@ -2,12 +2,8 @@ package raccoonman.reterraforged.world.worldgen.surface.rule;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 
 import com.mojang.serialization.MapCodec;
-import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import org.jetbrains.annotations.Nullable;
 
 import com.google.common.collect.ImmutableList;
@@ -27,7 +23,6 @@ import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.SurfaceRules;
 import net.minecraft.world.level.levelgen.SurfaceRules.Context;
 import raccoonman.reterraforged.world.worldgen.RTFRandomState;
-import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
 import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
 import raccoonman.reterraforged.world.worldgen.noise.module.Noise;
 import raccoonman.reterraforged.world.worldgen.noise.module.Noises;
@@ -35,16 +30,16 @@ import raccoonman.reterraforged.world.worldgen.surface.RTFSurfaceSystem;
 
 public record StrataRule(ResourceLocation name, Holder<Noise> selector, List<Strata> strata, int iterations) implements SurfaceRules.RuleSource {
 	public static final MapCodec<StrataRule> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-		ResourceLocation.CODEC.fieldOf("name").forGetter(StrataRule::name),
-		Noise.CODEC.fieldOf("selector").forGetter(StrataRule::selector),
-		Strata.CODEC.listOf().fieldOf("strata").forGetter(StrataRule::strata),
-		Codec.INT.fieldOf("iterations").forGetter(StrataRule::iterations)
+			ResourceLocation.CODEC.fieldOf("name").forGetter(StrataRule::name),
+			Noise.CODEC.fieldOf("selector").forGetter(StrataRule::selector),
+			Strata.CODEC.listOf().fieldOf("strata").forGetter(StrataRule::strata),
+			Codec.INT.fieldOf("iterations").forGetter(StrataRule::iterations)
 	).apply(instance, StrataRule::new));
-	
+
 	public StrataRule {
 		strata = ImmutableList.copyOf(strata);
 	}
-	
+
 	@Override
 	public Source apply(Context ctx) {
 		if(ctx.system instanceof RTFSurfaceSystem rtfSurfaceSystem && (Object) ctx.randomState instanceof RTFRandomState rtfRandomState) {
@@ -58,9 +53,9 @@ public record StrataRule(ResourceLocation name, Holder<Noise> selector, List<Str
 	public KeyDispatchDataCodec<StrataRule> codec() {
 		return new KeyDispatchDataCodec<>(CODEC);
 	}
-	
+
 	private List<List<Layer>> generateStrata(RandomSource random) {
-        List<List<Layer>> layers = new ArrayList<>();
+		List<List<Layer>> layers = new ArrayList<>();
 		for(int i = 0; i < this.iterations; i++) {
 			List<Layer> layer = new ArrayList<>();
 			for(Strata strata : this.strata) {
@@ -68,53 +63,50 @@ public record StrataRule(ResourceLocation name, Holder<Noise> selector, List<Str
 			}
 			layers.add(layer);
 		}
-        return layers;
+		return layers;
 	}
-	
+
 	public record Strata(TagKey<Block> materials, Holder<Noise> noise, int attempts, int minLayers, int maxLayers, float minDepth, float maxDepth) {
 		public static final Codec<Strata> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-			TagKey.hashedCodec(Registries.BLOCK).fieldOf("materials").forGetter(Strata::materials),
-			Noise.CODEC.fieldOf("noise").forGetter(Strata::noise),
-			Codec.INT.fieldOf("attempts").forGetter(Strata::attempts),
-			Codec.INT.fieldOf("min_layers").forGetter(Strata::minLayers),
-			Codec.INT.fieldOf("max_layers").forGetter(Strata::maxLayers),
-			Codec.FLOAT.fieldOf("min_depth").forGetter(Strata::minDepth),
-			Codec.FLOAT.fieldOf("max_depth").forGetter(Strata::maxDepth)			
+				TagKey.hashedCodec(Registries.BLOCK).fieldOf("materials").forGetter(Strata::materials),
+				Noise.CODEC.fieldOf("noise").forGetter(Strata::noise),
+				Codec.INT.fieldOf("attempts").forGetter(Strata::attempts),
+				Codec.INT.fieldOf("min_layers").forGetter(Strata::minLayers),
+				Codec.INT.fieldOf("max_layers").forGetter(Strata::maxLayers),
+				Codec.FLOAT.fieldOf("min_depth").forGetter(Strata::minDepth),
+				Codec.FLOAT.fieldOf("max_depth").forGetter(Strata::maxDepth)
 		).apply(instance, Strata::new));
-		
+
 		public List<Layer> generateLayers(RandomSource random) {
 			int lastIndex = -1;
-	        int layers = this.minLayers + NoiseUtil.round(random.nextFloat() * (this.maxLayers - this.minLayers));
-	        List<Layer> result = new ArrayList<>();
-	        List<Holder<Block>> materials = ImmutableList.copyOf(BuiltInRegistries.BLOCK.getTagOrEmpty(this.materials));
-	        
-	        int seed = random.nextInt();
-	        for (int i = 0; i < layers; i++) {
-	            int attempts = this.attempts;
-	            int index = random.nextInt(materials.size());
-	            while (--attempts >= 0 && index == lastIndex) {
-	                index = random.nextInt(materials.size());
-	            }
-	            if (index != lastIndex) {
-	                lastIndex = index;
-	                BlockState material = materials.get(index).value().defaultBlockState();
-	                float depth = this.minDepth + random.nextFloat() * (this.maxDepth - this.minDepth);
-	                result.add(new Layer(material, Noises.shiftSeed(Noises.mul(this.noise.value(), depth), random.nextInt()), seed));
-	            }
-	        }
-	        return result;
+			int layers = this.minLayers + NoiseUtil.round(random.nextFloat() * (this.maxLayers - this.minLayers));
+			List<Layer> result = new ArrayList<>();
+			List<Holder<Block>> materials = ImmutableList.copyOf(BuiltInRegistries.BLOCK.getTagOrEmpty(this.materials));
+
+			int seed = random.nextInt();
+			for (int i = 0; i < layers; i++) {
+				int attempts = this.attempts;
+				int index = random.nextInt(materials.size());
+				while (--attempts >= 0 && index == lastIndex) {
+					index = random.nextInt(materials.size());
+				}
+				if (index != lastIndex) {
+					lastIndex = index;
+					BlockState material = materials.get(index).value().defaultBlockState();
+					float depth = this.minDepth + random.nextFloat() * (this.maxDepth - this.minDepth);
+					result.add(new Layer(material, Noises.shiftSeed(Noises.mul(this.noise.value(), depth), random.nextInt()), seed));
+				}
+			}
+			return result;
 		}
 	}
-	
-	// this has to be public so that SurfaceSystemExtension can access it
-	// should be private otherwise
+
 	public record Layer(BlockState material, Noise depth, int seed) {
-	
 		public float computeDepth(float x, float z) {
 			return this.depth.compute(x, z, this.seed);
 		}
 	}
-	
+
 	private class Source implements SurfaceRules.SurfaceRule {
 		private Context surfaceContext;
 		private Noise selector;
@@ -122,7 +114,7 @@ public record StrataRule(ResourceLocation name, Holder<Noise> selector, List<Str
 		private List<Layer> layers;
 		private float[] depthBuffer;
 		private long lastUpdateXZ;
-		
+
 		public Source(Context surfaceContext, Noise selector, List<List<Layer>> strata) {
 			this.surfaceContext = surfaceContext;
 			this.selector = selector;
@@ -130,160 +122,56 @@ public record StrataRule(ResourceLocation name, Holder<Noise> selector, List<Str
 			this.lastUpdateXZ = Long.MIN_VALUE;
 		}
 
-        @Nullable
+		@Nullable
 		@Override
 		public BlockState tryApply(int x, int y, int z) {
-        	if(this.lastUpdateXZ != this.surfaceContext.lastUpdateXZ) {
-        		this.initBuffer(x, z);
-        		this.lastUpdateXZ = this.surfaceContext.lastUpdateXZ;
-        	}
+			if(this.lastUpdateXZ != this.surfaceContext.lastUpdateXZ) {
+				this.initBuffer(x, z);
+				this.lastUpdateXZ = this.surfaceContext.lastUpdateXZ;
+			}
 
-			if ((Object) this.surfaceContext.randomState instanceof RTFRandomState rtfRandomState) {
-				var genCtx = rtfRandomState.generatorContext();
-
-				if (genCtx != null) {
-					// 2. Get the Cell for this specific block column
-					// We use the cache to provide the tile for the current chunk
-					var chunkPos = this.surfaceContext.chunk.getPos();
-					var tile = genCtx.cache.provideAtChunk(chunkPos.x, chunkPos.z);
-					var reader = tile.getChunkReader(chunkPos.x, chunkPos.z);
-
-					int localX = x & 0xF;
-					int localZ = z & 0xF;
-					raccoonman.reterraforged.world.worldgen.cell.Cell cell = reader.getCell(localX, localZ);
-
-					// 3. Apply the water logic
-					if ((cell.terrain.isRiver() || cell.terrain.isLake() || cell.terrain.isWetland()) && cell.riverWaterLevel > 0) {
-						var levels = genCtx.generator.getHeightmap().levels();
-						int scaledY = levels.scale(cell.height);
-
-						// Calculate OUR integer water height
-						float oceanLevel = levels.water;
-						int waterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanLevel);
-
-						if (waterY < levels.scale(levels.water)) waterY = levels.scale(levels.water);
-
-						if (waterY > scaledY) {
-							boolean isTransitionColumn = false;
-							boolean multiBlockDrop = false;
-							int[] dx = {0, 0, 1, -1};
-							int[] dz = {-1, 1, 0, 0};
-
-							for (int i = 0; i < 4; i++) {
-								int nx = x + dx[i];
-								int nz = z + dz[i];
-
-								// Bridge to neighbor
-								var neighborTile = genCtx.cache.provideAtChunk(nx >> 4, nz >> 4);
-								var neighborReader = neighborTile.getChunkReader(nx >> 4, nz >> 4);
-								var neighborCell = neighborReader.getCell(nx & 0xF, nz & 0xF);
-
-								// Calculate the NEIGHBOR'S integer water height using their specific data
-								int nWaterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + levels.water);
-
-								if (nWaterY < levels.scale(levels.water)) nWaterY = levels.scale(levels.water);
-
-								// Only flag if the neighbor's actual water surface is lower than ours
-								if (nWaterY < waterY) {
-
-									if (waterY - nWaterY > 1){
-										multiBlockDrop = true;
-									}
-
-									isTransitionColumn = true;
-									if (multiBlockDrop) {
-
-										// make water fall onto the lower neighbour
-										for (int wy = nWaterY + 1; wy <= waterY; wy++) {
-											BlockState state = wy == waterY
-													? Blocks.WATER.defaultBlockState().setValue(BlockStateProperties.LEVEL, 1)
-													: Blocks.WATER.defaultBlockState();
-											BlockPos neighbour = new BlockPos(nx, wy, nz);
-											this.surfaceContext.chunk.setBlockState(neighbour, state, true);
-										}
-									}
-								}
-							}
-
-							net.minecraft.core.BlockPos.MutableBlockPos pos = new net.minecraft.core.BlockPos.MutableBlockPos();
-							BlockState water = Blocks.WATER.defaultBlockState();
-							BlockState stone = Blocks.STONE.defaultBlockState();
-
-							for (int wy = scaledY + 1; wy <= waterY; wy++) {
-
-								// top row of blocks should be flowing water
-								boolean isTopBlock = wy == waterY;
-
-								// top of waterfalls on top of stone
-								if (isTopBlock && isTransitionColumn && multiBlockDrop){
-									this.surfaceContext.chunk.setBlockState(pos.set(x, wy, z), water, false);
-								}
-
-								// standard single tile step down
-								else if (isTopBlock && isTransitionColumn && !multiBlockDrop){
-									this.surfaceContext.chunk.setBlockState(pos.set(x, wy, z), water.setValue(BlockStateProperties.LEVEL, 1), false);
-								}
-
-								// waterfall "walls"
-								// TODO - this needs to be better
-								else if (!isTopBlock && multiBlockDrop)
-								{
-									this.surfaceContext.chunk.setBlockState(pos.set(x, wy, z), stone, false);
-								}
-
-								// standard water blocks
-								else
-								{
-									this.surfaceContext.chunk.setBlockState(pos.set(x, wy, z), water, false);
-								}
-							}
-						}
-					}
+			Layer last = null;
+			for(int i = 0; i < this.layers.size(); i++) {
+				Layer layer = last = this.layers.get(i);
+				if(y > this.depthBuffer[i]) {
+					return layer.material();
 				}
 			}
 
-        	Layer last = null;
-        	for(int i = 0; i < this.layers.size(); i++) {
-        		Layer layer = last = this.layers.get(i);
-        		if(y > this.depthBuffer[i]) {
-        			return layer.material();
-        		}
-        	}
-
-        	return last != null ? last.material() : null;
+			return last != null ? last.material() : null;
 		}
-		
+
 		private void initBuffer(int x, int z) {
-        	this.layers = this.selectLayers(x, z);
+			this.layers = this.selectLayers(x, z);
 			int layerCount = this.layers.size();
-			
-	        if (this.depthBuffer == null || this.depthBuffer.length < layerCount) {
-	            this.depthBuffer = new float[layerCount];
-	        }
-	        
-            int localX = this.surfaceContext.blockX & 0xF;
-            int localZ = this.surfaceContext.blockZ & 0xF;
-            int height = this.surfaceContext.chunk.getHeight(Heightmap.Types.WORLD_SURFACE_WG, localX, localZ);
 
-            float sum = 0.0F;
-            for(int i = 0; i < layerCount; i++) {
-            	Layer layer = this.layers.get(i);
-            	float depth = layer.computeDepth(x, z);
-            	sum += depth;
-            	this.depthBuffer[i] = depth;
-            }
-            
-            int y = height;
-            for(int i = 0; i < layerCount; i++) {
-            	this.depthBuffer[i] = y -= Math.round((this.depthBuffer[i] / sum) * height);
-            }
+			if (this.depthBuffer == null || this.depthBuffer.length < layerCount) {
+				this.depthBuffer = new float[layerCount];
+			}
+
+			int localX = this.surfaceContext.blockX & 0xF;
+			int localZ = this.surfaceContext.blockZ & 0xF;
+			int height = this.surfaceContext.chunk.getHeight(Heightmap.Types.WORLD_SURFACE_WG, localX, localZ);
+
+			float sum = 0.0F;
+			for(int i = 0; i < layerCount; i++) {
+				Layer layer = this.layers.get(i);
+				float depth = layer.computeDepth(x, z);
+				sum += depth;
+				this.depthBuffer[i] = depth;
+			}
+
+			int y = height;
+			for(int i = 0; i < layerCount; i++) {
+				this.depthBuffer[i] = y -= Math.round((this.depthBuffer[i] / sum) * height);
+			}
 		}
-		
+
 		private List<Layer> selectLayers(int x, int z) {
 			float selector = this.selector.compute(x, z, 0);
-	        int index = (int) (selector * this.strata.size());
-	        index = Math.min(this.strata.size() - 1, index);
-	        return this.strata.get(index);
-	    }
+			int index = (int) (selector * this.strata.size());
+			index = Math.min(this.strata.size() - 1, index);
+			return this.strata.get(index);
+		}
 	}
 }


### PR DESCRIPTION
Dirty hacks eventually come home to roost.

I piggybacked strata generation to manage filling water levels tied to the waterTable implementation.

Unfortunately, when i fixed strata generation toggling in https://github.com/ETcodehome/ReTerraForged/pull/40 I inadvertently made a "turn off all water generation above ocean level" toggle because of how intertwined the two systems were.

This splits the two systems, and makes a couple of refinements to the water generation logic.
Specifically 
- fade off around rivers is now minimum height enforced to ensure waterfalls in degenerate continent falloff regions behave a bit nicer
- waterfalls have a single bloock falloff
- waterfalls now properly trigger flow updates
- ice steps without spawning flowing water transitions
