### PR TITLE
Holder / ResourceKey fixes for biome modifiers

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/RuntimeRegistryExporter.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/RuntimeRegistryExporter.java
@@ -1,0 +1,72 @@
+package raccoonman.reterraforged.data.worldgen;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.data.CachedOutput;
+import net.minecraft.data.DataProvider;
+import net.minecraft.data.PackOutput;
+import net.minecraft.resources.RegistryDataLoader;
+import net.minecraft.resources.RegistryOps;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class RuntimeRegistryExporter implements DataProvider {
+    private final PackOutput output;
+    private final RegistryAccess registries;
+
+    public RuntimeRegistryExporter(PackOutput output, RegistryAccess registries) {
+        this.output = output;
+        this.registries = registries;
+    }
+
+    @Override
+    public CompletableFuture<?> run(CachedOutput cache) {
+        // THE FIX: We explicitly create a pure Vanilla RegistryOps.
+        // This ensures NeoForge's Datagen Mixins cannot inject ConditionalOps,
+        // preventing the inline serialization crash.
+        DynamicOps<JsonElement> pureOps = RegistryOps.create(JsonOps.INSTANCE, this.registries);
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+
+        // Iterate over standard data-driven registries (biomes, configured features, etc.)
+        for (RegistryDataLoader.RegistryData<?> registryData : RegistryDataLoader.WORLDGEN_REGISTRIES) {
+            dumpRegistry(cache, pureOps, registryData, futures);
+        }
+
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+    }
+
+    private <T> void dumpRegistry(CachedOutput cache, DynamicOps<JsonElement> ops, RegistryDataLoader.RegistryData<T> registryData, List<CompletableFuture<?>> futures) {
+        Optional<Registry<T>> optionalRegistry = this.registries.registry(registryData.key());
+        if (optionalRegistry.isEmpty()) {
+            return;
+        }
+
+        Registry<T> registry = optionalRegistry.get();
+        PackOutput.PathProvider pathProvider = this.output.createRegistryElementsPathProvider(registryData.key());
+
+        for (Holder.Reference<T> holder : registry.holders().toList()) {
+            // Encode using the un-tainted pure Vanilla ops
+            registryData.elementCodec().encodeStart(ops, holder.value())
+                    .resultOrPartial(err -> {
+                        // Optional: You can log errors here if specific elements fail
+                    })
+                    .ifPresent(json -> {
+                        Path path = pathProvider.json(holder.key().location());
+                        futures.add(DataProvider.saveStable(cache, json, path));
+                    });
+        }
+    }
+
+    @Override
+    public String getName() {
+        return "Runtime Registry Exporter";
+    }
+}

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetBiomeModifierData.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetBiomeModifierData.java
@@ -27,7 +27,7 @@ public class PresetBiomeModifierData {
 	public static final ResourceKey<BiomeModifier> ADD_EROSION = createKey("add_erosion");
 	public static final ResourceKey<BiomeModifier> ADD_SNOW_PROCESSING = createKey("add_snow_processing");
 	public static final ResourceKey<BiomeModifier> ADD_SWAMP_SURFACE = createKey("add_swamp_surface");
-	
+
 	public static final ResourceKey<BiomeModifier> REPLACE_PLAINS_TREES = createKey("replace_plains_trees");
 	public static final ResourceKey<BiomeModifier> REPLACE_FOREST_TREES = createKey("replace_forest_trees");
 	public static final ResourceKey<BiomeModifier> REPLACE_FLOWER_FOREST_TREES = createKey("replace_flower_forest_trees");
@@ -52,10 +52,10 @@ public class PresetBiomeModifierData {
 	public static final ResourceKey<BiomeModifier> ADD_STEPPE_BUSH = createKey("add_stepps_bush");
 	public static final ResourceKey<BiomeModifier> ADD_COLD_STEPPE_BUSH = createKey("add_cold_steppe_bush");
 	public static final ResourceKey<BiomeModifier> ADD_TAIGA_SCRUB_BUSH = createKey("add_taiga_scrub_bush");
-	
+
 	public static final ResourceKey<BiomeModifier> ADD_FOREST_GRASS = createKey("add_forest_grass");
 	public static final ResourceKey<BiomeModifier> ADD_BIRCH_FOREST_GRASS = createKey("add_birch_forest_grass");
-	
+
 	public static void bootstrap(Preset preset, BootstrapContext<BiomeModifier> ctx) {
 		MiscellaneousSettings miscellaneous = preset.miscellaneous();
 		HolderGetter<PlacedFeature> placedFeatures = ctx.lookup(Registries.PLACED_FEATURE);
@@ -84,109 +84,91 @@ public class PresetBiomeModifierData {
 		HolderSet<Biome> steppeBushBiomes = HolderSet.direct(biomes.getOrThrow(Biomes.SAVANNA), biomes.getOrThrow(Biomes.WINDSWEPT_SAVANNA), biomes.getOrThrow(Biomes.SAVANNA_PLATEAU));
 		HolderSet<Biome> coldSteppeBiomes = HolderSet.direct();
 		HolderSet<Biome> taigaScrubBiomes = HolderSet.direct(biomes.getOrThrow(Biomes.SNOWY_PLAINS), biomes.getOrThrow(Biomes.TAIGA), biomes.getOrThrow(Biomes.WINDSWEPT_FOREST), biomes.getOrThrow(Biomes.WINDSWEPT_GRAVELLY_HILLS));
-		
+
 		HolderSet<Biome> forestsWithGrass = HolderSet.direct(biomes.getOrThrow(Biomes.FOREST), biomes.getOrThrow(Biomes.DARK_FOREST));
 
 		if(miscellaneous.customBiomeFeatures) {
-			Holder<PlacedFeature> plainsTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.PLAINS_TREES);
-			Holder<PlacedFeature> forestTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.FOREST_TREES);
-			Holder<PlacedFeature> flowerForestTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.FLOWER_FOREST_TREES);
-			Holder<PlacedFeature> birchTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.BIRCH_TREES);
-			Holder<PlacedFeature> darkForestTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.DARK_FOREST_TREES);
-			Holder<PlacedFeature> savannaTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.SAVANNA_TREES);
-			Holder<PlacedFeature> swampTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.SWAMP_TREES);
-			Holder<PlacedFeature> meadowTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.MEADOW_TREES);
-			Holder<PlacedFeature> firTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.FIR_TREES);
-			Holder<PlacedFeature> windsweptHillsFirTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.WINDSWEPT_HILLS_FIR_TREES);
-			Holder<PlacedFeature> pineTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.PINE_TREES);
-			Holder<PlacedFeature> spruceTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.SPRUCE_TREES);
-			Holder<PlacedFeature> spruceTundraTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.SPRUCE_TUNDRA_TREES);
-			Holder<PlacedFeature> redwoodTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.REDWOOD_TREES);
-			Holder<PlacedFeature> jungleTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.JUNGLE_TREES);
-			Holder<PlacedFeature> jungleEdgeTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.JUNGLE_EDGE_TREES);
-			Holder<PlacedFeature> badlandsTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.BADLANDS_TREES);
-			Holder<PlacedFeature> woodedBadlandsTrees = placedFeatures.getOrThrow(PresetPlacedFeatures.WOODED_BADLANDS_TREES);
-			
 			ctx.register(REPLACE_PLAINS_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, plains, Map.of(
-				VegetationPlacements.TREES_PLAINS, plainsTrees
+					VegetationPlacements.TREES_PLAINS, PresetPlacedFeatures.PLAINS_TREES
 			)));
 			ctx.register(REPLACE_FOREST_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, forests, Map.of(
-				VegetationPlacements.TREES_BIRCH_AND_OAK, forestTrees
+					VegetationPlacements.TREES_BIRCH_AND_OAK, PresetPlacedFeatures.FOREST_TREES
 			)));
 			ctx.register(REPLACE_FLOWER_FOREST_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, flowerForests, Map.of(
-				VegetationPlacements.TREES_FLOWER_FOREST, flowerForestTrees
+					VegetationPlacements.TREES_FLOWER_FOREST, PresetPlacedFeatures.FLOWER_FOREST_TREES
 			)));
 			ctx.register(REPLACE_BIRCH_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, birchForests, Map.of(
-				VegetationPlacements.TREES_BIRCH, birchTrees,
-				VegetationPlacements.BIRCH_TALL, birchTrees
+					VegetationPlacements.TREES_BIRCH, PresetPlacedFeatures.BIRCH_TREES,
+					VegetationPlacements.BIRCH_TALL, PresetPlacedFeatures.BIRCH_TREES
 			)));
 			ctx.register(REPLACE_DARK_FOREST_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, darkForests, Map.of(
-				VegetationPlacements.DARK_FOREST_VEGETATION, darkForestTrees
+					VegetationPlacements.DARK_FOREST_VEGETATION, PresetPlacedFeatures.DARK_FOREST_TREES
 			)));
 			ctx.register(REPLACE_SAVANNA_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, savannas, Map.of(
-				VegetationPlacements.TREES_SAVANNA, savannaTrees
+					VegetationPlacements.TREES_SAVANNA, PresetPlacedFeatures.SAVANNA_TREES
 			)));
 			ctx.register(REPLACE_SWAMP_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, swamps, Map.of(
-				VegetationPlacements.TREES_SWAMP, swampTrees
+					VegetationPlacements.TREES_SWAMP, PresetPlacedFeatures.SWAMP_TREES
 			)));
 			ctx.register(REPLACE_MEADOW_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, meadows, Map.of(
-				VegetationPlacements.TREES_MEADOW, meadowTrees
+					VegetationPlacements.TREES_MEADOW, PresetPlacedFeatures.MEADOW_TREES
 			)));
 			ctx.register(REPLACE_FIR_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, firForests, Map.of(
-				VegetationPlacements.TREES_GROVE, firTrees,
-				VegetationPlacements.TREES_WINDSWEPT_FOREST, firTrees
+					VegetationPlacements.TREES_GROVE, PresetPlacedFeatures.FIR_TREES,
+					VegetationPlacements.TREES_WINDSWEPT_FOREST, PresetPlacedFeatures.FIR_TREES
 			)));
 			ctx.register(REPLACE_WINDSWEPT_HILLS_FIR_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, windsweptHills, Map.of(
-				VegetationPlacements.TREES_WINDSWEPT_HILLS, windsweptHillsFirTrees
+					VegetationPlacements.TREES_WINDSWEPT_HILLS, PresetPlacedFeatures.WINDSWEPT_HILLS_FIR_TREES
 			)));
 			ctx.register(REPLACE_PINE_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, pineForests, Map.of(
-				VegetationPlacements.TREES_TAIGA, pineTrees,
-				VegetationPlacements.TREES_OLD_GROWTH_SPRUCE_TAIGA, pineTrees
+					VegetationPlacements.TREES_TAIGA, PresetPlacedFeatures.PINE_TREES,
+					VegetationPlacements.TREES_OLD_GROWTH_SPRUCE_TAIGA, PresetPlacedFeatures.PINE_TREES
 			)));
 			ctx.register(REPLACE_SPRUCE_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, spruceForests, Map.of(
-				VegetationPlacements.TREES_TAIGA, spruceTrees
+					VegetationPlacements.TREES_TAIGA, PresetPlacedFeatures.SPRUCE_TREES
 			)));
 			ctx.register(REPLACE_SPRUCE_TUNDRA_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, spruceTundras, Map.of(
-				VegetationPlacements.TREES_SNOWY, spruceTundraTrees
+					VegetationPlacements.TREES_SNOWY, PresetPlacedFeatures.SPRUCE_TUNDRA_TREES
 			)));
 			ctx.register(REPLACE_REDWOOD_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, redwoodForests, Map.of(
-				VegetationPlacements.TREES_OLD_GROWTH_PINE_TAIGA, redwoodTrees
+					VegetationPlacements.TREES_OLD_GROWTH_PINE_TAIGA, PresetPlacedFeatures.REDWOOD_TREES
 			)));
 			ctx.register(REPLACE_JUNGLE_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, jungles, Map.of(
-				VegetationPlacements.TREES_JUNGLE, jungleTrees,
-				VegetationPlacements.BAMBOO_VEGETATION, jungleTrees
+					VegetationPlacements.TREES_JUNGLE, PresetPlacedFeatures.JUNGLE_TREES,
+					VegetationPlacements.BAMBOO_VEGETATION, PresetPlacedFeatures.JUNGLE_TREES
 			)));
 			ctx.register(REPLACE_JUNGLE_EDGE_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, jungleEdges, Map.of(
-				VegetationPlacements.TREES_SPARSE_JUNGLE, jungleEdgeTrees
+					VegetationPlacements.TREES_SPARSE_JUNGLE, PresetPlacedFeatures.JUNGLE_EDGE_TREES
 			)));
 			ctx.register(REPLACE_BADLANDS_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, badlands, Map.of(
-				VegetationPlacements.TREES_BADLANDS, badlandsTrees,
-				VegetationPlacements.TREES_WINDSWEPT_SAVANNA, badlandsTrees
+					VegetationPlacements.TREES_BADLANDS, PresetPlacedFeatures.BADLANDS_TREES,
+					VegetationPlacements.TREES_WINDSWEPT_SAVANNA, PresetPlacedFeatures.BADLANDS_TREES
 			)));
 			ctx.register(REPLACE_WOODED_BADLANDS_TREES, BiomeModifiers.replace(GenerationStep.Decoration.VEGETAL_DECORATION, woodedBadlands, Map.of(
-				VegetationPlacements.TREES_BADLANDS, woodedBadlandsTrees
+					VegetationPlacements.TREES_BADLANDS, PresetPlacedFeatures.WOODED_BADLANDS_TREES
 			)));
 
