### PR TITLE
Boats will float in rivers

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinFloatyBoaty.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinFloatyBoaty.java
@@ -1,0 +1,38 @@
+package raccoonman.reterraforged.mixin;
+
+import net.minecraft.core.Holder;
+import net.minecraft.world.entity.vehicle.Boat;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.Biomes;
+import net.minecraft.world.phys.Vec3;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Boat.class)
+public abstract class MixinFloatyBoaty {
+    @Shadow private Boat.Status status;
+
+    @Inject(
+            method = "tick",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/world/entity/vehicle/Boat;move(Lnet/minecraft/world/entity/MoverType;Lnet/minecraft/world/phys/Vec3;)V"
+            )
+    )
+    private void applyRiverBuoyancy(CallbackInfo ci) {
+        Boat boat = (Boat) (Object) this;
+        Level level = boat.level();
+        Holder<Biome> biomeHolder = level.getBiome(boat.blockPosition());
+        if (biomeHolder.is(Biomes.RIVER)) {
+            if (this.status == Boat.Status.UNDER_WATER || this.status == Boat.Status.UNDER_FLOWING_WATER) {
+                Vec3 currentMotion = boat.getDeltaMovement();
+                double liftVelocity = (boat.getControllingPassenger() != null) ? 0.3 : 0.2;
+                boat.setDeltaMovement(currentMotion.x, liftVelocity, currentMotion.z);
+            }
+        }
+    }
+}

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -23,6 +23,7 @@
 		"MixinImposterProtoChunk",
 		"MixinNoiseBasedChunkGenerator",
 		"MixinSculkPatchFeature",
+		"MixinFloatyBoaty",
 		"BeardifierAccessor",
 		"LevelChunkSectionAccessor",
 		"terrablender.MixinParameterList",


### PR DESCRIPTION
Not being able to paddle boats upriver hurts survival play, so boats can now float and be paddled upstream on 3D rivers.

<img width="843" height="438" alt="floatyboaty" src="https://github.com/user-attachments/assets/659983d5-9b09-4226-8601-ffb149940f4d" />

Fixes #85 

