### PR TITLE
optimization: Fix sculk being ridiculously slow

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinSculkPatchFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinSculkPatchFeature.java
@@ -1,0 +1,169 @@
+package raccoonman.reterraforged.mixin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.MultifaceBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.feature.SculkPatchFeature;
+import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
+import net.minecraft.world.level.levelgen.feature.configurations.SculkPatchConfiguration;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import raccoonman.reterraforged.world.worldgen.noise.function.Interpolation;
+import raccoonman.reterraforged.world.worldgen.noise.module.Simplex;
+
+@Mixin(SculkPatchFeature.class)
+public class MixinSculkPatchFeature {
+
+    @Unique
+    private static final Simplex RTF_SCULK_NOISE = new Simplex(
+            0.04F,                 // FIX: Lower frequency (0.08 -> 0.04) makes patches 2x larger
+            3,
+            0.5F,
+            0.45F,
+            Interpolation.CURVE3
+    );
+
+    @Unique private static final int CONFIG_RADIUS = 12;
+    @Unique private static final float CONFIG_THRESHOLD = 0.42F;
+    @Unique private static final float VEIN_WINDOW = 0.05F;
+
+    // FIX: Set vertical coherence resolution. Blending every 6 blocks eliminates flat sheets.
+    @Unique private static final int VERTICAL_SCALE_STEPS = 6;
+
+    // FIX: Restrict face placement to 25% chance to reduce vein clusters by 4x
+    @Unique private static final float VEIN_CHANCE_PER_FACE = 0.25F;
+
+    @Inject(method = "place", at = @At("HEAD"), cancellable = true)
+    private void rtf$replaceSculkGeneration(FeaturePlaceContext<SculkPatchConfiguration> context, CallbackInfoReturnable<Boolean> cir) {
+        WorldGenLevel level = context.level();
+        BlockPos origin = context.origin();
+        RandomSource random = level.getRandom();
+
+        long longSeed = level.getSeed();
+        int baseSeed = (int) (longSeed ^ (longSeed >>> 32));
+
+        float radiusSq = CONFIG_RADIUS * CONFIG_RADIUS;
+        boolean placedAnything = false;
+
+        BlockPos.MutableBlockPos mutablePos = new BlockPos.MutableBlockPos();
+
+        for (int x = -CONFIG_RADIUS; x <= CONFIG_RADIUS; x++) {
+            for (int y = -CONFIG_RADIUS; y <= CONFIG_RADIUS; y++) {
+                for (int z = -CONFIG_RADIUS; z <= CONFIG_RADIUS; z++) {
+                    float distSq = x * x + y * y + z * z;
+                    if (distSq > radiusSq) continue;
+
+                    int absoluteX = origin.getX() + x;
+                    int absoluteY = origin.getY() + y;
+                    int absoluteZ = origin.getZ() + z;
+                    mutablePos.set(absoluteX, absoluteY, absoluteZ);
+
+                    BlockState state = level.getBlockState(mutablePos);
+
+                    if (state.is(BlockTags.SCULK_REPLACEABLE)) {
+                        if (rtf$isAdjacentToAir(level, mutablePos)) {
+
+                            // FIX: Pseudo-3D Noise Sampling via Vertical Layer Lerping
+                            // Handles negative Y coordinates cleanly using floorDiv
+                            int yFloor = Math.floorDiv(absoluteY, VERTICAL_SCALE_STEPS);
+                            float yAlpha = (float) (absoluteY - (yFloor * VERTICAL_SCALE_STEPS)) / (float) VERTICAL_SCALE_STEPS;
+
+                            // Smoothstep alpha to prevent angular transitions
+                            float smoothedAlpha = yAlpha * yAlpha * (3.0F - 2.0F * yAlpha);
+
+                            // Sample upper and lower 2D boundaries
+                            float sampleLower = RTF_SCULK_NOISE.compute(absoluteX, absoluteZ, baseSeed + yFloor);
+                            float sampleUpper = RTF_SCULK_NOISE.compute(absoluteX, absoluteZ, baseSeed + yFloor + 1);
+
+                            // Blend them together linearly over 3D space
+                            float noiseVal = Mth.lerp(smoothedAlpha, sampleLower, sampleUpper);
+
+                            float falloff = 1.0F - (distSq / radiusSq);
+                            float combinedScore = noiseVal - (1.0F - falloff) * 0.25F;
+
+                            if (combinedScore > CONFIG_THRESHOLD) {
+                                level.setBlock(mutablePos, Blocks.SCULK.defaultBlockState(), 2);
+                                placedAnything = true;
+
+                                if (combinedScore > (CONFIG_THRESHOLD + 0.15F) && random.nextFloat() < 0.08F) {
+                                    rtf$placeDecorations(level, mutablePos, random);
+                                }
+                            } else if (combinedScore > (CONFIG_THRESHOLD - VEIN_WINDOW)) {
+                                // Pass random down to execute the 4x reduction roll
+                                rtf$tryPlaceVeinOnExposedFaces(level, mutablePos, random);
+                                placedAnything = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        cir.setReturnValue(placedAnything);
+    }
+
+    @Unique
+    private static boolean rtf$isAdjacentToAir(WorldGenLevel level, BlockPos pos) {
+        for (Direction dir : Direction.values()) {
+            if (level.getBlockState(pos.relative(dir)).isAir()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Unique
+    private static void rtf$tryPlaceVeinOnExposedFaces(WorldGenLevel level, BlockPos solidPos, RandomSource random) {
+        for (Direction dir : Direction.values()) {
+            // FIX: Probability filter to thin out vein clusters cleanly
+            if (random.nextFloat() > VEIN_CHANCE_PER_FACE) continue;
+
+            BlockPos airPos = solidPos.relative(dir);
+            BlockState airState = level.getBlockState(airPos);
+
+            boolean isAir = airState.isAir();
+            boolean isExistingVein = airState.is(Blocks.SCULK_VEIN);
+
+            if (isAir || isExistingVein) {
+                Direction faceToSet = dir.getOpposite();
+
+                BlockState veinState = isExistingVein ? airState : Blocks.SCULK_VEIN.defaultBlockState();
+                veinState = veinState.setValue(MultifaceBlock.getFaceProperty(faceToSet), true);
+
+                level.setBlock(airPos, veinState, 2);
+            }
+        }
+    }
+
+    @Unique
+    private static void rtf$placeDecorations(WorldGenLevel level, BlockPos pos, RandomSource random) {
+        BlockPos above = pos.above();
+        if (level.getBlockState(above).isAir()) {
+            float roll = random.nextFloat();
+            BlockState decor;
+
+            if (roll < 0.50F) {
+                // 50% chance for a Sensor
+                decor = Blocks.SCULK_SENSOR.defaultBlockState();
+            } else if (roll < 0.88F) {
+                // 38% chance for a Catalyst
+                decor = Blocks.SCULK_CATALYST.defaultBlockState();
+            } else {
+                // 12% chance for an active Shrieker that can summon the Warden
+                decor = Blocks.SCULK_SHRIEKER.defaultBlockState()
+                        .setValue(net.minecraft.world.level.block.SculkShriekerBlock.CAN_SUMMON, true);
+            }
+
+            level.setBlock(above, decor, 2);
+        }
+    }
+}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinSculkPatchFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinSculkPatchFeature.java
@@ -25,7 +25,7 @@ public class MixinSculkPatchFeature {
 
     @Unique
     private static final Simplex RTF_SCULK_NOISE = new Simplex(
-            0.04F,                 // FIX: Lower frequency (0.08 -> 0.04) makes patches 2x larger
+            0.04F,
             3,
             0.5F,
             0.45F,
@@ -35,11 +35,7 @@ public class MixinSculkPatchFeature {
     @Unique private static final int CONFIG_RADIUS = 12;
     @Unique private static final float CONFIG_THRESHOLD = 0.42F;
     @Unique private static final float VEIN_WINDOW = 0.05F;
-
-    // FIX: Set vertical coherence resolution. Blending every 6 blocks eliminates flat sheets.
     @Unique private static final int VERTICAL_SCALE_STEPS = 6;
-
-    // FIX: Restrict face placement to 25% chance to reduce vein clusters by 4x
     @Unique private static final float VEIN_CHANCE_PER_FACE = 0.25F;
 
     @Inject(method = "place", at = @At("HEAD"), cancellable = true)
@@ -72,7 +68,7 @@ public class MixinSculkPatchFeature {
                     if (state.is(BlockTags.SCULK_REPLACEABLE)) {
                         if (rtf$isAdjacentToAir(level, mutablePos)) {
 
-                            // FIX: Pseudo-3D Noise Sampling via Vertical Layer Lerping
+                            // Pseudo-3D Noise Sampling via Vertical Layer Lerping
                             // Handles negative Y coordinates cleanly using floorDiv
                             int yFloor = Math.floorDiv(absoluteY, VERTICAL_SCALE_STEPS);
                             float yAlpha = (float) (absoluteY - (yFloor * VERTICAL_SCALE_STEPS)) / (float) VERTICAL_SCALE_STEPS;
@@ -98,7 +94,6 @@ public class MixinSculkPatchFeature {
                                     rtf$placeDecorations(level, mutablePos, random);
                                 }
                             } else if (combinedScore > (CONFIG_THRESHOLD - VEIN_WINDOW)) {
-                                // Pass random down to execute the 4x reduction roll
                                 rtf$tryPlaceVeinOnExposedFaces(level, mutablePos, random);
                                 placedAnything = true;
                             }

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -22,6 +22,7 @@
 		"MixinLevelChunk",
 		"MixinImposterProtoChunk",
 		"MixinNoiseBasedChunkGenerator",
+		"MixinSculkPatchFeature",
 		"BeardifierAccessor",
 		"LevelChunkSectionAccessor",
 		"terrablender.MixinParameterList",


### PR DESCRIPTION
Fixes #69 

Vanilla sculk generation is ridiculously, riduclously slow. It uses a cellular automata style spreading approach rather than a pure maths function builder. Because it has no strict geometric boundaries, the spread frequently crosses over the decoration margin into ungenerated chunks, stalling the main server thread. 

This is visible in profiling showing as significant fractions of the world generation thread timings.
https://spark.lucko.me/3eaNEXdZKV
<img width="1277" height="369" alt="image" src="https://github.com/user-attachments/assets/7112ecb9-f9a8-41a1-b3a8-e36ed6ad89b8" />

***

This PR replaces the entire vanilla sculk generation pathway with an optimized alternative that uses an O(1) noise based generation approach. 

It is undesirable to have to manually manage any major feature like this since ideally we'd leave this delegated to the vanilla methods. Forcing a complete override of the approach admittedly introduces a risk of incompatibility and moves us further from vanilla behavior (both undesirable) but the *significant* performance gains that almost every end user would benefit from outweighs those concerns in this particular case. 

It's worth noting I'd be comfortable considering targeted compatibility patches down the line if required for the relatively small number of sculk related mods that would potentially doing mixin modifications to the world generation method.

***

# Vanilla reference:

<table>
  <tr>
    <td><img width="2582" height="1372" alt="image" src="https://github.com/user-attachments/assets/ee9b4460-2001-4bdb-99a2-d78c96191fb3" /></td>
    <td><img width="2566" height="1375" alt="image" src="https://github.com/user-attachments/assets/3f33e97e-db35-4e4f-aed8-c873e495a96b" /></td>
  </tr>
  <tr>
    <td><img width="2556" height="1384" alt="image" src="https://github.com/user-attachments/assets/c175b81e-7b66-4a77-991a-dde027da3d76" /></td>
    <td><img width="2573" height="1380" alt="image" src="https://github.com/user-attachments/assets/deda892c-d7de-406c-adbb-fc40a02b374a" /></td>
  </tr>
</table>

# Fast replacement

<table>
  <tr>
    <td>
<img width="2570" height="1374" alt="image" src="https://github.com/user-attachments/assets/2a2e4f31-d282-45a6-b286-092f32c12a88" /></td>
    <td><img width="2570" height="1381" alt="image" src="https://github.com/user-attachments/assets/2f191ee5-429f-430a-b732-e06c0ef7f9fd" /></td>
  </tr>
  <tr>
    <td><img width="2573" height="1381" alt="image" src="https://github.com/user-attachments/assets/00f4096c-6ab7-46cc-b5a4-5f707a5e6e81" /></td>
    <td>
<img width="2569" height="1378" alt="image" src="https://github.com/user-attachments/assets/722481cb-61de-40c1-a72a-777de316479d" /></td>
  </tr>
  <tr>
    <td><img width="2580" height="1389" alt="image" src="https://github.com/user-attachments/assets/cc83d839-683f-4626-9090-af6626bd9f8e" /></td>
    <td><img width="2578" height="1385" alt="image" src="https://github.com/user-attachments/assets/434edecb-b0bd-423d-96df-a16cdc8d1bb5" /></td>
  </tr>
</table>

***

AI thoughts on the relative optimization gains

<img width="1101" height="1426" alt="image" src="https://github.com/user-attachments/assets/814acbf2-86eb-461a-a80f-3abaa2d2e9c5" />

<img width="1090" height="648" alt="image" src="https://github.com/user-attachments/assets/ca6b9cc4-6759-4772-a490-6d3946c430ad" />

***

Multiple subsequent benchmark runs shows sculk cost now as negligible.

https://spark.lucko.me/RdRHGtIIBG
https://spark.lucko.me/3tmLpxQNkH
https://spark.lucko.me/Q7SojKMKYI

New frontrunners are gaskets (my own fault) and chunk pyramid which both can use further investigation now I guess.