### PR TITLE
Improve river valley style

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -148,38 +148,48 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float zone3Radius = zone2Radius + zone3Width;
         float zone4Radius = zone3Radius + (unshrunkZone3BaseWidth * (4 + discrepancyScale));
 
+        // early exit guard if we're a cell outside the river influence
         if (currentLinearDist >= zone4Radius) return;
 
+        // calculate the final cell heights
         float finalHeight = cell.height;
-        RiverCarverSettings.RiverZone prospectiveZone = cell.riverZone;
-
         if (currentLinearDist < zone1Radius) {
             finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, oceanHeightOffset, sqScaleFactor, targetWaterLevel, lakeMultiplier);
-            prospectiveZone = RiverCarverSettings.RiverZone.Riverbed;
         } else if (currentLinearDist < zone2Radius) {
-            // Banks scale smoothly into our unified actualValleyFloorHeight instead of the flat targetValleyFloor
             finalHeight = carveZone2BankStep(currentLinearDist, zone1Radius, zone2Radius, targetWaterLevel, actualValleyFloorHeight, terraceMask, drainageMask);
-            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed) {
-                prospectiveZone = RiverCarverSettings.RiverZone.Banks;
-            }
         } else if (currentLinearDist < zone3Radius) {
             finalHeight = actualValleyFloorHeight;
-            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed && prospectiveZone != RiverCarverSettings.RiverZone.Banks) {
-                prospectiveZone = RiverCarverSettings.RiverZone.ValleyFloor;
-            }
         } else {
-            // Fadeout safely steps out directly from our bumpy actualValleyFloorHeight
             finalHeight = carveZone4Fadeout(cell.height, currentLinearDist, zone3Radius, zone4Radius, actualValleyFloorHeight, terraceMask, drainageMask);
-            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed && prospectiveZone != RiverCarverSettings.RiverZone.Banks && prospectiveZone != RiverCarverSettings.RiverZone.ValleyFloor) {
-                prospectiveZone = RiverCarverSettings.RiverZone.ValleyFadeout;
-            }
         }
 
         // Only commit data changes to the cell if our carving operations actually cut down the world
         if (finalHeight < cell.height) {
             cell.height = finalHeight;
-            cell.riverZone = prospectiveZone;
+            cell.riverZone = getRiverZoneTag(cell, currentLinearDist, zone1Radius, zone2Radius, zone3Radius);
         }
+    }
+
+    private RiverCarverSettings.RiverZone getRiverZoneTag(Cell cell, float currentLinearDist, float zone1Radius, float zone2Radius, float zone3Radius){
+        RiverCarverSettings.RiverZone prospectiveZone = cell.riverZone;
+
+        if (currentLinearDist < zone1Radius) {
+            prospectiveZone = RiverCarverSettings.RiverZone.Riverbed;
+        } else if (currentLinearDist < zone2Radius) {
+            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed) {
+                prospectiveZone = RiverCarverSettings.RiverZone.Banks;
+            }
+        } else if (currentLinearDist < zone3Radius) {
+            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed && prospectiveZone != RiverCarverSettings.RiverZone.Banks) {
+                prospectiveZone = RiverCarverSettings.RiverZone.ValleyFloor;
+            }
+        } else {
+            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed && prospectiveZone != RiverCarverSettings.RiverZone.Banks && prospectiveZone != RiverCarverSettings.RiverZone.ValleyFloor) {
+                prospectiveZone = RiverCarverSettings.RiverZone.ValleyFadeout;
+            }
+        }
+
+        return prospectiveZone;
     }
 
     private float getLakeMultiplier(Cell cell, float currT, float currX, float currZ, float flatnessFactor) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -109,68 +109,37 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         // always run mask logic to ensure clean falloffs
         updateValleyMask(prevX, prevZ, prevT, currT, distSqToCurr, sqScaleFactor, cell);
 
-        // --- DRAINAGE CALCULATION ---
+        // drainage falloffs
         float gullyRaw = this.gullyNoise.compute(currX, currZ, 9876);
         float gullyShape = 1.0F - Math.abs(gullyRaw);
         gullyShape *= gullyShape;
-
         float rivuletRaw = this.rivuletNoise.compute(currX, currZ, 5432);
         float rivuletShape = 1.0F - Math.abs(rivuletRaw);
         rivuletShape = rivuletShape * rivuletShape * rivuletShape;
-
         float drainageMask = (gullyShape * 0.7F) + (rivuletShape * 0.3F);
 
+        // width falloffs
         float dynamicWidthMult = 1.0F + (widthVar * 0.35F);
         float dynamicDepthMult = 1.0F + (depthVar * 0.25F);
         float sideBias = 1.0F + (asymmetry * 0.4F);
         float valleyPinchMultiplier = NoiseUtil.clamp(1.0F + valleyPinchVar, 0.05F, 1.95F);
 
-        // --- TARGET ELEVATIONS ---
+        // target elevations
         float oceanHeightOffset = levels.water;
         float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanHeightOffset;
-
         float baseBedDepthOffset = oceanHeightOffset - config.bedHeight;
         float bedDepthOffset = baseBedDepthOffset * dynamicDepthMult;
-
         float bankHeightOffset = (config.maxBankHeight - config.minBankHeight);
         float targetValleyFloor = targetWaterLevel + bankHeightOffset;
         float discrepancyScale = 1.0F + (levels.scale(cell.height - targetWaterLevel)) / 100.0F;
-
-        // --- PRE-CALCULATE UNIFIED VALLEY FLOOR HEIGHT (Fix #2) ---
         float valleyFloorBumpiness = ((terraceMask * 0.4F) - (drainageMask * 0.6F)) * this.levels.unit;
         float actualValleyFloorHeight = targetValleyFloor + valleyFloorBumpiness;
 
-        // --- RADII BOUNDARIES ---
+        // Zone calculations
         float biasedScale = sqScaleFactor * dynamicWidthMult * sideBias;
         float zone1Radius = (float) Math.sqrt(this.getScaledSize(currT, this.bedWidth) * biasedScale);
