### PR TITLE
Fix mushroom islands

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/climate/ClimateModule.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/climate/ClimateModule.java
@@ -164,17 +164,36 @@ public class ClimateModule {
 
 		// Island biome override: sample climate for island terrain so islands
 		// get land biomes instead of ocean/frozen_ocean
-		if (cell.terrain == TerrainType.ISLAND_BEACH) {
-			cell.biome = BiomeType.SAVANNA;
-			cell.temperature = Temperature.LEVEL_3.mid();
-			cell.moisture = Humidity.LEVEL_1.mid();
-		} else if (cell.terrain == TerrainType.ISLAND || cell.terrain == TerrainType.ISLAND_MOUNTAINS) {
-			float islTemp = this.temperature.compute(centerX, centerZ, 0);
-			float islMoist = this.moisture.compute(centerX, centerZ, 0);
-			cell.biome = BiomeType.get(islTemp, islMoist);
-			cell.temperature = cell.biome.getTemperature(cell.biomeRegionId);
-			cell.moisture = cell.biome.getMoisture(cell.biomeRegionId);
+		if (cell.terrain == TerrainType.ISLAND_BEACH || cell.terrain == TerrainType.ISLAND || cell.terrain == TerrainType.ISLAND_MOUNTAINS) {
+
+			if (madeMushroomIslands(cell)){ return; }
+
+			if (cell.terrain == TerrainType.ISLAND_BEACH) {
+				cell.biome = BiomeType.SAVANNA; // Your existing logic
+				cell.temperature = Temperature.LEVEL_3.mid();
+				cell.moisture = Humidity.LEVEL_1.mid();
+			} else {
+				float islTemp = this.temperature.compute(centerX, centerZ, 0);
+				float islMoist = this.moisture.compute(centerX, centerZ, 0);
+				cell.biome = BiomeType.get(islTemp, islMoist);
+				cell.temperature = cell.biome.getTemperature(cell.biomeRegionId);
+				cell.moisture = cell.biome.getMoisture(cell.biomeRegionId);
+			}
 		}
+	}
+
+	private boolean madeMushroomIslands(Cell cell)
+	{
+		// Check for a rare noise threshold (e.g., top 5% of macroBiomeId)
+		if (cell.macroBiomeId > 0.95F) {
+			cell.terrain = TerrainType.MUSHROOM_FIELDS;
+
+			// Set appropriate temperature and moisture for mushrooms/mycelium
+			cell.temperature = Temperature.LEVEL_2.mid(); // Moderate
+			cell.moisture = Humidity.LEVEL_4.mid();       // Wet
+			return true;
+		}
+		return false;
 	}
 
 	private float modifyTemp(float height, float temp, float x, float z) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/climate/ClimateModule.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/climate/ClimateModule.java
@@ -169,7 +169,7 @@ public class ClimateModule {
 			if (madeMushroomIslands(cell)){ return; }
 
 			if (cell.terrain == TerrainType.ISLAND_BEACH) {
-				cell.biome = BiomeType.SAVANNA; // Your existing logic
+				cell.biome = BiomeType.SAVANNA;
 				cell.temperature = Temperature.LEVEL_3.mid();
 				cell.moisture = Humidity.LEVEL_1.mid();
 			} else {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/terrain/TerrainType.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/terrain/TerrainType.java
@@ -15,7 +15,6 @@ public class TerrainType {
     public static final Terrain COAST = register("coast", TerrainCategory.COAST);
     public static final Terrain BEACH = register("beach", TerrainCategory.BEACH);
     public static final Terrain RIVER = register("river", TerrainCategory.RIVER);
-    public static final Terrain LAKE = register("lake", TerrainCategory.LAKE);
     public static final Terrain WETLAND = registerWetlands("wetland", TerrainCategory.WETLAND);
     public static final Terrain FLATS = register("flats", TerrainCategory.FLATLAND);
     public static final Terrain BADLANDS = registerBadlands("badlands", TerrainCategory.FLATLAND);
@@ -27,35 +26,10 @@ public class TerrainType {
     public static final Terrain MOUNTAIN_CHAIN = registerMountain("mountain_chain", TerrainCategory.HIGHLAND);
     public static final Terrain VOLCANO = registerVolcano("volcano", TerrainCategory.HIGHLAND);
     public static final Terrain VOLCANO_PIPE = registerVolcano("volcano_pipe", TerrainCategory.HIGHLAND);
-
-    public static final Terrain REMOTE_ISLANDS = register("remote_islands", TerrainCategory.ISLAND);
     public static final Terrain ISLAND = register("island", TerrainCategory.ISLAND);
     public static final Terrain ISLAND_BEACH = register("island_beach", TerrainCategory.ISLAND);
     public static final Terrain ISLAND_MOUNTAINS = register("island_mountains", TerrainCategory.ISLAND);
-    public static final Terrain LAGOON = register("lagoon", TerrainCategory.ISLAND);
-    public static final Terrain DEEP_LAGOON = register("deep_lagoon", TerrainCategory.ISLAND);
-    public static final Terrain ARCHIPELAGO = register("archipelago", TerrainCategory.ISLAND);
-    public static final Terrain MUSHROOM_ARCHIPELAGO = register("mushroom_archipelago", TerrainCategory.ISLAND);
     public static final Terrain MUSHROOM_FIELDS = register("mushroom_fields", TerrainCategory.ISLAND);
-
-    public static void forEach(Consumer<Terrain> action) {
-        TerrainType.REGISTRY.forEach(action);
-    }
-    
-    public static Optional<Terrain> find(Predicate<Terrain> filter) {
-        return TerrainType.REGISTRY.stream().filter(filter).findFirst();
-    }
-    
-    public static Terrain getOrCreate(String name, Terrain parent) {
-        if (parent == null || parent == TerrainType.NONE) {
-            return TerrainType.NONE;
-        }
-        Terrain current = get(name);
-        if (current != null) {
-            return current;
-        }
-        return register(new Terrain(0, name, parent));
-    }
     
     public static Terrain get(String name) {
         for (Terrain terrain : TerrainType.REGISTRY) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/CellSampler.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/CellSampler.java
@@ -129,13 +129,12 @@ public record CellSampler(Supplier<WorldLookup> deferredLookup, Field field) imp
 				float deepOcean = controlPoints.deepOcean;
 				float shallowOcean = controlPoints.shallowOcean;
 				float beach = controlPoints.beach;
-				float coast = controlPoints.coast;
 				float inland = controlPoints.inland;
 				
 				if(cell.terrain == TerrainType.MUSHROOM_FIELDS) {
 					return Continentalness.MUSHROOM_FIELDS.mid();
 				}
-				
+
 				if(cell.terrain.isDeepOcean()) {
 					float alpha = NoiseUtil.clamp(cell.continentEdge, 0.0F, deepOcean);
 					alpha = NoiseUtil.lerp(alpha, 0.0F, deepOcean, 0.0F, 1.0F);
@@ -157,6 +156,7 @@ public record CellSampler(Supplier<WorldLookup> deferredLookup, Field field) imp
 				float alpha = NoiseUtil.clamp(cell.continentEdge, beach, inland);
 				alpha = NoiseUtil.lerp(alpha, beach, inland, 0.0F, 1.0F);
 				return NoiseUtil.lerp(Continentalness.NEAR_INLAND.mid(), Continentalness.FAR_INLAND.max(), alpha);
+
 			}
 		},
 		EROSION("erosion") {


### PR DESCRIPTION
Mushroom islands can spawn again (rare chance approx 5% when island spawning enabled)

<img width="2572" height="1381" alt="image" src="https://github.com/user-attachments/assets/52b4567c-5cf6-4ef1-9603-803588c41ea3" />

I considered restricting to only making entire islands rigidily be either mushroom island or not but the variety from mixed biomes seems interesting.

<img width="2573" height="1379" alt="image" src="https://github.com/user-attachments/assets/7a2e508d-1c86-40cd-8176-164def1effac" />

