### PR TITLE
Fix carving near rivers

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetBiomeModifierData.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetBiomeModifierData.java
@@ -55,6 +55,7 @@ public class PresetBiomeModifierData {
 
 	public static final ResourceKey<BiomeModifier> ADD_FOREST_GRASS = createKey("add_forest_grass");
 	public static final ResourceKey<BiomeModifier> ADD_BIRCH_FOREST_GRASS = createKey("add_birch_forest_grass");
+	public static final ResourceKey<BiomeModifier> ADD_RIVER_GASKET = createKey("add_river_gasket");
 
 	public static void bootstrap(Preset preset, BootstrapContext<BiomeModifier> ctx) {
 		MiscellaneousSettings miscellaneous = preset.miscellaneous();
@@ -167,6 +168,8 @@ public class PresetBiomeModifierData {
 		}
 
 		ctx.register(ADD_SWAMP_SURFACE, prepend(GenerationStep.Decoration.RAW_GENERATION, Filter.Behavior.WHITELIST, swamps, placedFeatures.getOrThrow(PresetPlacedFeatures.SWAMP_SURFACE)));
+
+		ctx.register(ADD_RIVER_GASKET, prepend(GenerationStep.Decoration.RAW_GENERATION, placedFeatures.getOrThrow(PresetPlacedFeatures.RIVER_GASKET)));
 	}
 
 	@SafeVarargs

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetConfiguredFeatures.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetConfiguredFeatures.java
@@ -103,6 +103,7 @@ public class PresetConfiguredFeatures {
 	public static final ResourceKey<ConfiguredFeature<?, ?>> REDWOOD_TREES = createKey("redwood_trees");
 	public static final ResourceKey<ConfiguredFeature<?, ?>> JUNGLE_TREES = createKey("jungle_trees");
 	public static final ResourceKey<ConfiguredFeature<?, ?>> JUNGLE_EDGE_TREES = createKey("jungle_edge_trees");
+	public static final ResourceKey<ConfiguredFeature<?, ?>> RIVER_GASKET = createKey("river_gasket");
 	
 	public static void bootstrap(Preset preset, BootstrapContext<ConfiguredFeature<?, ?>> ctx) {
 		MiscellaneousSettings miscellaneous = preset.miscellaneous();
@@ -119,6 +120,7 @@ public class PresetConfiguredFeatures {
 		}
 		
 		FeatureUtils.register(ctx, SWAMP_SURFACE, RTFFeatures.SWAMP_SURFACE, new SwampSurfaceFeature.Config(Blocks.CLAY.defaultBlockState(), Blocks.GRAVEL.defaultBlockState(), Blocks.DIRT.defaultBlockState()));
+		FeatureUtils.register(ctx, RIVER_GASKET, RTFFeatures.RIVER_GASKET, FeatureConfiguration.NONE);
 		
 		if(miscellaneous.customBiomeFeatures) {
 			HolderGetter<PlacedFeature> placedFeatures = ctx.lookup(Registries.PLACED_FEATURE);

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetPlacedFeatures.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetPlacedFeatures.java
@@ -83,6 +83,7 @@ public class PresetPlacedFeatures {
 	public static final ResourceKey<PlacedFeature> REDWOOD_TREES = createKey("redwood_trees");
 	public static final ResourceKey<PlacedFeature> JUNGLE_TREES = createKey("jungle_trees");
 	public static final ResourceKey<PlacedFeature> JUNGLE_EDGE_TREES = createKey("jungle_edge_trees");
+	public static final ResourceKey<PlacedFeature> RIVER_GASKET = createKey("river_gasket");
     
 	public static void bootstrap(Preset preset, BootstrapContext<PlacedFeature> ctx) {
 		HolderGetter<ConfiguredFeature<?, ?>> features = ctx.lookup(Registries.CONFIGURED_FEATURE);
@@ -99,6 +100,7 @@ public class PresetPlacedFeatures {
 		}
 		
 		PlacementUtils.register(ctx, SWAMP_SURFACE, features.getOrThrow(PresetConfiguredFeatures.SWAMP_SURFACE));
+		PlacementUtils.register(ctx, RIVER_GASKET, features.getOrThrow(PresetConfiguredFeatures.RIVER_GASKET));
 		
         if(!miscellaneous.vanillaSprings) {
         	PlacementUtils.register(ctx, MiscOverworldPlacements.SPRING_WATER, features.getOrThrow(MiscOverworldFeatures.SPRING_WATER), blacklistOverworld);

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
@@ -95,6 +95,9 @@ public class Cell {
         this.moisture = other.moisture;
         this.beachNoise = other.beachNoise;
         this.continentSizeModifier = other.continentSizeModifier;
+        this.riverWaterLevel = other.riverWaterLevel;
+        this.riverZone = other.riverZone;
+        this.waterTable = other.waterTable;
     }
 
     public Cell reset() {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RTFFeatures.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RTFFeatures.java
@@ -4,6 +4,7 @@ import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.DiskConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.FeatureConfiguration;
+import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 import raccoonman.reterraforged.platform.RegistryUtil;
 import raccoonman.reterraforged.world.worldgen.feature.chance.ChanceFeature;
 import raccoonman.reterraforged.world.worldgen.feature.template.TemplateFeature;
@@ -16,10 +17,12 @@ public class RTFFeatures {
 	public static final Feature<ErodeFeature.Config> ERODE = register("erode", new ErodeFeature(ErodeFeature.Config.CODEC));
 	public static final Feature<DecorateSnowFeature.Config> DECORATE_SNOW = register("decorate_snow", new DecorateSnowFeature(DecorateSnowFeature.Config.CODEC));
 	public static final Feature<SwampSurfaceFeature.Config> SWAMP_SURFACE = register("swamp_surface", new SwampSurfaceFeature(SwampSurfaceFeature.Config.CODEC));
-	
+	public static final Feature<NoneFeatureConfiguration> RIVER_GASKET = register("river_gasket", new RiverGasketFeature(NoneFeatureConfiguration.CODEC));
+
 	public static void bootstrap() {
+
 	}
-	
+
 	private static <T extends FeatureConfiguration> Feature<T> register(String name, Feature<T> feature) {
 		RegistryUtil.register(BuiltInRegistries.FEATURE, name, feature);
 		return feature;

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
@@ -2,6 +2,7 @@ package raccoonman.reterraforged.world.worldgen.feature;
 
 import com.mojang.serialization.Codec;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.Blocks;
@@ -9,19 +10,17 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
-import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.WorldLookup;
 import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
-import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.River;
-import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSettings;
-
-import java.util.function.Supplier;
 
 public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
-    public static Supplier<WorldLookup> LOOKUP_PROVIDER = () -> null;
+
+    private static final Direction[] HORIZONTAL_DIRECTIONS = {
+            Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST
+    };
 
     public RiverGasketFeature(Codec<NoneFeatureConfiguration> codec) {
         super(codec);
@@ -29,12 +28,13 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
 
     @Override
     public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> context) {
+        WorldGenLevel level = context.level();
 
-        // Get access to the relevant data
-        net.minecraft.server.level.ServerLevel serverLevel = context.level().getLevel();
+        // 1. Extract the ReTerraForged generator context from the server level state
+        net.minecraft.server.level.ServerLevel serverLevel = level.getLevel();
         net.minecraft.world.level.levelgen.RandomState randomState = serverLevel.getChunkSource().randomState();
         if (!((Object) randomState instanceof raccoonman.reterraforged.world.worldgen.RTFRandomState rtfRandomState)) {
-            return false; // Safely skip if this isn't an RTF-managed world state
+            return false; // Skip if this chunk isn't being driven by RTF
         }
 
         GeneratorContext generatorContext = rtfRandomState.generatorContext();
@@ -42,123 +42,78 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
             return false;
         }
 
-        // Instantiated a localized WorldLookup using the context
+        // 2. Initialize our localized lookup utilities
         WorldLookup worldLookup = new WorldLookup(generatorContext);
-        WorldGenLevel level = context.level();
-        BlockPos origin = context.origin();
         Levels levels = worldLookup.getHeightmap().levels();
+        BlockPos origin = context.origin();
 
         int minBlockX = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getX()));
         int minBlockZ = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getZ()));
 
         Cell cell = new Cell();
-        BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
-        BlockState defaultStone = Blocks.STONE.defaultBlockState();
+        BlockPos.MutableBlockPos currentPos = new BlockPos.MutableBlockPos();
+        BlockPos.MutableBlockPos neighborPos = new BlockPos.MutableBlockPos();
+        BlockPos.MutableBlockPos belowNeighborPos = new BlockPos.MutableBlockPos();
 
+        BlockState stoneState = Blocks.REDSTONE_BLOCK.defaultBlockState();
+
+        // 3. Process the 16x16 chunk grid
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
                 int blockX = minBlockX + x;
                 int blockZ = minBlockZ + z;
 
+                // Query the hydrology/terrain profile for this exact column
                 worldLookup.applyCell(cell.reset(), blockX, blockZ, false, false);
 
-                boolean inFillRegion = cell.riverZone != RiverCarverSettings.RiverZone.None;
+                // DYNAMIC BOUNDS CALCULATION
+                // Convert the cell's continuous noise values back into concrete world Y integers
+                float oceanHeightOffset = levels.water;
+                float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanHeightOffset;
+                int localWaterY = levels.scale(targetWaterLevel);
+                int currentFloorHeight = levels.scale(cell.height);
 
-                if (inFillRegion) {
-                    int targetWaterY = levels.scale(cell.riverWaterLevel);
-                    int currentFloorHeight = levels.scale(cell.height);
+                // scanTopY tracks the absolute ceiling of where water or surface assets interact
+                int scanTopY = Math.max(localWaterY, currentFloorHeight);
 
-                    // exit early if terrain is already one block above the water level
-                    if (currentFloorHeight >= targetWaterY + 1){
-                        break;
-                    }
+                // Scan down just slightly past the valley floor/riverbed to catch
+                // immediate subterranean cave punctures tearing open the bottom of the pool
+                int scanBottomY = Math.min(localWaterY, currentFloorHeight) - 8;
+                scanBottomY = Math.max(scanBottomY, level.getMinBuildHeight() + 16); // Absolute safety floor
 
-                    // Scan down from the maximum possible height to find the actual physical surface in the world right now
-                    int editY = currentFloorHeight;
-                    while (editY > level.getMinBuildHeight()) {
-                        mutablePos.set(blockX, editY, blockZ);
-                        BlockState state = level.getBlockState(mutablePos);
+                // 4. Vertical scan loop within the column's precise hydrology envelope
+                for (int y = scanTopY; y >= scanBottomY; y--) {
+                    currentPos.set(blockX, y, blockZ);
+                    BlockState currentState = level.getBlockState(currentPos);
 
-                        // Consider it the true surface when we hit something that isn't air, open cave spaces, or liquids
-                        if (!state.isAir() && !state.is(Blocks.WATER) && !state.is(Blocks.LAVA) && !state.is(Blocks.CAVE_AIR)) {
-                            break;
+                    if (currentState.is(Blocks.WATER)) {
+
+                        // ensure air below gets gasketed
+                        belowNeighborPos.set(blockX, y - 1, blockZ);
+                        BlockState belowState = level.getBlockState(belowNeighborPos);
+                        if (belowState.isAir() || belowState.is(Blocks.CAVE_AIR)) {
+                            level.setBlock(belowNeighborPos, stoneState, 2);
                         }
-                        editY--;
-                    }
 
-                    // EDGE SMOOTHING LOGIC: If we are in the outer valley floor, blend our target height smoothly down
-                    // to the natural physical terrain surface based on how close the riverMask is to 1.0.
-                    int targetGasketHeight = currentFloorHeight;
-                    if (cell.riverZone == RiverCarverSettings.RiverZone.ValleyFloor) {
-                        // The valley floor typically occupies the upper boundary of the mask (e.g., 0.55 to 1.0).
-                        // We slide our alpha gradient cleanly across this window.
-                        float startFadeMask = 0.55f;
-                        if (cell.riverMask > startFadeMask) {
-                            float alpha = (cell.riverMask - startFadeMask) / (1.0f - startFadeMask);
-                            alpha = Math.max(0.0f, Math.min(1.0f, alpha)); // Strict clamp to [0.0, 1.0]
+                        // Inspect horizontal neighbors for air exposure leaks
+                        for (Direction dir : HORIZONTAL_DIRECTIONS) {
+                            neighborPos.set(
+                                    blockX + dir.getStepX(),
+                                    y,
+                                    blockZ + dir.getStepZ()
+                            );
 
-                            // Linearly interpolate between the full design height and the native surface height
-                            targetGasketHeight = Math.round(currentFloorHeight + (editY - currentFloorHeight) * alpha);
-                        }
-                    }
+                            BlockState neighborState = level.getBlockState(neighborPos);
 
-                    // DYNAMIC FILLER SELECTION: Sample from the bottom block of the original 4-block crust stack
-                    int fillerY = Math.max(level.getMinBuildHeight(), editY - 3);
-                    BlockState columnFiller = level.getBlockState(mutablePos.set(blockX, fillerY, blockZ));
+                            if (neighborState.isAir() || neighborState.is(Blocks.CAVE_AIR)) {
+                                belowNeighborPos.set(neighborPos.getX(), neighborPos.getY() - 1, neighborPos.getZ());
+                                BlockState belowNeighborState = level.getBlockState(belowNeighborPos);
 
-                    if (columnFiller.isAir() || columnFiller.is(Blocks.CAVE_AIR) || columnFiller.is(Blocks.LAVA) || columnFiller.is(Blocks.WATER)) {
-                        columnFiller = defaultStone;
-                    }
-
-                    // If our sloped target height is still higher than the ground, perform a smooth upshift
-                    if (targetGasketHeight > editY && editY > level.getMinBuildHeight()) {
-                        int crustDepth = 4;
-                        BlockState[] crustSnapshot = new BlockState[crustDepth];
-
-                        for (int i = 0; i < crustDepth; i++) {
-                            int yCheck = editY - i;
-                            if (yCheck >= level.getMinBuildHeight()) {
-                                crustSnapshot[i] = level.getBlockState(mutablePos.set(blockX, yCheck, blockZ));
-                            } else {
-                                crustSnapshot[i] = columnFiller;
+                                // If the air gap isn't a natural waterfall plunging into a lower body of water, plug it
+                                if (!belowNeighborState.is(Blocks.WATER)) {
+                                    level.setBlock(neighborPos, stoneState, 2);
+                                }
                             }
-                        }
-
-                        // Place the shifted topsoil blocks at our newly sloped target surface position
-                        for (int i = 0; i < crustDepth; i++) {
-                            level.setBlock(mutablePos.set(blockX, targetGasketHeight - i, blockZ), crustSnapshot[i], 2);
-                        }
-
-                        // Fill the gap created under the sloped surface
-                        for (int y = targetGasketHeight - crustDepth; y > editY - crustDepth; y--) {
-                            if (y >= level.getMinBuildHeight()) {
-                                level.setBlock(mutablePos.set(blockX, y, blockZ), columnFiller, 2);
-                            }
-                        }
-                    }
-
-                    // Calculate our noise-based cavity thickness relative to our new sloped surface
-                    double noiseVal = (Math.sin(blockX * 0.12) * Math.cos(blockZ * 0.12)
-                            + Math.sin(blockX * 0.04)
-                            + Math.cos(blockZ * 0.04)) / 2.0;
-
-                    float normalizedNoise = (float) ((noiseVal + 1.0) / 2.0);
-                    int dynamicThickness = 3 + Math.round(normalizedNoise * 4);
-
-                    // Constrain the bottom scanning limit to our new sloped baseline
-                    int scanBottomY = targetGasketHeight - dynamicThickness;
-
-                    // The cavity scan top must also respect the sloped height to prevent filling air pockets
-                    // that are now supposed to be open sky above the sloped terrain.
-                    int gasketScanTopY = Math.max(targetWaterY, targetGasketHeight);
-
-                    // Cavity fill open air gaps using the sloped bounds
-                    for (int y = gasketScanTopY; y >= scanBottomY; y--) {
-                        mutablePos.set(blockX, y, blockZ);
-                        BlockState currentState = level.getBlockState(mutablePos);
-
-                        if (currentState.isAir() || currentState.is(Blocks.LAVA) || currentState.is(Blocks.CAVE_AIR)) {
-                            level.setBlock(mutablePos, columnFiller, 2);
                         }
                     }
                 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
@@ -28,13 +28,13 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
 
     @Override
     public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> context) {
-        WorldGenLevel level = context.level();
 
-        // 1. Extract the ReTerraForged generator context from the server level state
+        // Extract the ReTerraForged generator context from the server level state
+        WorldGenLevel level = context.level();
         net.minecraft.server.level.ServerLevel serverLevel = level.getLevel();
         net.minecraft.world.level.levelgen.RandomState randomState = serverLevel.getChunkSource().randomState();
         if (!((Object) randomState instanceof raccoonman.reterraforged.world.worldgen.RTFRandomState rtfRandomState)) {
-            return false; // Skip if this chunk isn't being driven by RTF
+            return false;
         }
 
         GeneratorContext generatorContext = rtfRandomState.generatorContext();
@@ -42,7 +42,7 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
             return false;
         }
 
-        // 2. Initialize our localized lookup utilities
+        // Initialize localized lookup utilities
         WorldLookup worldLookup = new WorldLookup(generatorContext);
         Levels levels = worldLookup.getHeightmap().levels();
         BlockPos origin = context.origin();
@@ -51,67 +51,140 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
         int minBlockZ = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getZ()));
 
         Cell cell = new Cell();
+        Cell neighborCell = new Cell();
+
         BlockPos.MutableBlockPos currentPos = new BlockPos.MutableBlockPos();
         BlockPos.MutableBlockPos neighborPos = new BlockPos.MutableBlockPos();
         BlockPos.MutableBlockPos belowNeighborPos = new BlockPos.MutableBlockPos();
+        BlockPos.MutableBlockPos samplePos = new BlockPos.MutableBlockPos();
 
-        BlockState stoneState = Blocks.REDSTONE_BLOCK.defaultBlockState();
+        // Extra mutables allocated for the surface decoration scanner to keep allocations at zero
+        BlockPos.MutableBlockPos testAbovePos = new BlockPos.MutableBlockPos();
+        BlockPos.MutableBlockPos testSidePos = new BlockPos.MutableBlockPos();
 
-        // 3. Process the 16x16 chunk grid
+
+        BlockState fallbackState = Blocks.STONE.defaultBlockState();
+
+        // We process the entire 16x16 chunk grid at once
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
                 int blockX = minBlockX + x;
                 int blockZ = minBlockZ + z;
 
-                // Query the hydrology/terrain profile for this exact column
                 worldLookup.applyCell(cell.reset(), blockX, blockZ, false, false);
 
-                // DYNAMIC BOUNDS CALCULATION
-                // Convert the cell's continuous noise values back into concrete world Y integers
+                // Calculate the region around water sources like rivers lakes and wetlands
                 float oceanHeightOffset = levels.water;
                 float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanHeightOffset;
                 int localWaterY = levels.scale(targetWaterLevel);
                 int currentFloorHeight = levels.scale(cell.height);
 
-                // scanTopY tracks the absolute ceiling of where water or surface assets interact
                 int scanTopY = Math.max(localWaterY, currentFloorHeight);
-
-                // Scan down just slightly past the valley floor/riverbed to catch
-                // immediate subterranean cave punctures tearing open the bottom of the pool
                 int scanBottomY = Math.min(localWaterY, currentFloorHeight) - 8;
-                scanBottomY = Math.max(scanBottomY, level.getMinBuildHeight() + 16); // Absolute safety floor
+                scanBottomY = Math.max(scanBottomY, level.getMinBuildHeight() + 16);
 
-                // 4. Vertical scan loop within the column's precise hydrology envelope
+                // Vertical scan loop within the column's precise hydrology envelope
                 for (int y = scanTopY; y >= scanBottomY; y--) {
                     currentPos.set(blockX, y, blockZ);
                     BlockState currentState = level.getBlockState(currentPos);
 
                     if (currentState.is(Blocks.WATER)) {
 
-                        // ensure air below gets gasketed
+                        if (!currentState.getFluidState().isSource()) {
+                            continue;
+                        }
+
+                        // Dynamic replacement block sampling (Default structural block)
+                        BlockState structuralState = fallbackState;
+                        for (int sampleY = y - 1; sampleY >= level.getMinBuildHeight(); sampleY--) {
+                            samplePos.set(blockX, sampleY, blockZ);
+                            BlockState sampleState = level.getBlockState(samplePos);
+
+                            if (!sampleState.isAir() && !sampleState.is(Blocks.CAVE_AIR) && !sampleState.is(Blocks.WATER)) {
+                                structuralState = sampleState;
+                                break;
+                            }
+                        }
+
+                        // Ensure air directly below the current water block gets gasketed
                         belowNeighborPos.set(blockX, y - 1, blockZ);
                         BlockState belowState = level.getBlockState(belowNeighborPos);
                         if (belowState.isAir() || belowState.is(Blocks.CAVE_AIR)) {
-                            level.setBlock(belowNeighborPos, stoneState, 2);
+                            level.setBlock(belowNeighborPos, structuralState, 2);
                         }
 
-                        // Inspect horizontal neighbors for air exposure leaks
-                        for (Direction dir : HORIZONTAL_DIRECTIONS) {
-                            neighborPos.set(
-                                    blockX + dir.getStepX(),
-                                    y,
-                                    blockZ + dir.getStepZ()
-                            );
+                        // Circular brush setup
+                        int radius = context.random().nextInt(5) + 3; // Radius 3 to 7
+                        int radiusSq = radius * radius;
 
-                            BlockState neighborState = level.getBlockState(neighborPos);
+                        // Scan the 2D bounding box of the circle
+                        for (int dx = -radius; dx <= radius; dx++) {
+                            for (int dz = -radius; dz <= radius; dz++) {
 
-                            if (neighborState.isAir() || neighborState.is(Blocks.CAVE_AIR)) {
-                                belowNeighborPos.set(neighborPos.getX(), neighborPos.getY() - 1, neighborPos.getZ());
-                                BlockState belowNeighborState = level.getBlockState(belowNeighborPos);
+                                if (dx * dx + dz * dz <= radiusSq) {
 
-                                // If the air gap isn't a natural waterfall plunging into a lower body of water, plug it
-                                if (!belowNeighborState.is(Blocks.WATER)) {
-                                    level.setBlock(neighborPos, stoneState, 2);
+                                    int targetX = blockX + dx;
+                                    int targetZ = blockZ + dz;
+
+                                    worldLookup.applyCell(neighborCell.reset(), targetX, targetZ, false, false);
+
+                                    float neighbourTargetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + oceanHeightOffset;
+                                    int neighbourWaterY = levels.scale(neighbourTargetWaterLevel);
+
+                                    if (y > neighbourWaterY) {
+                                        continue;
+                                    }
+
+                                    neighborPos.set(targetX, y, targetZ);
+                                    BlockState neighborState = level.getBlockState(neighborPos);
+
+                                    if (neighborState.isAir() || neighborState.is(Blocks.CAVE_AIR)) {
+                                        belowNeighborPos.set(neighborPos.getX(), neighborPos.getY() - 1, neighborPos.getZ());
+                                        BlockState belowNeighborState = level.getBlockState(belowNeighborPos);
+
+                                        if (belowNeighborState.is(Blocks.WATER)) {
+                                            continue;
+                                        }
+
+                                        // Perform contextual surface matching
+                                        // features are late in the minecraft world creation process.
+                                        // Surface decorators have run and density functions have carved caves
+                                        // if we leave it as abre stone here it stays as stone, so instead we try and draw on the surrounding terrain
+                                        // copying a nearby block finish to pretty up this column.
+                                        BlockState finalPlacementState = structuralState;
+
+                                        testAbovePos.set(targetX, y + 1, targetZ);
+                                        BlockState stateAbove = level.getBlockState(testAbovePos);
+
+                                        if (stateAbove.isAir() || stateAbove.is(Blocks.CAVE_AIR) || stateAbove.is(Blocks.WATER)) {
+
+                                            // Step outward progressively up to 4 blocks away to find valid terrain paint
+                                            searchLoop:
+                                            for (int dist = 1; dist <= 4; dist++) {
+                                                for (Direction dir : HORIZONTAL_DIRECTIONS) {
+                                                    testSidePos.set(
+                                                            targetX + (dir.getStepX() * dist),
+                                                            y,
+                                                            targetZ + (dir.getStepZ() * dist)
+                                                    );
+                                                    BlockState nearbyState = level.getBlockState(testSidePos);
+
+                                                    if (nearbyState.is(Blocks.GRASS_BLOCK)
+                                                            || nearbyState.is(Blocks.SAND)
+                                                            || nearbyState.is(Blocks.GRAVEL)
+                                                            || nearbyState.is(Blocks.MUD)
+                                                            || nearbyState.is(Blocks.PODZOL)
+                                                            || nearbyState.is(Blocks.MYCELIUM)) {
+
+                                                        finalPlacementState = nearbyState;
+                                                        break searchLoop; // Escapes both loops immediately upon match
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        level.setBlock(neighborPos, finalPlacementState, 2);
+                                    }
                                 }
                             }
                         }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
@@ -1,0 +1,169 @@
+package raccoonman.reterraforged.world.worldgen.feature;
+
+import com.mojang.serialization.Codec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
+import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
+import raccoonman.reterraforged.RTFCommon;
+import raccoonman.reterraforged.world.worldgen.GeneratorContext;
+import raccoonman.reterraforged.world.worldgen.cell.Cell;
+import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
+import raccoonman.reterraforged.world.worldgen.cell.heightmap.WorldLookup;
+import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
+import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.River;
+import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSettings;
+
+import java.util.function.Supplier;
+
+public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
+    public static Supplier<WorldLookup> LOOKUP_PROVIDER = () -> null;
+
+    public RiverGasketFeature(Codec<NoneFeatureConfiguration> codec) {
+        super(codec);
+    }
+
+    @Override
+    public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> context) {
+
+        // Get access to the relevant data
+        net.minecraft.server.level.ServerLevel serverLevel = context.level().getLevel();
+        net.minecraft.world.level.levelgen.RandomState randomState = serverLevel.getChunkSource().randomState();
+        if (!((Object) randomState instanceof raccoonman.reterraforged.world.worldgen.RTFRandomState rtfRandomState)) {
+            return false; // Safely skip if this isn't an RTF-managed world state
+        }
+
+        GeneratorContext generatorContext = rtfRandomState.generatorContext();
+        if (generatorContext == null) {
+            return false;
+        }
+
+        // Instantiated a localized WorldLookup using the context
+        WorldLookup worldLookup = new WorldLookup(generatorContext);
+        WorldGenLevel level = context.level();
+        BlockPos origin = context.origin();
+        Levels levels = worldLookup.getHeightmap().levels();
+
+        int minBlockX = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getX()));
+        int minBlockZ = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getZ()));
+
+        Cell cell = new Cell();
+        BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
+        BlockState defaultStone = Blocks.STONE.defaultBlockState();
+
+        for (int x = 0; x < 16; x++) {
+            for (int z = 0; z < 16; z++) {
+                int blockX = minBlockX + x;
+                int blockZ = minBlockZ + z;
+
+                worldLookup.applyCell(cell.reset(), blockX, blockZ, false, false);
+
+                boolean inFillRegion = cell.riverZone != RiverCarverSettings.RiverZone.None;
+
+                if (inFillRegion) {
+                    int targetWaterY = levels.scale(cell.riverWaterLevel);
+                    int currentFloorHeight = levels.scale(cell.height);
+
+                    // exit early if terrain is already one block above the water level
+                    if (currentFloorHeight >= targetWaterY + 1){
+                        break;
+                    }
+
+                    // Scan down from the maximum possible height to find the actual physical surface in the world right now
+                    int editY = currentFloorHeight;
+                    while (editY > level.getMinBuildHeight()) {
+                        mutablePos.set(blockX, editY, blockZ);
+                        BlockState state = level.getBlockState(mutablePos);
+
+                        // Consider it the true surface when we hit something that isn't air, open cave spaces, or liquids
+                        if (!state.isAir() && !state.is(Blocks.WATER) && !state.is(Blocks.LAVA) && !state.is(Blocks.CAVE_AIR)) {
+                            break;
+                        }
+                        editY--;
+                    }
+
+                    // EDGE SMOOTHING LOGIC: If we are in the outer valley floor, blend our target height smoothly down
+                    // to the natural physical terrain surface based on how close the riverMask is to 1.0.
+                    int targetGasketHeight = currentFloorHeight;
+                    if (cell.riverZone == RiverCarverSettings.RiverZone.ValleyFloor) {
+                        // The valley floor typically occupies the upper boundary of the mask (e.g., 0.55 to 1.0).
+                        // We slide our alpha gradient cleanly across this window.
+                        float startFadeMask = 0.55f;
+                        if (cell.riverMask > startFadeMask) {
+                            float alpha = (cell.riverMask - startFadeMask) / (1.0f - startFadeMask);
+                            alpha = Math.max(0.0f, Math.min(1.0f, alpha)); // Strict clamp to [0.0, 1.0]
+
+                            // Linearly interpolate between the full design height and the native surface height
+                            targetGasketHeight = Math.round(currentFloorHeight + (editY - currentFloorHeight) * alpha);
+                        }
+                    }
+
+                    // DYNAMIC FILLER SELECTION: Sample from the bottom block of the original 4-block crust stack
+                    int fillerY = Math.max(level.getMinBuildHeight(), editY - 3);
+                    BlockState columnFiller = level.getBlockState(mutablePos.set(blockX, fillerY, blockZ));
+
+                    if (columnFiller.isAir() || columnFiller.is(Blocks.CAVE_AIR) || columnFiller.is(Blocks.LAVA) || columnFiller.is(Blocks.WATER)) {
+                        columnFiller = defaultStone;
+                    }
+
+                    // If our sloped target height is still higher than the ground, perform a smooth upshift
+                    if (targetGasketHeight > editY && editY > level.getMinBuildHeight()) {
+                        int crustDepth = 4;
+                        BlockState[] crustSnapshot = new BlockState[crustDepth];
+
+                        for (int i = 0; i < crustDepth; i++) {
+                            int yCheck = editY - i;
+                            if (yCheck >= level.getMinBuildHeight()) {
+                                crustSnapshot[i] = level.getBlockState(mutablePos.set(blockX, yCheck, blockZ));
+                            } else {
+                                crustSnapshot[i] = columnFiller;
+                            }
+                        }
+
+                        // Place the shifted topsoil blocks at our newly sloped target surface position
+                        for (int i = 0; i < crustDepth; i++) {
+                            level.setBlock(mutablePos.set(blockX, targetGasketHeight - i, blockZ), crustSnapshot[i], 2);
+                        }
+
+                        // Fill the gap created under the sloped surface
+                        for (int y = targetGasketHeight - crustDepth; y > editY - crustDepth; y--) {
+                            if (y >= level.getMinBuildHeight()) {
+                                level.setBlock(mutablePos.set(blockX, y, blockZ), columnFiller, 2);
+                            }
+                        }
+                    }
+
+                    // Calculate our noise-based cavity thickness relative to our new sloped surface
+                    double noiseVal = (Math.sin(blockX * 0.12) * Math.cos(blockZ * 0.12)
+                            + Math.sin(blockX * 0.04)
+                            + Math.cos(blockZ * 0.04)) / 2.0;
+
+                    float normalizedNoise = (float) ((noiseVal + 1.0) / 2.0);
+                    int dynamicThickness = 3 + Math.round(normalizedNoise * 4);
+
+                    // Constrain the bottom scanning limit to our new sloped baseline
+                    int scanBottomY = targetGasketHeight - dynamicThickness;
+
+                    // The cavity scan top must also respect the sloped height to prevent filling air pockets
+                    // that are now supposed to be open sky above the sloped terrain.
+                    int gasketScanTopY = Math.max(targetWaterY, targetGasketHeight);
+
+                    // Cavity fill open air gaps using the sloped bounds
+                    for (int y = gasketScanTopY; y >= scanBottomY; y--) {
+                        mutablePos.set(blockX, y, blockZ);
+                        BlockState currentState = level.getBlockState(mutablePos);
+
+                        if (currentState.isAir() || currentState.is(Blocks.LAVA) || currentState.is(Blocks.CAVE_AIR)) {
+                            level.setBlock(mutablePos, columnFiller, 2);
+                        }
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
Implements a feature that cleans up after density functions and carvers blindly butcher water surrounds placed at ocean+ y levels.

Essentially goes through and fills carvers like this but more sophisticatedly in the final iteration:
<img width="2573" height="1370" alt="image" src="https://github.com/user-attachments/assets/e23a1273-e6b9-4e61-8c05-c34e57d5893f" />

I eventually opted for only a smaller 3-7 block fill radius as it's more discrete in the surrounding terrain and leads to some more interesting generation results.