+			// We keep these here because prepend/append still rely on Holders!
 			ctx.register(ADD_MARSH_BUSH, prepend(GenerationStep.Decoration.VEGETAL_DECORATION, Filter.Behavior.WHITELIST, marshBushBiomes, placedFeatures.getOrThrow(PresetPlacedFeatures.MARSH_BUSH)));
 			ctx.register(ADD_PLAINS_BUSH, prepend(GenerationStep.Decoration.VEGETAL_DECORATION, Filter.Behavior.WHITELIST, plainsBushBiomes, placedFeatures.getOrThrow(PresetPlacedFeatures.PLAINS_BUSH)));
 			ctx.register(ADD_STEPPE_BUSH, prepend(GenerationStep.Decoration.VEGETAL_DECORATION, Filter.Behavior.WHITELIST, steppeBushBiomes, placedFeatures.getOrThrow(PresetPlacedFeatures.STEPPE_BUSH)));
 			ctx.register(ADD_COLD_STEPPE_BUSH, prepend(GenerationStep.Decoration.VEGETAL_DECORATION, Filter.Behavior.WHITELIST, coldSteppeBiomes, placedFeatures.getOrThrow(PresetPlacedFeatures.COLD_STEPPE_BUSH)));
 			ctx.register(ADD_TAIGA_SCRUB_BUSH, prepend(GenerationStep.Decoration.VEGETAL_DECORATION, Filter.Behavior.WHITELIST, taigaScrubBiomes, placedFeatures.getOrThrow(PresetPlacedFeatures.TAIGA_SCRUB_BUSH)));