-
-        // --- ORGANIC LAKE SHORELINE WARPING ---
-        float plateauInput = isUpliftContinent ? cell.waterTable : currT;
-        int plateauIndex = ContinentalHydrology.getStepId(plateauInput);
-        float widenMultiplier = 1.0F;
-
-        if (this.shouldWidenOnPlateau(plateauIndex, lakeConfig, currT)) {
-            float lakeScaleMin = lakeConfig.sizeMin / 100.0F;
-            float lakeScaleMax = lakeConfig.sizeMax / 100.0F;
-
-            float baseStepScale = this.getLakeScaleForPlateau(plateauIndex, lakeScaleMin, lakeScaleMax);
-            float shorelineWarp = this.lakeWarpNoise.compute(currX, currZ, 7439);
-            float organicWarpFactor = baseStepScale * (1.0F + shorelineWarp * 0.45F);
-
-            float distanceMask = 1.0F;
-            float fadeWindow = 0.04F;
-
-            if (currT < lakeConfig.distanceMin) {
-                distanceMask = NoiseUtil.clamp((currT - (lakeConfig.distanceMin - fadeWindow)) / fadeWindow, 0.0F, 1.0F);
-            } else if (currT > lakeConfig.distanceMax) {
-                distanceMask = NoiseUtil.clamp(((lakeConfig.distanceMax + fadeWindow) - currT) / fadeWindow, 0.0F, 1.0F);
-            }
-
-            distanceMask = distanceMask * distanceMask * (3.0F - 2.0F * distanceMask);
-            widenMultiplier = 1.0F + (flatnessFactor * organicWarpFactor * distanceMask);
-            zone1Radius *= widenMultiplier;
-        }
-
+        float lakeMultiplier = getLakeMultiplier(cell, currT, currX, currZ, flatnessFactor);
+        zone1Radius *= lakeMultiplier;
         float zone2Width = (config.maxBankHeight - config.minBankHeight) / this.levels.unit * biasedScale;
         float zone2Radius = zone1Radius + zone2Width;
         float unshrunkZone3BaseWidth = config.bankWidth * dynamicWidthMult * valleyPinchMultiplier;
@@ -185,7 +154,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         RiverCarverSettings.RiverZone prospectiveZone = cell.riverZone;
 
         if (currentLinearDist < zone1Radius) {
-            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, oceanHeightOffset, sqScaleFactor, targetWaterLevel, widenMultiplier);
+            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, oceanHeightOffset, sqScaleFactor, targetWaterLevel, lakeMultiplier);
             prospectiveZone = RiverCarverSettings.RiverZone.Riverbed;
         } else if (currentLinearDist < zone2Radius) {
             // Banks scale smoothly into our unified actualValleyFloorHeight instead of the flat targetValleyFloor
@@ -211,6 +180,33 @@ public class UpliftRiverCarver implements RTFRiverCarver {
             cell.height = finalHeight;
             cell.riverZone = prospectiveZone;
         }
+    }
+
+    private float getLakeMultiplier(Cell cell, float currT, float currX, float currZ, float flatnessFactor) {
+        float plateauInput = isUpliftContinent ? cell.waterTable : currT;
+        float widenMultiplier = 1.0F;
+        int plateauIndex = ContinentalHydrology.getStepId(plateauInput);
+        if (this.shouldWidenOnPlateau(plateauIndex, lakeConfig, currT)) {
+            float lakeScaleMin = lakeConfig.sizeMin / 100.0F;
+            float lakeScaleMax = lakeConfig.sizeMax / 100.0F;
+
+            float baseStepScale = this.getLakeScaleForPlateau(plateauIndex, lakeScaleMin, lakeScaleMax);
+            float shorelineWarp = this.lakeWarpNoise.compute(currX, currZ, 7439);
+            float organicWarpFactor = baseStepScale * (1.0F + shorelineWarp * 0.45F);
+
+            float distanceMask = 1.0F;
+            float fadeWindow = 0.04F;
+
+            if (currT < lakeConfig.distanceMin) {
+                distanceMask = NoiseUtil.clamp((currT - (lakeConfig.distanceMin - fadeWindow)) / fadeWindow, 0.0F, 1.0F);
+            } else if (currT > lakeConfig.distanceMax) {
+                distanceMask = NoiseUtil.clamp(((lakeConfig.distanceMax + fadeWindow) - currT) / fadeWindow, 0.0F, 1.0F);
+            }
+
+            distanceMask = distanceMask * distanceMask * (3.0F - 2.0F * distanceMask);
+            widenMultiplier = 1.0F + (flatnessFactor * organicWarpFactor * distanceMask);
+        }
+        return widenMultiplier; // no op
     }
 
     private float carveZone1Riverbed(Cell cell, float currT, float distSqToCurr, float bedDepthOffset, float oceanHeightOffset, float sqScaleFactor, float targetWaterLevel, float widenMultiplier) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -112,7 +112,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float depthVar = this.depthNoise.compute(currX, currZ, 3912);
         float terraceMask = this.terraceNoise.compute(currX, currZ, 5510);
         float asymmetry = this.asymmetryNoise.compute(currX, currZ, 1193);
