### PR TITLE
Fix legacy preset loading

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Presets.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Presets.java
@@ -21,7 +21,7 @@ public class Presets {
 		return new Preset(
 			new WorldSettings(
 				new Continent(ContinentType.UPLIFT, DistanceFunction.EUCLIDEAN, 3000, 0.7F, 0.25F, 0.25F, 5, 0.26F, 4.33F),
-				new ControlPoints(0.0F, 0.0F, 0.1F, 0.25F, 0.327F, 0.448F, 0.502F),
+				new ControlPoints(0.0F, 0.074F, 0.1F, 0.25F, 0.327F, 0.448F, 0.502F),
 				new Properties(SpawnType.CONTINENT_CENTER, 384, 64, 63, -54,0,0)
 			), 
 			new SurfaceSettings(new SurfaceSettings.Erosion(30, 256, 40, 95, 0.65F, 0.475F, 0.4F)),
@@ -65,7 +65,7 @@ public class Presets {
 		return new Preset(
 			new WorldSettings(
 				new Continent(ContinentType.MULTI_IMPROVED, DistanceFunction.EUCLIDEAN, 3000, 0.7F, 0.25F, 0.25F, 5, 0.26F, 4.33F),
-				new ControlPoints(0.0F, 0.0F, 0.1F, 0.25F, 0.327F, 0.448F, 0.502F),
+				new ControlPoints(0.0F, 0.074F, 0.1F, 0.25F, 0.327F, 0.448F, 0.502F),
 				new Properties(SpawnType.CONTINENT_CENTER, 320, 64, 63, -54, 0,0)
 			), 
 			new SurfaceSettings(new SurfaceSettings.Erosion(30, 140, 40, 95, 0.65F, 0.475F, 0.4F)),
@@ -109,7 +109,7 @@ public class Presets {
 		return new Preset(
 			new WorldSettings(
 				new Continent(ContinentType.MULTI, DistanceFunction.EUCLIDEAN, 2000, 0.763F, 0.25F, 0.25F, 5, 0.26F, 4.33F),
-				new ControlPoints(0.0F, 0.0F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F),
+				new ControlPoints(0.0F, 0.074F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F),
 				new Properties(SpawnType.WORLD_ORIGIN, 320, 64, 63, -54, 0, 0)
 			), 
 			new SurfaceSettings(new SurfaceSettings.Erosion(30, 140, 40, 95, 0.65F, 0.475F, 0.4F)),
@@ -154,7 +154,7 @@ public class Presets {
 		return new Preset(
 			new WorldSettings(
 				new Continent(ContinentType.MULTI, DistanceFunction.EUCLIDEAN, 3000, 0.8F, 0.25F, 0.25F, 5, 0.26F, 4.33F),
-				new ControlPoints(0.0F, 0.0F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F),
+				new ControlPoints(0.0F, 0.074F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F),
 				new Properties(SpawnType.CONTINENT_CENTER, 320, 64, 63, -54, 0, 0)
 			), 
 			new SurfaceSettings(new SurfaceSettings.Erosion(30, 140, 40, 95, 0.65F, 0.475F, 0.4F)),
@@ -198,7 +198,7 @@ public class Presets {
 		return new Preset(
 			new WorldSettings(
 				new Continent(ContinentType.MULTI, DistanceFunction.EUCLIDEAN, 2000, 0.765F, 0.25F, 0.25F, 5, 0.26F, 4.33F),
-				new ControlPoints(-1.0F, -1.0F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F), 
+				new ControlPoints(0.0F, 0.074F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F),
 				new Properties(SpawnType.CONTINENT_CENTER, 320, 64, 63, -54, 0,0)
 			),
 			new SurfaceSettings(new SurfaceSettings.Erosion(30, 140, 40, 95, 0.65F, 0.475F, 0.4F)),
@@ -242,7 +242,7 @@ public class Presets {
 		return new Preset(
 			new WorldSettings(
 				new Continent(ContinentType.MULTI, DistanceFunction.EUCLIDEAN, 4029, 0.8F, 0.25F, 0.25F, 5, 0.26F, 4.33F),
-				new ControlPoints(-1.0F, -1.0F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F), 
+				new ControlPoints(0.0F, 0.074F, 0.1F, 0.25F, 0.326F, 0.448F, 0.5F),
 				new Properties(SpawnType.CONTINENT_CENTER, 320, 64, 63, -54, 0,0)
 			), 
 			new SurfaceSettings(new SurfaceSettings.Erosion(30, 140, 40, 95, 0.65F, 0.475F, 0.4F)),

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/WorldSettings.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/WorldSettings.java
@@ -5,6 +5,8 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 
 import raccoonman.reterraforged.world.worldgen.noise.function.DistanceFunction;
 
+import java.util.Optional;
+
 public class WorldSettings {
 	public static final Codec<WorldSettings> CODEC = RecordCodecBuilder.create(instance -> instance.group(
 		Continent.CODEC.fieldOf("continent").forGetter((o) -> o.continent),
@@ -68,8 +70,8 @@ public class WorldSettings {
     
     public static class ControlPoints {
     	public static final Codec<ControlPoints> CODEC = RecordCodecBuilder.create(instance -> instance.group(
-        	Codec.FLOAT.fieldOf("islandInland").forGetter((o) -> o.islandInland),
-        	Codec.FLOAT.fieldOf("islandCoast").forGetter((o) -> o.islandCoast),
+            Codec.FLOAT.optionalFieldOf("islandInland").xmap(opt -> opt.orElse(0.0F), Optional::of).forGetter((o) -> o.islandInland),
+            Codec.FLOAT.optionalFieldOf("islandCoast").xmap(opt -> opt.orElse(0.05F), Optional::of).forGetter((o) -> o.islandCoast),
     		Codec.FLOAT.fieldOf("deepOcean").forGetter((o) -> o.deepOcean),
     		Codec.FLOAT.fieldOf("shallowOcean").forGetter((o) -> o.shallowOcean),
     		Codec.FLOAT.fieldOf("beach").forGetter((o) -> o.beach),

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/WorldSettings.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/WorldSettings.java
@@ -71,7 +71,7 @@ public class WorldSettings {
     public static class ControlPoints {
     	public static final Codec<ControlPoints> CODEC = RecordCodecBuilder.create(instance -> instance.group(
             Codec.FLOAT.optionalFieldOf("islandInland").xmap(opt -> opt.orElse(0.0F), Optional::of).forGetter((o) -> o.islandInland),
-            Codec.FLOAT.optionalFieldOf("islandCoast").xmap(opt -> opt.orElse(0.05F), Optional::of).forGetter((o) -> o.islandCoast),
+            Codec.FLOAT.optionalFieldOf("islandCoast").xmap(opt -> opt.orElse(0.074F), Optional::of).forGetter((o) -> o.islandCoast),
     		Codec.FLOAT.fieldOf("deepOcean").forGetter((o) -> o.deepOcean),
     		Codec.FLOAT.fieldOf("shallowOcean").forGetter((o) -> o.shallowOcean),
     		Codec.FLOAT.fieldOf("beach").forGetter((o) -> o.beach),


### PR DESCRIPTION
Makes newly added control points optionals with defaults to ensure legacy presets can continue to be loaded.

It's unclear to me why every setting isn't handled similarly (probably should be).