-			
+
 			ctx.register(ADD_FOREST_GRASS, prepend(GenerationStep.Decoration.VEGETAL_DECORATION, Filter.Behavior.WHITELIST, forestsWithGrass, placedFeatures.getOrThrow(PresetPlacedFeatures.FOREST_GRASS)));
 			ctx.register(ADD_BIRCH_FOREST_GRASS, prepend(GenerationStep.Decoration.VEGETAL_DECORATION, Filter.Behavior.WHITELIST, birchForests, placedFeatures.getOrThrow(PresetPlacedFeatures.BIRCH_FOREST_GRASS)));
 		}
-		
+
 		if(miscellaneous.erosionDecorator) {
 			ctx.register(ADD_EROSION, prepend(GenerationStep.Decoration.RAW_GENERATION, placedFeatures.getOrThrow(PresetPlacedFeatures.ERODE)));
 		}
 		if(miscellaneous.naturalSnowDecorator || miscellaneous.smoothLayerDecorator) {
 			ctx.register(ADD_SNOW_PROCESSING, append(GenerationStep.Decoration.TOP_LAYER_MODIFICATION, placedFeatures.getOrThrow(PresetPlacedFeatures.DECORATE_SNOW)));
 		}
-		
+
 		ctx.register(ADD_SWAMP_SURFACE, prepend(GenerationStep.Decoration.RAW_GENERATION, Filter.Behavior.WHITELIST, swamps, placedFeatures.getOrThrow(PresetPlacedFeatures.SWAMP_SURFACE)));
 	}
