### PR TITLE
Fix overworld derived dimensions

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinChunkMap.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinChunkMap.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.mojang.datafixers.DataFixer;
-
+import net.minecraft.world.level.Level;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.progress.ChunkProgressListener;
@@ -23,12 +23,21 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
 import net.minecraft.world.level.storage.DimensionDataStorage;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import raccoonman.reterraforged.world.worldgen.RTFRandomState;
+import raccoonman.reterraforged.world.worldgen.RTFWorldGenContext;
 
 @Mixin(ChunkMap.class)
 public class MixinChunkMap {
 	@Shadow
     private RandomState randomState;
-	
+
+	@Inject(
+			at = @At("HEAD"),
+			method = "<init>"
+			)
+	private static void beforeChunkMapInit(ServerLevel serverLevel, LevelStorageSource.LevelStorageAccess storageAccess, DataFixer dataFixer, StructureTemplateManager templateLoader, Executor executor, BlockableEventLoop<Runnable> eventLoop, LightChunkGetter lightChunkGetter, ChunkGenerator chunkGenerator, ChunkProgressListener chunkProgressListener, ChunkStatusUpdateListener chunkStatusListener, Supplier<DimensionDataStorage> dimensionStorage, int viewDistance, boolean syncChunkWrites, CallbackInfo callback) {
+		RTFWorldGenContext.IS_VANILLA_OVERWORLD.set(serverLevel.dimension() == Level.OVERWORLD);
+	}
+
 	@Inject(
 		at = @At("TAIL"),
 		method = "<init>"
@@ -37,5 +46,6 @@ public class MixinChunkMap {
 		if((Object) this.randomState instanceof RTFRandomState rtfRandomState) {
 			rtfRandomState.initialize(serverLevel.registryAccess());
 		}
+		RTFWorldGenContext.IS_VANILLA_OVERWORLD.remove();
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseBasedChunkGenerator.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseBasedChunkGenerator.java
@@ -82,6 +82,12 @@ abstract class MixinNoiseBasedChunkGenerator extends ChunkGenerator {
 		)
 	)
     public int fillFromNoise(NoiseSettings settings, Blender blender, RandomState randomState, StructureManager structureManager, ChunkAccess chunk) {
+
+		RTFRandomState rtfRandomState = (RTFRandomState) (Object) randomState;
+		if (rtfRandomState.generatorContext() == null) {
+			return settings.height();
+		}
+
 		RTFChunk rtfChunk = (RTFChunk) chunk;
 		int maxHeight = rtfChunk.getMaxHeight().orElseGet(settings::height);
 		maxHeight = MaxHeightUtil.getMaxHeight(chunk.getPos(), maxHeight, this.settings.value(), settings, structureManager);
@@ -93,6 +99,12 @@ abstract class MixinNoiseBasedChunkGenerator extends ChunkGenerator {
 		at = @At("HEAD")
 	)
     private void createNoiseChunk(ChunkAccess chunkAccess, StructureManager structureManager, Blender blender, RandomState randomState, CallbackInfoReturnable<NoiseChunk> callback) {
+
+		RTFRandomState rtfRandomState = (RTFRandomState) (Object) randomState;
+		if (rtfRandomState.generatorContext() == null) {
+			return;
+		}
+
 		ActiveChunk.set(chunkAccess);
 	}
 

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinRandomState.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinRandomState.java
@@ -1,5 +1,6 @@
 package raccoonman.reterraforged.mixin;
 
+import net.minecraft.world.level.levelgen.*;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Implements;
@@ -17,12 +18,7 @@ import net.minecraft.core.HolderLookup.RegistryLookup;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.biome.Climate;
-import net.minecraft.world.level.levelgen.DensityFunction;
 import net.minecraft.world.level.levelgen.DensityFunction.NoiseHolder;
-import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
-import net.minecraft.world.level.levelgen.NoiseRouter;
-import net.minecraft.world.level.levelgen.RandomState;
-import net.minecraft.world.level.levelgen.SurfaceSystem;
 import net.minecraft.world.level.levelgen.synth.NormalNoise;
 import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.concurrent.ThreadPools;
@@ -33,7 +29,9 @@ import raccoonman.reterraforged.registries.RTFRegistries;
 import raccoonman.reterraforged.tags.RTFDensityFunctionTags;
 import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.RTFRandomState;
+import raccoonman.reterraforged.world.worldgen.RTFWorldGenContext;
 import raccoonman.reterraforged.world.worldgen.densityfunction.CellSampler;
+import raccoonman.reterraforged.world.worldgen.densityfunction.MarkerFunction;
 import raccoonman.reterraforged.world.worldgen.densityfunction.NoiseFunction;
 import raccoonman.reterraforged.world.worldgen.noise.module.Noise;
 import raccoonman.reterraforged.world.worldgen.noise.module.Noises;
@@ -71,6 +69,8 @@ class MixinRandomState {
 	)
 	private NoiseRouter RandomState(NoiseRouter router, DensityFunction.Visitor visitor, NoiseGeneratorSettings noiseGeneratorSettings, HolderGetter<NormalNoise.NoiseParameters> params, final long seed) {
 		this.seed = seed;
+
+		final boolean isVanillaOverworld = RTFWorldGenContext.IS_VANILLA_OVERWORLD.get();
 		this.densityFunctionWrapper = new DensityFunction.Visitor() {
 
 			@Override
@@ -79,9 +79,19 @@ class MixinRandomState {
 					return new NoiseFunction(marker.noise(), (int) seed);
 				}
 				if(function instanceof CellSampler.Marker marker) {
+
+					if (!isVanillaOverworld) {
+						return DensityFunctions.zero();
+					}
+
 					MixinRandomState.this.hasContext = true;
 					return new CellSampler(Suppliers.memoize(() -> MixinRandomState.this.generatorContext.lookup), marker.field());
 				}
+
+				if (function instanceof MarkerFunction && !isVanillaOverworld) {
+					return DensityFunctions.zero();
+				}
+
 				return visitor.apply(function);
 			}
 
@@ -93,7 +103,7 @@ class MixinRandomState {
 
 		// Map the base router first. If the current dimension naturally utilizes RTF, hasContext flips to true here.
 		NoiseRouter mappedRouter = router.mapAll(this.densityFunctionWrapper);
-		if (this.hasContext) {
+		if (this.hasContext && isVanillaOverworld) {
 			this.reterraforged$isRTFDimension = true;
 		}
 		return mappedRouter;

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/RTFWorldGenContext.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/RTFWorldGenContext.java
@@ -1,0 +1,6 @@
+package raccoonman.reterraforged.world.worldgen;
+
+public class RTFWorldGenContext {
+    // Safely tracks if the ChunkMap/RandomState currently being built belongs to the true overworld
+    public static final ThreadLocal<Boolean> IS_VANILLA_OVERWORLD = ThreadLocal.withInitial(() -> false);
+}


### PR DESCRIPTION
Fixes https://github.com/ETcodehome/ReTerraForged/issues/121 which documents an issue with 3d rivers propogating to custom dimensions. The dimension itself was using vanilla overworld noise to generate which caused RTF to leak into the dimension.

Change made below (hopefully, finally) now restricts RTF to only the vanilla overworld which should prevent this issue.

Tested by reviewing a 100k block range and multiple biome searches for rivers in nether, end and eternal starlight dimension for both fabric and neoforge loaders with starlight enabled.

TP command for future reference
/execute in eternal_starlight:starlight run tp @p ~ ~ ~




