### PR TITLE
Fix pagination

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/WorldSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/WorldSettingsPage.java
@@ -214,9 +214,7 @@ public class WorldSettingsPage extends PresetEditorPage {
 	}
 
 	@Override
-	public Optional<Page> previous() {
-		return Optional.of(new PresetListPage(this.screen));
-	}
+	public Optional<Page> previous() { return Optional.empty();	}
 
 	@Override
 	public Optional<Page> next() {


### PR DESCRIPTION
The settings menu back button will go back past the end of available settings pages wiping preset changes.

This change prevents exiting the settings menu via the back button.

<img width="856" height="526" alt="image" src="https://github.com/user-attachments/assets/02a32cd3-21b3-49bc-9e79-6ca1e9bedfd3" />