-        float valleyPinchVar = this.valleyPinchNoise.compute(currX, currZ, 6204);
+        float valleyPinchVar = this.valleyPinchNoise.compute(currX, currZ, 6204) * 2.0F;
 
         // --- DRAINAGE CALCULATION (Ridged Noise) ---
         float gullyRaw = this.gullyNoise.compute(currX, currZ, 9876);

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -101,7 +101,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
     public void carve(Cell cell, float prevX, float prevZ, float prevT, float currX, float currZ, float currT) {
         float distSqToCurr = this.getDistance2(currX, currZ, currT);
         float currentLinearDist = (float) Math.sqrt(distSqToCurr);
-
+        float shrinkFactor = this.fade * currT;
         float flatnessInput = isUpliftContinent ? cell.waterTable : currT;
         float flatnessFactor = NoiseUtil.clamp(ContinentalHydrology.getFlatnessFactor(flatnessInput), 0.0F, 1.0F);
         float scaleFactor = 1.0F + 0.75F * flatnessFactor;
@@ -152,7 +152,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         // --- ORGANIC LAKE SHORELINE WARPING MODULATION ---
         float plateauInput = isUpliftContinent ? cell.waterTable : currT;
         int plateauIndex = ContinentalHydrology.getStepId(plateauInput);
-        float widenMultiplier = 1.0F;
+        float widenMultiplier = 0.25F + 0.75F * shrinkFactor;
 
         if (this.shouldWidenOnPlateau(plateauIndex, lakeConfig, currT)) {
             float lakeScaleMin = lakeConfig.sizeMin / 100.0F;
@@ -183,11 +183,18 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float zone2Radius = zone1Radius + zone2Width;
 
         // --- APPLY PATH-BASED PINCH/FLARE TO ZONE 3 VALLEY FLOOR ---
-        float zone3Width = config.bankWidth * dynamicWidthMult * valleyPinchMultiplier;
+
+        // The full, unshrunk base width (ignoring shrinkFactor)
+        float unshrunkZone3BaseWidth = config.bankWidth * dynamicWidthMult * valleyPinchMultiplier;
+
+        // Apply only to Zone 3 so the valley floor still pinches out
+        float zone3BaseWidth = unshrunkZone3BaseWidth * shrinkFactor;
+        float zone3Width = zone3BaseWidth * shrinkFactor;
         float zone3Radius = zone2Radius + zone3Width;
 
-        // Zone 4 dynamically accommodates the changes automatically via the chain
-        float zone4Radius = zone3Radius + (zone3Width * (4 + discrepancyScale));
+        // Calculate Zone 4 using the base width
+        // This ensures the fadeout distance remains broad and constant all the way to the river head
+        float zone4Radius = zone3Radius + (unshrunkZone3BaseWidth * (4 + discrepancyScale));
 
         if (currentLinearDist >= zone4Radius) return;
 

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -35,6 +35,9 @@ public class UpliftRiverCarver implements RTFRiverCarver {
     private Noise terraceNoise;
     private Noise asymmetryNoise;
 
+    // Broad-scale "pinch & flare" noise driving zone 3 valley floor width along the river path
+    private Noise valleyPinchNoise;
+
     // New Drainage Noises
     private Noise gullyNoise;
     private Noise rivuletNoise;
@@ -44,7 +47,6 @@ public class UpliftRiverCarver implements RTFRiverCarver {
     public LakeConfig lakeConfig;
 
     // --- PER-RIVER VARIANCE FIELDS ---
-    private final float riverValleyWidthModifier;
     private boolean isUpliftContinent;
 
     public UpliftRiverCarver(River river, RiverWarp warp, RiverConfig config, RiverCarverSettings settings, Levels levels, LakeConfig lakeConfig, boolean isUpliftContinent) {
@@ -80,6 +82,10 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         this.terraceNoise = Noises.simplex(5510, 200, 1);
         this.asymmetryNoise = Noises.simplex(1193, 250, 1);
 
+        // Broad spatial period (~360 blocks) so the valley floor gradually pinches
+        // narrow then flares wide as the river travels through the world
+        this.valleyPinchNoise = Noises.simplex(6204, 360, 2);
+
         // Drainage initialization
         this.gullyNoise = Noises.simplex(9876, 65, 2);
         this.rivuletNoise = Noises.simplex(5432, 20, 2);
@@ -89,16 +95,6 @@ public class UpliftRiverCarver implements RTFRiverCarver {
 
         this.lakeConfig = lakeConfig;
         this.isUpliftContinent = isUpliftContinent;
-
-        // --- INITIALIZE DETERMINISTIC PER-RIVER VALLEY VARIANCE ---
-        int rh1 = Float.floatToIntBits(river.x1);
-        int rh2 = Float.floatToIntBits(river.z1);
-        long uniqueRiverSeed = ((long) rh1 << 32) | (rh2 & 0xFFFFFFFFL);
-        uniqueRiverSeed ^= 0x4B3C2B1A5L; // Unique salt modifier for valley layout variance
-
-        Random riverVarRand = new Random(uniqueRiverSeed);
-        // Generates a scaling factor between 0.70 and 1.30 (+/- 30% total width deviation per river system)
-        this.riverValleyWidthModifier = 0.70F + riverVarRand.nextFloat() * 0.60F;
     }
 
     @Override
@@ -116,6 +112,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float depthVar = this.depthNoise.compute(currX, currZ, 3912);
         float terraceMask = this.terraceNoise.compute(currX, currZ, 5510);
         float asymmetry = this.asymmetryNoise.compute(currX, currZ, 1193);
+        float valleyPinchVar = this.valleyPinchNoise.compute(currX, currZ, 6204);
 
         // --- DRAINAGE CALCULATION (Ridged Noise) ---
         float gullyRaw = this.gullyNoise.compute(currX, currZ, 9876);
@@ -131,6 +128,10 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float dynamicWidthMult = 1.0F + (widthVar * 0.35F);
         float dynamicDepthMult = 1.0F + (depthVar * 0.25F);
         float sideBias = 1.0F + (asymmetry * 0.4F);
+
+        // Zone 3 pinch/flare: noise output (~-1 to 1) maps to ~0.05x (pinched) through
+        // ~1.95x (flared) so the valley floor narrows and widens as the river runs
+        float valleyPinchMultiplier = NoiseUtil.clamp(1.0F + valleyPinchVar, 0.05F, 1.95F);
 
         // --- 1. TARGET ELEVATIONS ---
         float oceanHeightOffset = levels.water;
@@ -181,8 +182,8 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float zone2Width = (config.maxBankHeight - config.minBankHeight) / this.levels.unit * biasedScale;
         float zone2Radius = zone1Radius + zone2Width;
 
-        // --- APPLY PER-RIVER VARIANCE TO ZONE 3 VALLEY FLOOR ---
-        float zone3Width = config.bankWidth * dynamicWidthMult * this.riverValleyWidthModifier;
+        // --- APPLY PATH-BASED PINCH/FLARE TO ZONE 3 VALLEY FLOOR ---
+        float zone3Width = config.bankWidth * dynamicWidthMult * valleyPinchMultiplier;
         float zone3Radius = zone2Radius + zone3Width;
 
         // Zone 4 dynamically accommodates the changes automatically via the chain

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -101,7 +101,10 @@ public class UpliftRiverCarver implements RTFRiverCarver {
     public void carve(Cell cell, float prevX, float prevZ, float prevT, float currX, float currZ, float currT) {
         float distSqToCurr = this.getDistance2(currX, currZ, currT);
         float currentLinearDist = (float) Math.sqrt(distSqToCurr);
-        float shrinkFactor = this.fade * currT;
+
+        // FIX: Calculate proper river progression scale clamped between 0.0 and 1.0
+        float shrinkFactor = NoiseUtil.clamp(currT * this.fadeInv, 0.0F, 1.0F);
+
         float flatnessInput = isUpliftContinent ? cell.waterTable : currT;
         float flatnessFactor = NoiseUtil.clamp(ContinentalHydrology.getFlatnessFactor(flatnessInput), 0.0F, 1.0F);
         float scaleFactor = 1.0F + 0.75F * flatnessFactor;
@@ -206,17 +209,17 @@ public class UpliftRiverCarver implements RTFRiverCarver {
             cell.riverZone = RiverCarverSettings.RiverZone.Riverbed;
         } else if (currentLinearDist < zone2Radius) {
             finalHeight = carveZone2BankStep(currentLinearDist, zone1Radius, zone2Radius, targetWaterLevel, targetValleyFloor, terraceMask, drainageMask);
-            if (cell.riverZone != RiverCarverSettings.RiverZone.Riverbed) {
+            if (finalHeight < cell.height && cell.riverZone != RiverCarverSettings.RiverZone.Riverbed) {
                 cell.riverZone = RiverCarverSettings.RiverZone.Banks;
             }
         } else if (currentLinearDist < zone3Radius) {
             finalHeight = carveZone3ValleyFloor(targetValleyFloor, terraceMask, drainageMask);
-            if (cell.riverZone != RiverCarverSettings.RiverZone.Riverbed && cell.riverZone != RiverCarverSettings.RiverZone.Banks) {
+            if (finalHeight < cell.height && cell.riverZone != RiverCarverSettings.RiverZone.Riverbed && cell.riverZone != RiverCarverSettings.RiverZone.Banks) {
                 cell.riverZone = RiverCarverSettings.RiverZone.ValleyFloor;
             }
         } else {
             finalHeight = carveZone4Fadeout(cell.height, currentLinearDist, zone3Radius, zone4Radius, targetValleyFloor, terraceMask, drainageMask);
-            if (cell.riverZone != RiverCarverSettings.RiverZone.Riverbed && cell.riverZone != RiverCarverSettings.RiverZone.Banks && cell.riverZone != RiverCarverSettings.RiverZone.ValleyFloor) {
+            if (finalHeight < cell.height && cell.riverZone != RiverCarverSettings.RiverZone.Riverbed && cell.riverZone != RiverCarverSettings.RiverZone.Banks && cell.riverZone != RiverCarverSettings.RiverZone.ValleyFloor) {
                 cell.riverZone = RiverCarverSettings.RiverZone.ValleyFadeout;
             }
         }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -99,25 +99,27 @@ public class UpliftRiverCarver implements RTFRiverCarver {
 
     @Override
     public void carve(Cell cell, float prevX, float prevZ, float prevT, float currX, float currZ, float currT) {
+
+        // fixed reference values
         float distSqToCurr = this.getDistance2(currX, currZ, currT);
         float currentLinearDist = (float) Math.sqrt(distSqToCurr);
-
-        // FIX: Calculate proper river progression scale clamped between 0.0 and 1.0
         float shrinkFactor = NoiseUtil.clamp(currT * this.fadeInv, 0.0F, 1.0F);
-
         float flatnessInput = isUpliftContinent ? cell.waterTable : currT;
         float flatnessFactor = NoiseUtil.clamp(ContinentalHydrology.getFlatnessFactor(flatnessInput), 0.0F, 1.0F);
         float scaleFactor = 1.0F + 0.75F * flatnessFactor;
         float sqScaleFactor = scaleFactor * scaleFactor;
 
-        // --- ENVIRONMENTAL VARIATION SAMPLES ---
+        // noise sampling
         float widthVar = this.widthNoise.compute(currX, currZ, 8241);
         float depthVar = this.depthNoise.compute(currX, currZ, 3912);
         float terraceMask = this.terraceNoise.compute(currX, currZ, 5510);
         float asymmetry = this.asymmetryNoise.compute(currX, currZ, 1193);
         float valleyPinchVar = this.valleyPinchNoise.compute(currX, currZ, 6204) * 2.0F;
 
-        // --- DRAINAGE CALCULATION (Ridged Noise) ---
+        // always run mask logic to ensure clean falloffs
+        updateValleyMask(prevX, prevZ, prevT, currX, currZ, currT, distSqToCurr, sqScaleFactor, levels.water - config.bedHeight, cell);
+
+        // --- DRAINAGE CALCULATION ---
         float gullyRaw = this.gullyNoise.compute(currX, currZ, 9876);
         float gullyShape = 1.0F - Math.abs(gullyRaw);
         gullyShape *= gullyShape;
@@ -131,31 +133,31 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float dynamicWidthMult = 1.0F + (widthVar * 0.35F);
         float dynamicDepthMult = 1.0F + (depthVar * 0.25F);
         float sideBias = 1.0F + (asymmetry * 0.4F);
-
-        // Zone 3 pinch/flare: noise output (~-1 to 1) maps to ~0.05x (pinched) through
-        // ~1.95x (flared) so the valley floor narrows and widens as the river runs
         float valleyPinchMultiplier = NoiseUtil.clamp(1.0F + valleyPinchVar, 0.05F, 1.95F);
 
-        // --- 1. TARGET ELEVATIONS ---
+        // --- TARGET ELEVATIONS ---
         float oceanHeightOffset = levels.water;
         float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanHeightOffset;
 
         float baseBedDepthOffset = oceanHeightOffset - config.bedHeight;
         float bedDepthOffset = baseBedDepthOffset * dynamicDepthMult;
-        float targetBedFloor = targetWaterLevel - bedDepthOffset;
 
         float bankHeightOffset = (config.maxBankHeight - config.minBankHeight);
         float targetValleyFloor = targetWaterLevel + bankHeightOffset;
         float discrepancyScale = 1.0F + (levels.scale(cell.height - targetWaterLevel)) / 100.0F;
 
+        // --- PRE-CALCULATE UNIFIED VALLEY FLOOR HEIGHT (Fix #2) ---
+        float valleyFloorBumpiness = ((terraceMask * 0.4F) - (drainageMask * 0.6F)) * this.levels.unit;
+        float actualValleyFloorHeight = targetValleyFloor + valleyFloorBumpiness;
+
         // --- RADII BOUNDARIES ---
         float biasedScale = sqScaleFactor * dynamicWidthMult * sideBias;
         float zone1Radius = (float) Math.sqrt(this.getScaledSize(currT, this.bedWidth) * biasedScale);
 
-        // --- ORGANIC LAKE SHORELINE WARPING MODULATION ---
+        // --- ORGANIC LAKE SHORELINE WARPING ---
         float plateauInput = isUpliftContinent ? cell.waterTable : currT;
         int plateauIndex = ContinentalHydrology.getStepId(plateauInput);
-        float widenMultiplier = 0.25F + 0.75F * shrinkFactor;
+        float widenMultiplier = 1.0F;
 
         if (this.shouldWidenOnPlateau(plateauIndex, lakeConfig, currT)) {
             float lakeScaleMin = lakeConfig.sizeMin / 100.0F;
@@ -165,7 +167,6 @@ public class UpliftRiverCarver implements RTFRiverCarver {
             float shorelineWarp = this.lakeWarpNoise.compute(currX, currZ, 7439);
             float organicWarpFactor = baseStepScale * (1.0F + shorelineWarp * 0.45F);
 
-            // --- SMOOTH DISTANCE FADE FACTOR ---
             float distanceMask = 1.0F;
             float fadeWindow = 0.04F;
 
@@ -176,59 +177,53 @@ public class UpliftRiverCarver implements RTFRiverCarver {
             }
 
             distanceMask = distanceMask * distanceMask * (3.0F - 2.0F * distanceMask);
-
             widenMultiplier = 1.0F + (flatnessFactor * organicWarpFactor * distanceMask);
             zone1Radius *= widenMultiplier;
         }
 
-        // Additive chaining recalculates layout bounds
         float zone2Width = (config.maxBankHeight - config.minBankHeight) / this.levels.unit * biasedScale;
         float zone2Radius = zone1Radius + zone2Width;
-
-        // --- APPLY PATH-BASED PINCH/FLARE TO ZONE 3 VALLEY FLOOR ---
-
-        // The full, unshrunk base width (ignoring shrinkFactor)
         float unshrunkZone3BaseWidth = config.bankWidth * dynamicWidthMult * valleyPinchMultiplier;
-
-        // Apply only to Zone 3 so the valley floor still pinches out
         float zone3BaseWidth = unshrunkZone3BaseWidth * shrinkFactor;
         float zone3Width = zone3BaseWidth * shrinkFactor;
         float zone3Radius = zone2Radius + zone3Width;
-
-        // Calculate Zone 4 using the base width
-        // This ensures the fadeout distance remains broad and constant all the way to the river head
         float zone4Radius = zone3Radius + (unshrunkZone3BaseWidth * (4 + discrepancyScale));
 
+        // Spatial gate for the actual carving step
         if (currentLinearDist >= zone4Radius) return;
 
-        // --- 3. PROFILE SELECTION ---
+        // --- PROFILE SELECTION ---
         float finalHeight = cell.height;
+        RiverCarverSettings.RiverZone prospectiveZone = cell.riverZone;
 
         if (currentLinearDist < zone1Radius) {
             finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, oceanHeightOffset, sqScaleFactor, targetWaterLevel, widenMultiplier);
-            cell.riverZone = RiverCarverSettings.RiverZone.Riverbed;
+            prospectiveZone = RiverCarverSettings.RiverZone.Riverbed;
         } else if (currentLinearDist < zone2Radius) {
-            finalHeight = carveZone2BankStep(currentLinearDist, zone1Radius, zone2Radius, targetWaterLevel, targetValleyFloor, terraceMask, drainageMask);
-            if (finalHeight < cell.height && cell.riverZone != RiverCarverSettings.RiverZone.Riverbed) {
-                cell.riverZone = RiverCarverSettings.RiverZone.Banks;
+            // Banks scale smoothly into our unified actualValleyFloorHeight instead of the flat targetValleyFloor
+            finalHeight = carveZone2BankStep(currentLinearDist, zone1Radius, zone2Radius, targetWaterLevel, actualValleyFloorHeight, terraceMask, drainageMask);
+            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed) {
+                prospectiveZone = RiverCarverSettings.RiverZone.Banks;
             }
         } else if (currentLinearDist < zone3Radius) {
-            finalHeight = carveZone3ValleyFloor(targetValleyFloor, terraceMask, drainageMask);
-            if (finalHeight < cell.height && cell.riverZone != RiverCarverSettings.RiverZone.Riverbed && cell.riverZone != RiverCarverSettings.RiverZone.Banks) {
-                cell.riverZone = RiverCarverSettings.RiverZone.ValleyFloor;
+            finalHeight = actualValleyFloorHeight;
+            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed && prospectiveZone != RiverCarverSettings.RiverZone.Banks) {
+                prospectiveZone = RiverCarverSettings.RiverZone.ValleyFloor;
             }
         } else {
-            finalHeight = carveZone4Fadeout(cell.height, currentLinearDist, zone3Radius, zone4Radius, targetValleyFloor, terraceMask, drainageMask);
-            if (finalHeight < cell.height && cell.riverZone != RiverCarverSettings.RiverZone.Riverbed && cell.riverZone != RiverCarverSettings.RiverZone.Banks && cell.riverZone != RiverCarverSettings.RiverZone.ValleyFloor) {
-                cell.riverZone = RiverCarverSettings.RiverZone.ValleyFadeout;
+            // Fadeout safely steps out directly from our bumpy actualValleyFloorHeight (Fix #2)
+            finalHeight = carveZone4Fadeout(cell.height, currentLinearDist, zone3Radius, zone4Radius, actualValleyFloorHeight, terraceMask, drainageMask);
+            if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed && prospectiveZone != RiverCarverSettings.RiverZone.Banks && prospectiveZone != RiverCarverSettings.RiverZone.ValleyFloor) {
+                prospectiveZone = RiverCarverSettings.RiverZone.ValleyFadeout;
             }
         }
 
+        // --- DESTRUCTIVE MUTATION GATE (Fix #3) ---
+        // Only commit data changes to the cell if our carving operations actually cut down the world
         if (finalHeight < cell.height) {
             cell.height = finalHeight;
+            cell.riverZone = prospectiveZone;
         }
-
-        updateValleyMask(prevX, prevZ, prevT, currX, currZ, currT, distSqToCurr, sqScaleFactor, targetBedFloor, cell);
     }
 
     private float carveZone1Riverbed(Cell cell, float currT, float distSqToCurr, float bedDepthOffset, float oceanHeightOffset, float sqScaleFactor, float targetWaterLevel, float widenMultiplier) {
@@ -281,11 +276,48 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float intactTerrace = Math.max(0.0F, terraceMask - (drainageMask * 1.5F));
         float terraceStrength = NoiseUtil.clamp(intactTerrace * 1.5F, 0.0F, 1.0F);
 
-        if (terraceStrength > 0.0F) {
-            float steppedProgress = (float) Math.round(progress * steps) / steps;
-            return NoiseUtil.lerp(progress, steppedProgress, terraceStrength * 0.65F);
+        // If terracing isn't influencing this cell, maintain the native slope gradient
+        if (terraceStrength <= 0.0F) {
+            return progress;
         }
-        return progress;
+
+        // Map the continuous linear progress into discrete step spaces
+        float scaledProgress = progress * steps;
+        float floor = (float) Math.floor(scaledProgress);
+        float fract = scaledProgress - floor; // Ranges from 0.0 to 1.0 within the current step
+
+        // --- GEOMORPHOLOGY & WEATHERING MODIFIERS ---
+        // High drainage causes the cliff to erode backward, making the cliff zone narrower
+        float baseCliffBias = 0.72F; // Default: Cliff face occupies the upper 28% of the step
+        float cliffBias = NoiseUtil.clamp(baseCliffBias - (drainageMask * 0.15F), 0.45F, 0.85F);
+
+        // High drainage washes eroded material downward, increasing the height of the talus pile
+        float baseTalusHeight = 0.15F; // Default: Talus accumulation takes up 15% of the step height
+        float talusHeight = NoiseUtil.clamp(baseTalusHeight + (drainageMask * 0.25F), 0.05F, 0.50F);
+
+        float steppedFract;
+        if (fract < cliffBias) {
+            // ZONE 1: Flat Terrace Tier leading into the Concave Talus Apron
+            float t = fract / cliffBias;
+
+            // A cubic curve (t^3) keeps the valley floor flat initially, then creates
+            // a perfect concave upward sweep mimicking loose rock accumulating at the base.
+            steppedFract = (float) Math.pow(t, 3.0F) * talusHeight;
+        } else {
+            // ZONE 2: The Cliff Face
+            float t = (fract - cliffBias) / (1.0F - cliffBias);
+
+            // Use a smoothstep (S-curve) to transition the cliff steepness out of the
+            // talus apron and gracefully roll over into the lip of the next upper terrace floor.
+            float smoothCliff = t * t * (3.0F - 2.0F * t);
+            steppedFract = NoiseUtil.lerp(talusHeight, 1.0F, smoothCliff);
+        }
+
+        // Reconstruct the modified step back into world space
+        float steppedProgress = (floor + steppedFract) / steps;
+
+        // Blend our hyper-realistic profile with the raw terrain based on local terrace strength
+        return NoiseUtil.lerp(progress, steppedProgress, terraceStrength * 0.85F);
     }
 
     private void updateValleyMask(float prevX, float prevZ, float prevT, float currX, float currZ, float currT, float distSqToCurr, float sqScaleFactor, float targetBedFloor, Cell cell) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -274,50 +274,51 @@ public class UpliftRiverCarver implements RTFRiverCarver {
 
     private float applyTerracing(float progress, float terraceMask, float drainageMask, float steps) {
         float intactTerrace = Math.max(0.0F, terraceMask - (drainageMask * 1.5F));
-        float terraceStrength = NoiseUtil.clamp(intactTerrace * 1.5F, 0.0F, 1.0F);
+        // Balanced strength multiplier (1.75F) for a confident but natural terrace presence
+        float terraceStrength = NoiseUtil.clamp(intactTerrace * 1.75F, 0.0F, 1.0F);
 
-        // If terracing isn't influencing this cell, maintain the native slope gradient
         if (terraceStrength <= 0.0F) {
             return progress;
         }
 
-        // Map the continuous linear progress into discrete step spaces
         float scaledProgress = progress * steps;
         float floor = (float) Math.floor(scaledProgress);
-        float fract = scaledProgress - floor; // Ranges from 0.0 to 1.0 within the current step
+        float fract = scaledProgress - floor;
 
-        // --- GEOMORPHOLOGY & WEATHERING MODIFIERS ---
-        // High drainage causes the cliff to erode backward, making the cliff zone narrower
-        float baseCliffBias = 0.72F; // Default: Cliff face occupies the upper 28% of the step
-        float cliffBias = NoiseUtil.clamp(baseCliffBias - (drainageMask * 0.15F), 0.45F, 0.85F);
+        // --- BALANCED GEOMORPHOLOGY TUNING ---
+        // 0.78F puts the cliff face in the upper 22% of the step—distinctly steep but scalable.
+        float baseCliffBias = 0.78F;
+        float cliffBias = NoiseUtil.clamp(baseCliffBias - (drainageMask * 0.14F), 0.55F, 0.88F);
 
-        // High drainage washes eroded material downward, increasing the height of the talus pile
-        float baseTalusHeight = 0.15F; // Default: Talus accumulation takes up 15% of the step height
-        float talusHeight = NoiseUtil.clamp(baseTalusHeight + (drainageMask * 0.25F), 0.05F, 0.50F);
+        float baseTalusHeight = 0.14F;
+        float talusHeight = NoiseUtil.clamp(baseTalusHeight + (drainageMask * 0.22F), 0.04F, 0.45F);
 
         float steppedFract;
         if (fract < cliffBias) {
-            // ZONE 1: Flat Terrace Tier leading into the Concave Talus Apron
             float t = fract / cliffBias;
 
-            // A cubic curve (t^3) keeps the valley floor flat initially, then creates
-            // a perfect concave upward sweep mimicking loose rock accumulating at the base.
-            steppedFract = (float) Math.pow(t, 3.0F) * talusHeight;
+            // Split the difference between t^3 and t^4 using t^3.5
+            // This gives a flat-ish shelf that transitions smoothly into the debris heap
+            steppedFract = (float) Math.pow(t, 3.5F) * talusHeight;
         } else {
-            // ZONE 2: The Cliff Face
             float t = (fract - cliffBias) / (1.0F - cliffBias);
 
-            // Use a smoothstep (S-curve) to transition the cliff steepness out of the
-            // talus apron and gracefully roll over into the lip of the next upper terrace floor.
-            float smoothCliff = t * t * (3.0F - 2.0F * t);
-            steppedFract = NoiseUtil.lerp(talusHeight, 1.0F, smoothCliff);
+            // HYBRID CLIFF CURVE:
+            // We blend a sharp quadratic curve (t^2) with a smooth S-curve (3t^2 - 2t^3).
+            // This yields a cliff face that breaks out of the talus cleanly, but wraps
+            // into the upper shelf with a slightly weathered, natural roll-over.
+            float sharpCurve = t * t;
+            float smoothCurve = t * t * (3.0F - 2.0F * t);
+            float hybridCliff = NoiseUtil.lerp(sharpCurve, smoothCurve, 0.5F);
+
+            steppedFract = NoiseUtil.lerp(talusHeight, 1.0F, hybridCliff);
         }
 
-        // Reconstruct the modified step back into world space
         float steppedProgress = (floor + steppedFract) / steps;
 
-        // Blend our hyper-realistic profile with the raw terrain based on local terrace strength
-        return NoiseUtil.lerp(progress, steppedProgress, terraceStrength * 0.85F);
+        // A 90% maximum blend weight ensures the steps stay well-defined
+        // while allowing the regional terrain shape to gently break up the monotony.
+        return NoiseUtil.lerp(progress, steppedProgress, terraceStrength * 0.90F);
     }
 
     private void updateValleyMask(float prevX, float prevZ, float prevT, float currX, float currZ, float currT, float distSqToCurr, float sqScaleFactor, float targetBedFloor, Cell cell) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -28,25 +28,15 @@ public class UpliftRiverCarver implements RTFRiverCarver {
     public RiverConfig config;
     public CurveFunction valleyCurve;
     private Levels levels;
-
-    // Environmental Variation Noises
     private Noise widthNoise;
     private Noise depthNoise;
     private Noise terraceNoise;
     private Noise asymmetryNoise;
-
-    // Broad-scale "pinch & flare" noise driving zone 3 valley floor width along the river path
     private Noise valleyPinchNoise;
-
-    // New Drainage Noises
     private Noise gullyNoise;
     private Noise rivuletNoise;
-
-    // Organic Lake Shoreline Distortion Noise
     private Noise lakeWarpNoise;
     public LakeConfig lakeConfig;
-
-    // --- PER-RIVER VARIANCE FIELDS ---
     private boolean isUpliftContinent;
 
     public UpliftRiverCarver(River river, RiverWarp warp, RiverConfig config, RiverCarverSettings settings, Levels levels, LakeConfig lakeConfig, boolean isUpliftContinent) {
@@ -117,7 +107,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float valleyPinchVar = this.valleyPinchNoise.compute(currX, currZ, 6204) * 2.0F;
 
         // always run mask logic to ensure clean falloffs
-        updateValleyMask(prevX, prevZ, prevT, currX, currZ, currT, distSqToCurr, sqScaleFactor, levels.water - config.bedHeight, cell);
+        updateValleyMask(prevX, prevZ, prevT, currT, distSqToCurr, sqScaleFactor, cell);
 
         // --- DRAINAGE CALCULATION ---
         float gullyRaw = this.gullyNoise.compute(currX, currZ, 9876);
@@ -189,10 +179,8 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float zone3Radius = zone2Radius + zone3Width;
         float zone4Radius = zone3Radius + (unshrunkZone3BaseWidth * (4 + discrepancyScale));
 
-        // Spatial gate for the actual carving step
         if (currentLinearDist >= zone4Radius) return;
 
-        // --- PROFILE SELECTION ---
         float finalHeight = cell.height;
         RiverCarverSettings.RiverZone prospectiveZone = cell.riverZone;
 
@@ -211,14 +199,13 @@ public class UpliftRiverCarver implements RTFRiverCarver {
                 prospectiveZone = RiverCarverSettings.RiverZone.ValleyFloor;
             }
         } else {
-            // Fadeout safely steps out directly from our bumpy actualValleyFloorHeight (Fix #2)
+            // Fadeout safely steps out directly from our bumpy actualValleyFloorHeight
             finalHeight = carveZone4Fadeout(cell.height, currentLinearDist, zone3Radius, zone4Radius, actualValleyFloorHeight, terraceMask, drainageMask);
             if (prospectiveZone != RiverCarverSettings.RiverZone.Riverbed && prospectiveZone != RiverCarverSettings.RiverZone.Banks && prospectiveZone != RiverCarverSettings.RiverZone.ValleyFloor) {
                 prospectiveZone = RiverCarverSettings.RiverZone.ValleyFadeout;
             }
         }
 
-        // --- DESTRUCTIVE MUTATION GATE (Fix #3) ---
         // Only commit data changes to the cell if our carving operations actually cut down the world
         if (finalHeight < cell.height) {
             cell.height = finalHeight;
@@ -254,11 +241,6 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         return NoiseUtil.lerp(targetWaterLevel, targetValleyFloor, smoothProgress);
     }
 
-    private float carveZone3ValleyFloor(float targetValleyFloor, float terraceMask, float drainageMask) {
-        float bumpiness = (terraceMask * 0.4F) - (drainageMask * 0.6F);
-        return targetValleyFloor + (bumpiness * this.levels.unit);
-    }
-
     private float carveZone4Fadeout(float originalTerrainHeight, float distance, float zone3Radius, float zone4Radius, float targetValleyFloor, float terraceMask, float drainageMask) {
         float progress = (distance - zone3Radius) / (zone4Radius - zone3Radius);
         progress = NoiseUtil.clamp(progress, 0.0F, 1.0F);
@@ -274,6 +256,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
 
     private float applyTerracing(float progress, float terraceMask, float drainageMask, float steps) {
         float intactTerrace = Math.max(0.0F, terraceMask - (drainageMask * 1.5F));
+
         // Balanced strength multiplier (1.75F) for a confident but natural terrace presence
         float terraceStrength = NoiseUtil.clamp(intactTerrace * 1.75F, 0.0F, 1.0F);
 
@@ -285,8 +268,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float floor = (float) Math.floor(scaledProgress);
         float fract = scaledProgress - floor;
 
-        // --- BALANCED GEOMORPHOLOGY TUNING ---
-        // 0.78F puts the cliff face in the upper 22% of the step—distinctly steep but scalable.
+        // 0.78F puts the cliff face in the upper 22% of the step, distinctly steep but scalable.
         float baseCliffBias = 0.78F;
         float cliffBias = NoiseUtil.clamp(baseCliffBias - (drainageMask * 0.14F), 0.55F, 0.88F);
 
@@ -303,7 +285,6 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         } else {
             float t = (fract - cliffBias) / (1.0F - cliffBias);
 
-            // HYBRID CLIFF CURVE:
             // We blend a sharp quadratic curve (t^2) with a smooth S-curve (3t^2 - 2t^3).
             // This yields a cliff face that breaks out of the talus cleanly, but wraps
             // into the upper shelf with a slightly weathered, natural roll-over.
@@ -321,7 +302,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         return NoiseUtil.lerp(progress, steppedProgress, terraceStrength * 0.90F);
     }
 
-    private void updateValleyMask(float prevX, float prevZ, float prevT, float currX, float currZ, float currT, float distSqToCurr, float sqScaleFactor, float targetBedFloor, Cell cell) {
+    private void updateValleyMask(float prevX, float prevZ, float prevT, float currT, float distSqToCurr, float sqScaleFactor, Cell cell) {
         float distSqToPrev = this.getDistance2(prevX, prevZ, prevT);
         float valleyInfluence = this.getDistanceAlpha(currT, Math.min(distSqToCurr, distSqToPrev), this.valleyWidth, sqScaleFactor);
         if (valleyInfluence > 0.0F) {
@@ -329,8 +310,6 @@ public class UpliftRiverCarver implements RTFRiverCarver {
             cell.riverMask = Math.min(cell.riverMask, 1.0F - valleyInfluence);
         }
     }
-
-    // --- PLATEAU SELECTION HELPER METHODS ---
 
     private boolean shouldWidenOnPlateau(int plateauIndex, LakeConfig config, float currT) {
         if (plateauIndex < -1) return false;


### PR DESCRIPTION
In combination with the river working committee
Denier, Broke, Leo, Prymz, Nerdcraft we addressed many of the concerns that were originally targeted by 
https://github.com/ETcodehome/ReTerraForged/pull/77 manually pulling in some of the changes on Prymz and nerdcrafts working branch and combining them with some working changes to terracing I'd been tweaking.

Notably the following change have been made
- zone 4 falloff is more deterministic being less determined by bank width
- valley fade is more fade value aware shrinking at configured headwaters now
- zone 3 now varies much more heavily which introduces desirable cliff characteristics.
- terraces now longer apply as distinct fans but are incorporated much more tidily into cliff faces
- falloff zones braodly are more relaible and shitty vertical V-cliffs will generate even less often
- ridgeline flanges caused by near 0 value noise sampling have been prevented smoothly transitioning to surrounding terrain
- river valley walls / surrounding mountains will generally be more survival friendly as the terraces are typically flat enough to traverse.

***

<img width="2569" height="1373" alt="image" src="https://github.com/user-attachments/assets/0b6cbc74-37d7-471c-b675-184a8205384b" />

<img width="2572" height="1371" alt="image" src="https://github.com/user-attachments/assets/c9c5420c-2c4f-4827-b486-4d912608ea50" />

<img width="2580" height="1374" alt="image" src="https://github.com/user-attachments/assets/ee71d46a-4323-481f-8ff2-3fef891e3c79" />

<img width="2567" height="1381" alt="image" src="https://github.com/user-attachments/assets/9fe43075-db01-4431-b15d-8d01a812a5d3" />

<img width="2563" height="1379" alt="image" src="https://github.com/user-attachments/assets/35158985-d0c7-45cf-a010-fcde33fcf659" />

<img width="2573" height="1375" alt="image" src="https://github.com/user-attachments/assets/d1adb750-6406-4e97-8c35-57ec74bdbc16" />

