### PR TITLE
Fix mods injecting into minecraft namespace causing loader crashes

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
@@ -116,14 +116,8 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 		return new RegistryAccess() {
 			@Override
 			public <T> Optional<Registry<T>> registry(ResourceKey<? extends Registry<? extends T>> key) {
-				String namespace = key.location().getNamespace();
-
-				// Always allow standard/internal namespaces so lookups (like STRUCTURE_SET) reliably work
-				if (namespace.equals("minecraft") || namespace.equals("reterraforged")) {
-					return original.registry(key);
-				}
-
-				// For third-party mods, ONLY allow if they explicitly provided a cloner
+				// ONLY allow the registry if we have explicitly armed it with a cloner.
+				// This prevents third-party registries injected into the 'minecraft' namespace from crashing us.
 				if (armed.contains(key)) {
 					return original.registry(key);
 				}
@@ -134,10 +128,8 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 
 			@Override
 			public Stream<RegistryEntry<?>> registries() {
-				return original.registries().filter(entry -> {
-					String ns = entry.key().location().getNamespace();
-					return ns.equals("minecraft") || ns.equals("reterraforged") || armed.contains(entry.key());
-				});
+				// Filter out any registry that hasn't been explicitly armed
+				return original.registries().filter(entry -> armed.contains(entry.key()));
 			}
 		};
 	}


### PR DESCRIPTION
Fixes https://github.com/ETcodehome/ReTerraForged/issues/118
Fixes #109 
Fixes https://github.com/ETcodehome/ReTerraForged/issues/108

We no longer allow injections into the minecraft namespace to sneak past and cause crashes. Only explicitly handled entries are now permitted to prevent crashes on preview screen.

Galospher Lichen Caves
<img width="2585" height="1381" alt="image" src="https://github.com/user-attachments/assets/886e37a2-37d6-4396-9500-7dfe2f807e2c" />

Galosphere Pink Salt Caves
<img width="2583" height="1385" alt="image" src="https://github.com/user-attachments/assets/33a860ce-a6a4-4d64-b9bb-019fc4b8a675" />

Spell Engine
<img width="3840" height="2100" alt="image" src="https://github.com/user-attachments/assets/92f17cf4-b086-4476-b55a-15d88053e806" />

Mega Showdown
<img width="3840" height="2100" alt="image" src="https://github.com/user-attachments/assets/1e96068a-97b6-4ac3-ab54-9cc117d0b186" />

Tested that other structures continue to be correctly spawned. Gravestone warning and explicit namespace handling doesn't seem required on reflection.