### PR TITLE
Fix preset saving bugs

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/page/LinkedPageScreen.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/page/LinkedPageScreen.java
@@ -7,7 +7,6 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetConfigScreen;
 import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetEditorPage;
 import raccoonman.reterraforged.client.gui.widget.Label;
 
@@ -23,7 +22,7 @@ public abstract class LinkedPageScreen extends Screen {
 	}
 	
 	public void setPage(Page page) {
-		this.currentPage.onClose();
+		this.currentPage.onCancel();
 		this.currentPage = page;
 		this.rebuildWidgets();
 	}
@@ -90,11 +89,11 @@ public abstract class LinkedPageScreen extends Screen {
 	
 	@Override
 	public void onClose() {
-		this.currentPage.onClose();
+		this.currentPage.onCancel();
 	}
 	
 	public void onDone() {
-		this.currentPage.onDone();
+		this.currentPage.onSave();
 	}
 	
 	public interface Page {
@@ -106,10 +105,10 @@ public abstract class LinkedPageScreen extends Screen {
 		
 		Optional<Page> next();
 		
-		default void onClose() {
+		default void onCancel() {
 		}
 		
-		default void onDone() {
+		default void onSave() {
 		}
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetEditorPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetEditorPage.java
@@ -210,18 +210,22 @@ public abstract class PresetEditorPage extends BisectedPage<PresetConfigScreen, 
 	}
 
 	@Override
-	public void onClose() {
-		super.onClose();
+	public void onCancel() {
+		super.onCancel();
 		try {
-			this.preset.save();
 			if (this.preview3D != null) this.preview3D.close();
 			if (this.preview2D != null) this.preview2D.close();
 		} catch (Exception e) { e.printStackTrace(); }
 	}
 
 	@Override
-	public void onDone() {
-		super.onDone();
-		try { this.screen.applyPreset(this.preset); } catch (IOException e) { e.printStackTrace(); }
+	public void onSave() {
+		super.onSave();
+		try {
+			this.screen.applyPreset(this.preset);
+			this.preset.save();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetListPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetListPage.java
@@ -270,8 +270,6 @@ class PresetListPage extends BisectedPage<PresetConfigScreen, PresetEntry, Abstr
 		public void save() throws IOException {
 
 			RTFCommon.LOGGER.info("Encoding Preset - {}", this.getPath().getFileName().toString());
-			RTFCommon.LOGGER.info("Preset Object: {}", this.preset);
-			RTFCommon.LOGGER.info("Island Settings: {}", this.preset.island());
 
 			if (!this.builtin) {
 				Path path = this.getPath();

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetListPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetListPage.java
@@ -14,11 +14,9 @@ import java.util.regex.Pattern;
 import org.apache.commons.compress.utils.FileNameUtils;
 import org.jetbrains.annotations.Nullable;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.stream.JsonWriter;
 import com.mojang.serialization.DataResult;
-import com.mojang.serialization.DataResult.Error;
 import com.mojang.serialization.JsonOps;
 
 import io.netty.util.internal.StringUtil;
@@ -29,7 +27,6 @@ import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.toasts.SystemToast.SystemToastId;
 import net.minecraft.network.chat.Component;
-import net.minecraft.network.chat.Style;
 import net.minecraft.util.GsonHelper;
 import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.client.data.RTFTranslationKeys;
@@ -159,8 +156,8 @@ class PresetListPage extends BisectedPage<PresetConfigScreen, PresetEntry, Abstr
 	}
 	
 	@Override
-	public void onDone() {
-		super.onDone();
+	public void onSave() {
+		super.onSave();
 		
 		Entry<PresetEntry> selected = this.left.getSelected();
 		if(selected != null) {
@@ -223,13 +220,10 @@ class PresetListPage extends BisectedPage<PresetConfigScreen, PresetEntry, Abstr
 				try(Reader reader = Files.newBufferedReader(presetPath)) {
 					String base = FileNameUtils.getBaseName(presetPath.toString());
 					DataResult<Preset> result = Preset.DIRECT_CODEC.parse(JsonOps.INSTANCE, JsonParser.parseReader(reader));
-					Optional<Error<Preset>> error = result.error();
-					if(error.isPresent()) {
-						RTFCommon.LOGGER.error(error.get().message());
-						continue;
+					Preset preset = result.resultOrPartial(RTFCommon.LOGGER::error).orElse(null);
+					if(preset != null) {
+						presets.add(new PresetEntry(Component.literal(base).withStyle(ChatFormatting.GOLD), preset, false, this));
 					}
-					Preset preset = result.result().get();
-					presets.add(new PresetEntry(Component.literal(base).withStyle(ChatFormatting.GOLD), preset, false, this));
 				}
 			}
 		}
@@ -272,19 +266,32 @@ class PresetListPage extends BisectedPage<PresetConfigScreen, PresetEntry, Abstr
 		public Path getPath() {
 			return PRESET_PATH.resolve(this.name.getString() + ".json");
 		}
-		
-		//FIXME delete old pack before save
+
 		public void save() throws IOException {
-			if(!this.builtin) {
-				try(
-					Writer writer = Files.newBufferedWriter(this.getPath());
-					JsonWriter jsonWriter = new JsonWriter(writer);
-				) {
-					JsonElement element = Preset.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, this.preset).result().orElseThrow();
-					jsonWriter.setSerializeNulls(false);
-					jsonWriter.setIndent("  ");
-					GsonHelper.writeValue(jsonWriter, element, null);
-				}
+
+			RTFCommon.LOGGER.info("Encoding Preset - {}", this.getPath().getFileName().toString());
+			RTFCommon.LOGGER.info("Preset Object: {}", this.preset);
+			RTFCommon.LOGGER.info("Island Settings: {}", this.preset.island());
+
+			if (!this.builtin) {
+				Path path = this.getPath();
+				Path tempPath = path.resolveSibling(path.getFileName().toString() + ".tmp");
+
+				Preset.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, this.preset)
+						.resultOrPartial(error -> RTFCommon.LOGGER.error("Failed to encode preset: {}", error))
+						.ifPresent(element -> {
+							try (Writer writer = Files.newBufferedWriter(tempPath);
+								 JsonWriter jsonWriter = new JsonWriter(writer)) {
+								jsonWriter.setSerializeNulls(false);
+								jsonWriter.setIndent("  ");
+								GsonHelper.writeValue(jsonWriter, element, null);
+
+								// Atomic move (if save succeeds, overwrite original)
+								java.nio.file.Files.move(tempPath, path, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+							} catch (IOException e) {
+								RTFCommon.LOGGER.error("Failed to write preset to disk", e);
+							}
+						});
 			}
 		}
 	}

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/IslandSettings.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/IslandSettings.java
@@ -36,7 +36,7 @@ public class IslandSettings {
 	public float beachWidth;
 	public float beachCoverage;
 	
-	public IslandSettings(boolean enableArchipelago, float islandDensity, float islandSize, float islandHeight, float islandBaseScale, float islandVerticalScale, float islandHorizontalScale, float mountainChance, float volcanoChance, float offshoreDepth, float beachWidth, float beachCoverage, float mountainScale, float volcanismScale) {
+	public IslandSettings(boolean enableArchipelago, float islandDensity, float islandSize, float islandHeight, float islandBaseScale, float islandVerticalScale, float islandHorizontalScale, float mountainChance, float volcanoChance, float offshoreDepth, float beachWidth, float beachCoverage, float volcanismScale, float mountainScale) {
 		this.enableArchipelago = enableArchipelago;
 		this.islandDensity = islandDensity;
 		this.islandSize = islandSize;

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
@@ -35,7 +35,12 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 			ClimateSettings.CODEC.fieldOf("climate").forGetter(Preset::climate),
 			TerrainSettings.CODEC.fieldOf("terrain").forGetter(Preset::terrain),
 			RiverSettings.CODEC.fieldOf("rivers").forGetter(Preset::rivers),
-			IslandSettings.CODEC.optionalFieldOf("island", IslandSettings.makeDefault()).forGetter(Preset::island),
+			IslandSettings.CODEC.optionalFieldOf("island")
+					.xmap(
+							optional -> optional.orElseGet(IslandSettings::makeDefault),
+							Optional::of
+					)
+					.forGetter(Preset::island),
 			FilterSettings.CODEC.fieldOf("filters").forGetter(Preset::filters),
 			StructureSettings.CODEC.fieldOf("structures").forGetter(Preset::structures),
 			MiscellaneousSettings.CODEC.fieldOf("miscellaneous").forGetter(Preset::miscellaneous)

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
@@ -35,12 +35,7 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 			ClimateSettings.CODEC.fieldOf("climate").forGetter(Preset::climate),
 			TerrainSettings.CODEC.fieldOf("terrain").forGetter(Preset::terrain),
 			RiverSettings.CODEC.fieldOf("rivers").forGetter(Preset::rivers),
-			IslandSettings.CODEC.optionalFieldOf("island")
-					.xmap(
-							optional -> optional.orElseGet(IslandSettings::makeDefault),
-							Optional::of
-					)
-					.forGetter(Preset::island),
+			IslandSettings.CODEC.optionalFieldOf("island").xmap(optional -> optional.orElseGet(IslandSettings::makeDefault),Optional::of).forGetter(Preset::island),
 			FilterSettings.CODEC.fieldOf("filters").forGetter(Preset::filters),
 			StructureSettings.CODEC.fieldOf("structures").forGetter(Preset::structures),
 			MiscellaneousSettings.CODEC.fieldOf("miscellaneous").forGetter(Preset::miscellaneous)


### PR DESCRIPTION
This fixes island settings not persisting correctly on custom presets.

- Cancelling was saving, 
- Done wasn't saving.
- Volcanism and mountain orders were reversed.
- The optionalFieldOf applied in both directions and wouldn't write the IslandSettings to file. the default comparison fallback in use by surfacesettings and cavesettings requires an equality override to work correctly otherwise it resolves back to the default.