### PR TITLE
Tune preset

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Presets.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Presets.java
@@ -308,11 +308,11 @@ public class Presets {
 								0)
 				),
 				new SurfaceSettings(new SurfaceSettings.Erosion(30,
-						140,
+						400,
 						40,
 						95,
-						0.65F,
-						0.475F,
+						0.95F,
+						0.68F,
 						0.4F)),
 
 				new CaveSettings(0.199F,
@@ -422,13 +422,13 @@ public class Presets {
 				new RiverSettings(
 
 						-807426906,
-						15,
+						10,
 
 						//main rivers
 						new River(7,
 								1,
 								3,
-								16,
+								24,
 								10,
 								1.0F),
 
@@ -462,9 +462,7 @@ public class Presets {
 								0.8112F,
 								0.8112F),
 
-						new Smoothing(0,
-								0.0F,
-								0.0F)
+						new Smoothing(1, 1.8F, 0.9F)
 				),
 
 				new StructureSettings(),


### PR DESCRIPTION
Tunes the preset erosion settings to generate better default results.

Now erosion settings are working correctly, generates much better aesthetics especially with a single smoothing step.

Fixes https://github.com/ETcodehome/ReTerraForged/issues/45
by moving the stone cutoff to y400
and adjusting the erosion params

<img width="2573" height="1377" alt="image" src="https://github.com/user-attachments/assets/39df0826-77fb-4f53-ac9d-0533b37a12cb" />

<img width="2570" height="1385" alt="image" src="https://github.com/user-attachments/assets/97364a66-64e9-403f-9784-455b3b9b9cc7" />

<img width="2560" height="1379" alt="image" src="https://github.com/user-attachments/assets/2e257be2-7a5e-4f71-aaff-5e0ec4ee4337" />

<img width="2580" height="1381" alt="image" src="https://github.com/user-attachments/assets/2e356bc0-be5c-4eda-b959-be9db514de6b" />