-	
+
 	@SafeVarargs
 	private static BiomeModifier prepend(GenerationStep.Decoration step, Holder<PlacedFeature>... features) {
 		return BiomeModifiers.add(Order.PREPEND, step, HolderSet.direct(features));
@@ -201,13 +183,13 @@ public class PresetBiomeModifierData {
 	private static BiomeModifier append(GenerationStep.Decoration step, Holder<PlacedFeature>... features) {
 		return BiomeModifiers.add(Order.APPEND, step, HolderSet.direct(features));
 	}
-	
+
 	@SafeVarargs
 	private static BiomeModifier append(GenerationStep.Decoration step, Filter.Behavior filterBehavior, HolderSet<Biome> biomes, Holder<PlacedFeature>... features) {
 		return BiomeModifiers.add(Order.APPEND, step, filterBehavior, biomes, HolderSet.direct(features));
 	}
-	
+
 	private static ResourceKey<BiomeModifier> createKey(String name) {
-        return ResourceKey.create(RTFRegistries.BIOME_MODIFIER, RTFCommon.location(name));
+		return ResourceKey.create(RTFRegistries.BIOME_MODIFIER, RTFCommon.location(name));
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/BiomeModifiers.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/BiomeModifiers.java
@@ -4,9 +4,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.mojang.datafixers.util.Pair;
-import com.mojang.serialization.Codec;
-
 import com.mojang.serialization.MapCodec;
+
 import dev.architectury.injectables.annotations.ExpectPlatform;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
@@ -18,7 +17,7 @@ import raccoonman.reterraforged.platform.RegistryUtil;
 import raccoonman.reterraforged.registries.RTFBuiltInRegistries;
 
 public class BiomeModifiers {
-	
+
 	@ExpectPlatform
 	public static void bootstrap() {
 		throw new UnsupportedOperationException();
@@ -28,7 +27,7 @@ public class BiomeModifiers {
 	public static BiomeModifier add(Order order, GenerationStep.Decoration step, Holder<PlacedFeature>... features) {
 		return add(order, step, HolderSet.direct(features));
 	}
-	
+
 	public static BiomeModifier add(Order order, GenerationStep.Decoration step, HolderSet<PlacedFeature> features) {
 		return add(order, step, Optional.empty(), features);
 	}
@@ -41,22 +40,22 @@ public class BiomeModifiers {
 	public static BiomeModifier add(Order order, GenerationStep.Decoration step, Filter.Behavior filterBehavior, HolderSet<Biome> biomes, HolderSet<PlacedFeature> features) {
 		return add(order, step, Optional.of(Pair.of(filterBehavior, biomes)), features);
 	}
-	
+
 	@ExpectPlatform
 	public static BiomeModifier add(Order order, GenerationStep.Decoration step, Optional<Pair<Filter.Behavior, HolderSet<Biome>>> biomes, HolderSet<PlacedFeature> features) {
 		throw new UnsupportedOperationException();
 	}
 
-	public static BiomeModifier replace(GenerationStep.Decoration step, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) {
+	public static BiomeModifier replace(GenerationStep.Decoration step, Map<ResourceKey<PlacedFeature>, ResourceKey<PlacedFeature>> replacements) {
 		return replace(step, Optional.empty(), replacements);
 	}
 
-	public static BiomeModifier replace(GenerationStep.Decoration step, HolderSet<Biome> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) {
+	public static BiomeModifier replace(GenerationStep.Decoration step, HolderSet<Biome> biomes, Map<ResourceKey<PlacedFeature>, ResourceKey<PlacedFeature>> replacements) {
 		return replace(step, Optional.of(biomes), replacements);
 	}
-	
+
 	@ExpectPlatform
-	public static BiomeModifier replace(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) {
+	public static BiomeModifier replace(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, ResourceKey<PlacedFeature>> replacements) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/fabric/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/fabric/BiomeModifiersImpl.java
+++ b/fabric/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/fabric/BiomeModifiersImpl.java
@@ -4,10 +4,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import com.mojang.datafixers.util.Pair;
-import com.mojang.serialization.Codec;
-
 import com.mojang.serialization.MapCodec;
-import net.minecraft.core.Holder;
+
 import net.minecraft.core.HolderSet;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.biome.Biome;
@@ -20,41 +18,21 @@ import raccoonman.reterraforged.world.worldgen.biome.modifier.Filter;
 import raccoonman.reterraforged.world.worldgen.biome.modifier.Order;
 
 public class BiomeModifiersImpl {
-	
+
 	public static void bootstrap() {
 		register("add", AddModifier.CODEC);
 		register("replace", ReplaceModifier.CODEC);
-		
-		//prevent forge biome modifiers from being loaded
-		//FIXME this is a bad way to do this 
-		register("neoforge:none", Dummy.makeCodec());
-		register("neoforge:add_features", Dummy.makeCodec());
-		register("neoforge:remove_features", Dummy.makeCodec());
-		register("neoforge:add_spawns", Dummy.makeCodec());
-		register("neoforge:remove_spawns", Dummy.makeCodec());
 	}
-	
+
 	public static BiomeModifier add(Order order, GenerationStep.Decoration step, Optional<Pair<Filter.Behavior, HolderSet<Biome>>> biomes, HolderSet<PlacedFeature> features) {
 		return new AddModifier(order, step, biomes.map((p) -> new Filter(p.getSecond(), p.getFirst())), features);
 	}
 
-	public static BiomeModifier replace(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) {
+	public static BiomeModifier replace(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, ResourceKey<PlacedFeature>> replacements) {
 		return new ReplaceModifier(step, biomes, replacements);
 	}
-	
+
 	public static void register(String name, MapCodec<? extends BiomeModifier> value) {
 		RegistryUtil.register(RTFBuiltInRegistries.BIOME_MODIFIER_TYPE, name, value);
 	}
-
-	private record Dummy() implements BiomeModifier	{
-		
-		@Override
-		public MapCodec<Dummy> codec() {
-			return makeCodec();
-		}
-		
-		public static MapCodec<Dummy> makeCodec() {
-			return MapCodec.unit(Dummy::new);
-		}
-	};
 }

--- a/fabric/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/fabric/ReplaceModifier.java
+++ b/fabric/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/fabric/ReplaceModifier.java
@@ -1,7 +1,5 @@
 package raccoonman.reterraforged.world.worldgen.biome.modifier.fabric;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -11,47 +9,41 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import net.fabricmc.fabric.api.biome.v1.BiomeModificationContext;
 import net.fabricmc.fabric.api.biome.v1.BiomeSelectionContext;
-import net.minecraft.core.Holder;
 import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeGenerationSettings;
 import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
-record ReplaceModifier(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) implements FabricBiomeModifier {
+public record ReplaceModifier(
+		GenerationStep.Decoration step,
+		Optional<HolderSet<Biome>> biomes,
+		Map<ResourceKey<PlacedFeature>, ResourceKey<PlacedFeature>> replacements
+) implements FabricBiomeModifier {
+
 	public static final MapCodec<ReplaceModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-		GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(ReplaceModifier::step),
-		Biome.LIST_CODEC.optionalFieldOf("biomes").forGetter(ReplaceModifier::biomes),
-		Codec.unboundedMap(ResourceKey.codec(Registries.PLACED_FEATURE), PlacedFeature.CODEC).fieldOf("replacements").forGetter(ReplaceModifier::replacements)
+			GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(ReplaceModifier::step),
+			Biome.LIST_CODEC.optionalFieldOf("biomes").forGetter(ReplaceModifier::biomes),
+			Codec.unboundedMap(
+					ResourceKey.codec(Registries.PLACED_FEATURE),
+					ResourceKey.codec(Registries.PLACED_FEATURE)
+			).fieldOf("replacements").forGetter(ReplaceModifier::replacements)
 	).apply(instance, ReplaceModifier::new));
 
 	@Override
 	public void apply(BiomeSelectionContext selectionContext, BiomeModificationContext modificationContext) {
-		if(this.biomes.isPresent() && !this.biomes.get().contains(selectionContext.getBiomeRegistryEntry())) {
+		if (this.biomes.isPresent() && !this.biomes.get().contains(selectionContext.getBiomeRegistryEntry())) {
 			return;
 		}
-		
-		BiomeGenerationSettings generationSettings = selectionContext.getBiome().getGenerationSettings();
-		List<HolderSet<PlacedFeature>> featureSteps = generationSettings.features();
-		int index = this.step.ordinal();
 
-		while (index >= featureSteps.size()) {
-			featureSteps.add(HolderSet.direct());
-		}
-
-		featureSteps.set(index, this.replace(featureSteps.get(index)));
-		
-		this.rebuildFlowerFeatures(generationSettings);
-	}
-	
-	private HolderSet<PlacedFeature> replace(HolderSet<PlacedFeature> features) {
-		List<Holder<PlacedFeature>> newList = new ArrayList<>(features.stream().toList());
-		newList.replaceAll((f) -> {
-			return f.unwrapKey().map(this.replacements::get).orElse(f);
+		this.replacements.forEach((originalKey, replacementKey) -> {
+			// Attempt to safely remove the vanilla feature using Fabric's API
+			if (modificationContext.getGenerationSettings().removeFeature(this.step, originalKey)) {
+				// If it was successfully found and removed, inject the custom replacement
+				modificationContext.getGenerationSettings().addFeature(this.step, replacementKey);
+			}
 		});
-		return HolderSet.direct(newList);
 	}
 
 	@Override

--- a/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/BiomeModifiersImpl.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/BiomeModifiersImpl.java
@@ -28,11 +28,11 @@ public class BiomeModifiersImpl {
 	public static BiomeModifier add(Order order, GenerationStep.Decoration step, Optional<Pair<Filter.Behavior, HolderSet<Biome>>> biomes, HolderSet<PlacedFeature> features) {
 		return new AddModifier(order, step, biomes.map((p) -> new Filter(p.getSecond(), p.getFirst())), features);
 	}
-	
-	public static BiomeModifier replace(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) {
+
+	public static BiomeModifier replace(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, ResourceKey<PlacedFeature>> replacements) {
 		return new ReplaceModifier(step, biomes, replacements);
 	}
-	
+
 	public static void register(String name, MapCodec<? extends BiomeModifier> value) {
 		RegistryUtil.register(RTFBuiltInRegistries.BIOME_MODIFIER_TYPE, name, value);
 	}

--- a/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/ReplaceModifier.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/world/worldgen/biome/modifier/neoforge/ReplaceModifier.java
@@ -18,11 +18,15 @@ import net.neoforged.neoforge.common.world.BiomeModifier;
 import net.neoforged.neoforge.common.world.ModifiableBiomeInfo.BiomeInfo;
 import raccoonman.reterraforged.neoforge.mixin.MixinBiomeGenerationSettingsPlainsBuilder;
 
-public record ReplaceModifier(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, Holder<PlacedFeature>> replacements) implements ForgeBiomeModifier {
+public record ReplaceModifier(GenerationStep.Decoration step, Optional<HolderSet<Biome>> biomes, Map<ResourceKey<PlacedFeature>, ResourceKey<PlacedFeature>> replacements) implements ForgeBiomeModifier {
 	public static final MapCodec<ReplaceModifier> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-		GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(ReplaceModifier::step),
-		Biome.LIST_CODEC.optionalFieldOf("biomes").forGetter(ReplaceModifier::biomes),
-		Codec.unboundedMap(ResourceKey.codec(Registries.PLACED_FEATURE), PlacedFeature.CODEC).fieldOf("replacements").forGetter(ReplaceModifier::replacements)
+			GenerationStep.Decoration.CODEC.fieldOf("step").forGetter(ReplaceModifier::step),
+			Biome.LIST_CODEC.optionalFieldOf("biomes").forGetter(ReplaceModifier::biomes),
+			// Use ResourceKey.codec here instead of the full object codec
+			Codec.unboundedMap(
+					ResourceKey.codec(Registries.PLACED_FEATURE),
+					ResourceKey.codec(Registries.PLACED_FEATURE)
+			).fieldOf("replacements").forGetter(ReplaceModifier::replacements)
 	).apply(instance, ReplaceModifier::new));
 
 	@Override
@@ -33,6 +37,10 @@ public record ReplaceModifier(GenerationStep.Decoration step, Optional<HolderSet
 					return;
 				}
 
+				var server = net.neoforged.neoforge.server.ServerLifecycleHooks.getCurrentServer();
+				var registryAccess = server.registryAccess();
+				var featureRegistry = registryAccess.lookupOrThrow(Registries.PLACED_FEATURE);
+
 				List<List<Holder<PlacedFeature>>> featureSteps = builderAccessor.getFeatures();
 				int index = this.step.ordinal();
 
@@ -40,13 +48,23 @@ public record ReplaceModifier(GenerationStep.Decoration step, Optional<HolderSet
 					featureSteps.add(Collections.emptyList());
 				}
 
-				// Copy to a new mutable list, then set it back
 				List<Holder<PlacedFeature>> replaced = new ArrayList<>(featureSteps.get(index));
-				replaced.replaceAll((f) -> f.unwrapKey().map(this.replacements::get).orElse(f));
-				featureSteps.set(index, replaced);
 
-			} else {
-				throw new IllegalStateException();
+				replaced.replaceAll((f) -> {
+					// Check if this feature is one of our keys
+					return f.unwrapKey()
+							.map(key -> {
+								// If we have a replacement, look it up in the registry
+								if (this.replacements.containsKey(key)) {
+									ResourceKey<PlacedFeature> replacementKey = this.replacements.get(key);
+									return featureRegistry.get(replacementKey)
+											.orElseThrow(() -> new IllegalStateException("Missing feature: " + replacementKey.location()));
+								}
+								return f;
+							})
+							.orElse(f);
+				});
+				featureSteps.set(index, replaced);
 			}
 		}
 	}


### PR DESCRIPTION
There's been longstanding issues with Biome Modifiers causing instability. 

After some investigation the root cause of all these changes appears to be an issue with serialization caused by a Holder vs ResourceKey mismatch that was silently failing previously due to Java generics essentially hiding how cooked it was. 

I managed to generate reproducible crash conditions in Fabric by starting worlds, exiting immediately then reopening them. I used those crashes to iteratively develop fixes working with Gemini, which suggested a number of fixes

- not mutating an immutable list
- using our own implementation of the registry exporter to avoid neoforge injections causing serialization crashes
- using resourcekey lookups rather than holders to allow for delayed creation
- using fabrics native biome modification contexts

With the changes in place I have confirmed biome modifiers still spawn for both Neoforge and Fabric clients, and that saving worlds and reloading them dont trigger crashes, and that running for ~15m in a single direction doesn't trigger crashes (Fabric client - 75k travel generating realtime new chunks)

I'm hoping this hardening is the last we see of these. the added benefit is it also cleaned up a good chunk of duplicated, older and todo code.

Probably fixes https://github.com/ETcodehome/ReTerraForged/issues/67 because the serialization between Fabric runs now works reliably when chunk generation is interrupted mid generation

