### PR TITLE
Better river scales

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinSurfaceSystem.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinSurfaceSystem.java
@@ -98,7 +98,13 @@ class MixinSurfaceSystem {
 				int scaledY = levels.scale(cell.height);
 
 				if (isWaterCell) {
-					int waterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanLevel);
+					int waterY = levels.scale(
+							(ContinentalHydrology.getComplexWaterHeight(
+									cell.waterTable,
+									cell.globalContinentScale,
+									cell.continentSizeModifier)
+							) + oceanLevel
+					);
 
 					if (waterY < levels.scale(levels.water)) waterY = levels.scale(levels.water);
 
@@ -122,7 +128,14 @@ class MixinSurfaceSystem {
 							// Only consider the neighbor's water height if it is actually a water cell
 							boolean nIsWaterCell = (neighborCell.terrain.isRiver() || neighborCell.terrain.isLake() || neighborCell.terrain.isWetland()) && neighborCell.riverWaterLevel > 0;
 							if (nIsWaterCell) {
-								int nWaterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + levels.water);
+								int nWaterY = levels.scale(
+										(ContinentalHydrology.getComplexWaterHeight(
+												neighborCell.waterTable,
+												neighborCell.globalContinentScale,
+												neighborCell.continentSizeModifier)
+										) + levels.water
+								);
+
 								if (nWaterY < levels.scale(levels.water)) nWaterY = levels.scale(levels.water);
 
 								if (nWaterY < waterY) {
@@ -184,7 +197,6 @@ class MixinSurfaceSystem {
 
 						// GASKET LOGIC: Soft fade using riverMask
 						int maxNeighborWaterY = scaledY;
-						float maxRiverMask = 0.0F;
 
 						// Check neighbors for water and record the strongest mask influence
 						int[] dx = {0, 0, 1, -1};
@@ -197,16 +209,29 @@ class MixinSurfaceSystem {
 							var neighborCell = neighborReader.getCell(nx & 0xF, nz & 0xF);
 
 							if ((neighborCell.terrain.isRiver() || neighborCell.terrain.isLake())) {
-								int nWaterY = levels.scale(ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable) + oceanLevel);
+								int nWaterY = levels.scale(
+									(ContinentalHydrology.getComplexWaterHeight(
+											neighborCell.waterTable,
+											neighborCell.globalContinentScale,
+											neighborCell.continentSizeModifier)
+									) + oceanLevel
+								);
+
 								if (nWaterY > maxNeighborWaterY) {
 									maxNeighborWaterY = nWaterY;
-									maxRiverMask = neighborCell.riverMask; // Capture the mask strength
 								}
 							}
 						}
 
 						// If in river zone and lower than water table, we shouldn't be.
-						int waterTableCeil = levels.scale(ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanLevel);
+						int waterTableCeil = levels.scale(
+							(ContinentalHydrology.getComplexWaterHeight(
+									cell.waterTable,
+									cell.globalContinentScale,
+									cell.continentSizeModifier)
+								) + oceanLevel
+							);
+
 						boolean isInRiverZone = cell.riverZone == RiverCarverSettings.RiverZone.Banks
 								|| cell.riverZone == RiverCarverSettings.RiverZone.ValleyFloor
 								|| cell.riverZone == RiverCarverSettings.RiverZone.ValleyFadeout;

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
@@ -43,6 +43,7 @@ public class Cell {
     public float riverWaterLevel = 0.0F;
     public int continentX;
     public int continentZ;
+    public float globalContinentScale;
     public boolean erosionMask;
     public Terrain terrain;
     public BiomeType biome;
@@ -98,6 +99,7 @@ public class Cell {
         this.riverWaterLevel = other.riverWaterLevel;
         this.riverZone = other.riverZone;
         this.waterTable = other.waterTable;
+        this.globalContinentScale = other.globalContinentScale;
     }
 
     public Cell reset() {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/continent/uplift/UpliftContinentGenerator.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/continent/uplift/UpliftContinentGenerator.java
@@ -29,10 +29,13 @@ public class UpliftContinentGenerator extends AbstractContinent implements Simpl
     protected Noise bayNoise;
     protected Levels levels;
 
+    protected WorldSettings.Continent continentSettings;
+
     public UpliftContinentGenerator(Seed seed, GeneratorContext context) {
         super(seed, context);
         WorldSettings settings = context.preset.world();
         int tectonicScale = settings.continent.continentScale * 4;
+        this.continentSettings = settings.continent;
         this.frequency = 1.0F / tectonicScale;
         this.varianceSeed = seed.next();
         this.variance = settings.continent.continentSizeVariance;
@@ -336,7 +339,7 @@ public class UpliftContinentGenerator extends AbstractContinent implements Simpl
         );
     }
 
-    protected float getContinentSizeModifier(int cellX, int cellY){
+    public float getContinentSizeModifier(int cellX, int cellY){
         if (this.variance > 0.0f && !this.isDefaultContinent(cellX, cellY)) {
             float sizeValue = AbstractContinent.getCellValue(this.varianceSeed, cellX, cellY);
             float sizeModifier = NoiseUtil.map(sizeValue, 0.0f, this.variance, this.variance);

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/heightmap/Heightmap.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/heightmap/Heightmap.java
@@ -138,7 +138,12 @@ public record Heightmap(CellPopulator terrain, CellPopulator region, Continent c
 
         CellPopulator terrain = new ContinentLerper2(oceans, (cell, x, z) -> {
             land.apply(cell, x, z);
-            cell.height += (ContinentalHydrology.getWeightedWaterHeight(cell.waterTable));
+            cell.globalContinentScale = world.continent.continentScale;
+            cell.height += (ContinentalHydrology.getComplexWaterHeight(
+                    cell.waterTable,
+                    cell.globalContinentScale,
+                    cell.continentSizeModifier)
+            );
         }, controlPoints.shallowOcean, controlPoints.inland);
         
         // Wrap with archipelago layer if enabled

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/ContinentalHydrology.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/ContinentalHydrology.java
@@ -128,8 +128,11 @@ public class ContinentalHydrology {
         return fixedCurvedStep(continentEdge);
     }
 
-    public static float getWeightedWaterHeight(float inlandPercentage) {
-        return getTargetWaterHeight(inlandPercentage) * 0.50F;
+    public static float getComplexWaterHeight(float waterTableBaseGradient, float globalContinentScale, float thisContinentScale) {
+        return getTargetWaterHeight(waterTableBaseGradient) // base gradient strength input
+                * (globalContinentScale / 4000.0F) // scale uplift based on continent width
+                * (thisContinentScale / 1.0F) // obey per continent jitter
+                * 0.50F; // base uplift
     }
 
     public static float getFlatnessFactor(double x) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -134,7 +134,13 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float zone3Width = zone3BaseWidth * shrinkFactor;
         float zone3Radius = zone2Radius + zone3Width;
 
-        float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + levels.water;
+        float targetWaterLevel =
+            (ContinentalHydrology.getComplexWaterHeight(
+                    cell.waterTable,
+                    cell.globalContinentScale,
+                    cell.continentSizeModifier)
+            ) + levels.water;
+
         float discrepancyScale = 1.0F + (levels.scale(cell.height - targetWaterLevel)) / 100.0F;
         float zone4Radius = zone3Radius + (unshrunkZone3BaseWidth * (4.0F + discrepancyScale));
 

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -104,8 +104,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float currentLinearDist = (float) Math.sqrt(distSqToCurr);
         float flatnessInput = isUpliftContinent ? cell.waterTable : currT;
         float flatnessFactor = NoiseUtil.clamp(ContinentalHydrology.getFlatnessFactor(flatnessInput), 0.0F, 1.0F);
-        float scaleFactor = 1.0F + 0.75F * flatnessFactor;
-        float sqScaleFactor = scaleFactor * scaleFactor;
+        float scaleFactor = 1.0F;
 
         // Step 1: Sample ONLY layout-critical noise arrays to determine structural boundaries
         float widthVar = this.widthNoise.compute(currX, currZ, 8241);
@@ -113,7 +112,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float valleyPinchVar = this.valleyPinchNoise.compute(currX, currZ, 6204) * 2.0F;
 
         // Always run mask logic to ensure clean falloffs
-        updateValleyMask(prevX, prevZ, prevT, currT, distSqToCurr, sqScaleFactor, cell);
+        updateValleyMask(prevX, prevZ, prevT, currT, distSqToCurr, scaleFactor, cell);
 
         // Compute layout parameters
         float dynamicWidthMult = 1.0F + (widthVar * 0.35F);
@@ -121,7 +120,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         float valleyPinchMultiplier = NoiseUtil.clamp(1.0F + valleyPinchVar, 0.05F, 1.95F);
 
         // Zone radius calculations
-        float biasedScale = sqScaleFactor * dynamicWidthMult * sideBias;
+        float biasedScale = scaleFactor * dynamicWidthMult * sideBias;
         float zone1Radius = (float) Math.sqrt(this.getScaledSize(currT, this.bedWidth) * biasedScale);
         float lakeMultiplier = getLakeMultiplier(cell, currT, currX, currZ, flatnessFactor);
         zone1Radius *= lakeMultiplier;
@@ -172,7 +171,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         // Calculate the final cell heights
         float finalHeight = cell.height;
         if (currentLinearDist < zone1Radius) {
-            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, sqScaleFactor, targetWaterLevel, lakeMultiplier, flatnessFactor, depthVar);
+            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, scaleFactor, targetWaterLevel, lakeMultiplier, flatnessFactor, depthVar);
         } else if (currentLinearDist < zone2Radius) {
             finalHeight = carveZone2BankStep(currentLinearDist, zone1Radius, zone2Radius, targetWaterLevel, actualValleyFloorHeight, terraceMask, drainageMask);
         } else if (currentLinearDist < zone3Radius) {
@@ -425,8 +424,14 @@ public class UpliftRiverCarver implements RTFRiverCarver {
     }
 
     private float getDistanceAlpha(float t, float dist2, Range range, float sqScaleFactor) {
+
+
         float size2 = this.getScaledSize(t, range) * sqScaleFactor;
+
+        // fade is beyond area of maximum influence
         if (dist2 >= size2) return 0.0F;
+
+        // return a gradient between 1.0 (at the exact center) and 0.0 (right at the edge).
         return 1.0F - dist2 / size2;
     }
 

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -1,6 +1,5 @@
 package raccoonman.reterraforged.world.worldgen.cell.rivermap.river;
 
-import java.util.Random;
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
@@ -38,6 +37,11 @@ public class UpliftRiverCarver implements RTFRiverCarver {
     private Noise lakeWarpNoise;
     public LakeConfig lakeConfig;
     private boolean isUpliftContinent;
+
+    // Precomputed immutable constants to alleviate CPU overhead per cell
+    private final float bankHeightOffset;
+    private final float baseBedDepthOffset;
+    private final float zone2WidthFactor;
 
     public UpliftRiverCarver(River river, RiverWarp warp, RiverConfig config, RiverCarverSettings settings, Levels levels, LakeConfig lakeConfig, boolean isUpliftContinent) {
         this.fade = settings.fadeIn;
@@ -85,76 +89,81 @@ public class UpliftRiverCarver implements RTFRiverCarver {
 
         this.lakeConfig = lakeConfig;
         this.isUpliftContinent = isUpliftContinent;
+
+        // Calculate constants once during instantiation
+        this.bankHeightOffset = config.maxBankHeight - config.minBankHeight;
+        this.baseBedDepthOffset = levels.water - config.bedHeight;
+        this.zone2WidthFactor = this.bankHeightOffset / levels.unit;
     }
 
     @Override
     public void carve(Cell cell, float prevX, float prevZ, float prevT, float currX, float currZ, float currT) {
 
-        // fixed reference values
+        // Fixed reference values
         float distSqToCurr = this.getDistance2(currX, currZ, currT);
         float currentLinearDist = (float) Math.sqrt(distSqToCurr);
-        float shrinkFactor = NoiseUtil.clamp(currT * this.fadeInv, 0.0F, 1.0F);
         float flatnessInput = isUpliftContinent ? cell.waterTable : currT;
         float flatnessFactor = NoiseUtil.clamp(ContinentalHydrology.getFlatnessFactor(flatnessInput), 0.0F, 1.0F);
         float scaleFactor = 1.0F + 0.75F * flatnessFactor;
         float sqScaleFactor = scaleFactor * scaleFactor;
 
-        // noise sampling
+        // Step 1: Sample ONLY layout-critical noise arrays to determine structural boundaries
         float widthVar = this.widthNoise.compute(currX, currZ, 8241);
-        float depthVar = this.depthNoise.compute(currX, currZ, 3912);
-        float terraceMask = this.terraceNoise.compute(currX, currZ, 5510);
         float asymmetry = this.asymmetryNoise.compute(currX, currZ, 1193);
         float valleyPinchVar = this.valleyPinchNoise.compute(currX, currZ, 6204) * 2.0F;
 
-        // always run mask logic to ensure clean falloffs
+        // Always run mask logic to ensure clean falloffs
         updateValleyMask(prevX, prevZ, prevT, currT, distSqToCurr, sqScaleFactor, cell);
 
-        // drainage falloffs
-        float gullyRaw = this.gullyNoise.compute(currX, currZ, 9876);
-        float gullyShape = 1.0F - Math.abs(gullyRaw);
-        gullyShape *= gullyShape;
-        float rivuletRaw = this.rivuletNoise.compute(currX, currZ, 5432);
-        float rivuletShape = 1.0F - Math.abs(rivuletRaw);
-        rivuletShape = rivuletShape * rivuletShape * rivuletShape;
-        float drainageMask = (gullyShape * 0.7F) + (rivuletShape * 0.3F);
-
-        // width falloffs
+        // Compute layout parameters
         float dynamicWidthMult = 1.0F + (widthVar * 0.35F);
-        float dynamicDepthMult = 1.0F + (depthVar * 0.25F);
         float sideBias = 1.0F + (asymmetry * 0.4F);
         float valleyPinchMultiplier = NoiseUtil.clamp(1.0F + valleyPinchVar, 0.05F, 1.95F);
 
-        // target elevations
-        float oceanHeightOffset = levels.water;
-        float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanHeightOffset;
-        float baseBedDepthOffset = oceanHeightOffset - config.bedHeight;
-        float bedDepthOffset = baseBedDepthOffset * dynamicDepthMult;
-        float bankHeightOffset = (config.maxBankHeight - config.minBankHeight);
-        float targetValleyFloor = targetWaterLevel + bankHeightOffset;
-        float discrepancyScale = 1.0F + (levels.scale(cell.height - targetWaterLevel)) / 100.0F;
-        float valleyFloorBumpiness = ((terraceMask * 0.4F) - (drainageMask * 0.6F)) * this.levels.unit;
-        float actualValleyFloorHeight = targetValleyFloor + valleyFloorBumpiness;
-
-        // Zone calculations
+        // Zone radius calculations
         float biasedScale = sqScaleFactor * dynamicWidthMult * sideBias;
         float zone1Radius = (float) Math.sqrt(this.getScaledSize(currT, this.bedWidth) * biasedScale);
         float lakeMultiplier = getLakeMultiplier(cell, currT, currX, currZ, flatnessFactor);
         zone1Radius *= lakeMultiplier;
-        float zone2Width = (config.maxBankHeight - config.minBankHeight) / this.levels.unit * biasedScale;
+
+        float zone2Width = this.zone2WidthFactor * biasedScale;
         float zone2Radius = zone1Radius + zone2Width;
         float unshrunkZone3BaseWidth = config.bankWidth * dynamicWidthMult * valleyPinchMultiplier;
+        float shrinkFactor = NoiseUtil.clamp(currT * this.fadeInv, 0.0F, 1.0F);
         float zone3BaseWidth = unshrunkZone3BaseWidth * shrinkFactor;
         float zone3Width = zone3BaseWidth * shrinkFactor;
         float zone3Radius = zone2Radius + zone3Width;
-        float zone4Radius = zone3Radius + (unshrunkZone3BaseWidth * (4 + discrepancyScale));
 
-        // early exit guard if we're a cell outside the river influence
+        float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + levels.water;
+        float discrepancyScale = 1.0F + (levels.scale(cell.height - targetWaterLevel)) / 100.0F;
+        float zone4Radius = zone3Radius + (unshrunkZone3BaseWidth * (4.0F + discrepancyScale));
+
+        // Step 2: Early Exit Guard. If outside the maximum radius, skip the remaining expensive operations
         if (currentLinearDist >= zone4Radius) return;
 
-        // calculate the final cell heights
+        // Step 3: Defer remaining heavy noise evaluations until we are guaranteed to modify the cell
+        float depthVar = this.depthNoise.compute(currX, currZ, 3912);
+        float terraceMask = this.terraceNoise.compute(currX, currZ, 5510);
+        float gullyRaw = this.gullyNoise.compute(currX, currZ, 9876);
+        float rivuletRaw = this.rivuletNoise.compute(currX, currZ, 5432);
+
+        // Drainage calculation adjustments
+        float gullyShape = 1.0F - Math.abs(gullyRaw);
+        gullyShape *= gullyShape;
+        float rivuletShape = 1.0F - Math.abs(rivuletRaw);
+        rivuletShape = rivuletShape * rivuletShape * rivuletShape;
+        float drainageMask = (gullyShape * 0.7F) + (rivuletShape * 0.3F);
+
+        float dynamicDepthMult = 1.0F + (depthVar * 0.25F);
+        float bedDepthOffset = this.baseBedDepthOffset * dynamicDepthMult;
+        float targetValleyFloor = targetWaterLevel + this.bankHeightOffset;
+        float valleyFloorBumpiness = ((terraceMask * 0.4F) - (drainageMask * 0.6F)) * this.levels.unit;
+        float actualValleyFloorHeight = targetValleyFloor + valleyFloorBumpiness;
+
+        // Calculate the final cell heights
         float finalHeight = cell.height;
         if (currentLinearDist < zone1Radius) {
-            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, oceanHeightOffset, sqScaleFactor, targetWaterLevel, lakeMultiplier);
+            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, levels.water, sqScaleFactor, targetWaterLevel, lakeMultiplier);
         } else if (currentLinearDist < zone2Radius) {
             finalHeight = carveZone2BankStep(currentLinearDist, zone1Radius, zone2Radius, targetWaterLevel, actualValleyFloorHeight, terraceMask, drainageMask);
         } else if (currentLinearDist < zone3Radius) {
@@ -216,7 +225,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
             distanceMask = distanceMask * distanceMask * (3.0F - 2.0F * distanceMask);
             widenMultiplier = 1.0F + (flatnessFactor * organicWarpFactor * distanceMask);
         }
-        return widenMultiplier; // no op
+        return widenMultiplier;
     }
 
     private float carveZone1Riverbed(Cell cell, float currT, float distSqToCurr, float bedDepthOffset, float oceanHeightOffset, float sqScaleFactor, float targetWaterLevel, float widenMultiplier) {
@@ -330,8 +339,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
 
         riverSeed ^= plateauIndex * 0x5DEECE66DL;
 
-        Random selectionRand = new Random(riverSeed);
-        return selectionRand.nextFloat() < config.chance;
+        return getDeterministicFloat(riverSeed) < config.chance;
     }
 
     private float getLakeScaleForPlateau(int plateauIndex, float minScale, float maxScale) {
@@ -341,8 +349,21 @@ public class UpliftRiverCarver implements RTFRiverCarver {
 
         riverSeed ^= plateauIndex * 0x2545F4914L;
 
-        Random scaleRand = new Random(riverSeed);
-        return minScale + scaleRand.nextFloat() * (maxScale - minScale);
+        return minScale + getDeterministicFloat(riverSeed) * (maxScale - minScale);
+    }
+
+    /**
+     * A stateless, high-quality mixing hash function that maps a long seed
+     * to a pseudo-random uniform float in the range [0.0f, 1.0f).
+     * Eliminates object allocation completely.
+     */
+    private static float getDeterministicFloat(long seed) {
+        seed ^= (seed >>> 33);
+        seed *= 0xff51afd7ed558ccdL;
+        seed ^= (seed >>> 33);
+        seed *= 0xc4ceb9fe1a85ec53L;
+        seed ^= (seed >>> 33);
+        return (float) (seed & 0xFFFFFF) / 16777216.0F;
     }
 
     @Override

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/river/UpliftRiverCarver.java
@@ -154,8 +154,11 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         rivuletShape = rivuletShape * rivuletShape * rivuletShape;
         float drainageMask = (gullyShape * 0.7F) + (rivuletShape * 0.3F);
 
+        // Calculate dynamic depth multiplier and apply downstream depth progression logic
         float dynamicDepthMult = 1.0F + (depthVar * 0.25F);
-        float bedDepthOffset = this.baseBedDepthOffset * dynamicDepthMult;
+        float depthProgress = NoiseUtil.clamp(currT, 0.0F, 1.0F);
+        float bedDepthOffset = this.baseBedDepthOffset * dynamicDepthMult * depthProgress;
+
         float targetValleyFloor = targetWaterLevel + this.bankHeightOffset;
         float valleyFloorBumpiness = ((terraceMask * 0.4F) - (drainageMask * 0.6F)) * this.levels.unit;
         float actualValleyFloorHeight = targetValleyFloor + valleyFloorBumpiness;
@@ -163,7 +166,7 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         // Calculate the final cell heights
         float finalHeight = cell.height;
         if (currentLinearDist < zone1Radius) {
-            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, levels.water, sqScaleFactor, targetWaterLevel, lakeMultiplier);
+            finalHeight = carveZone1Riverbed(cell, currT, distSqToCurr, bedDepthOffset, sqScaleFactor, targetWaterLevel, lakeMultiplier, flatnessFactor, depthVar);
         } else if (currentLinearDist < zone2Radius) {
             finalHeight = carveZone2BankStep(currentLinearDist, zone1Radius, zone2Radius, targetWaterLevel, actualValleyFloorHeight, terraceMask, drainageMask);
         } else if (currentLinearDist < zone3Radius) {
@@ -228,15 +231,45 @@ public class UpliftRiverCarver implements RTFRiverCarver {
         return widenMultiplier;
     }
 
-    private float carveZone1Riverbed(Cell cell, float currT, float distSqToCurr, float bedDepthOffset, float oceanHeightOffset, float sqScaleFactor, float targetWaterLevel, float widenMultiplier) {
+    private float carveZone1Riverbed(Cell cell, float currT, float distSqToCurr, float bedDepthOffset, float sqScaleFactor, float targetWaterLevel, float widenMultiplier, float flatnessFactor, float depthVar) {
         float effectiveScaleFactor = sqScaleFactor * (widenMultiplier * widenMultiplier);
         float bedInfluence = this.getDistanceAlpha(currT, distSqToCurr, this.bedWidth, effectiveScaleFactor);
         bedInfluence = bedInfluence * bedInfluence * (3.0F - 2.0F * bedInfluence);
 
-        float lakeDepthMulti = 0.35F + (lakeConfig.depth / 50.0F);
-        float dynamicDepthOffset = bedDepthOffset * (1.0F + (widenMultiplier - 1.0F) * lakeDepthMulti);
+        // 1. Establish a baseline floor that naturally undulates between ~2.0 and ~2.6 blocks.
+        // This ensures headwaters and shallows have organic ripples/sandbars instead of a flat sheet.
+        float shallowNoiseFloor = (2.3F + (depthVar * 0.3F)) * this.levels.unit;
 
-        float bedHeight = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) - (dynamicDepthOffset * bedInfluence) + oceanHeightOffset;
+        // 2. Base deep-water capability (driven by downstream progress)
+        float progressiveDepth = bedDepthOffset;
+
+        // Repurpose depth noise to ensure lake basins break out of uniform parameters natively
+        if (widenMultiplier > 1.0F) {
+            float lakeDepthMulti = 0.35F + (lakeConfig.depth / 50.0F);
+            float lakeVariance = 1.0F + (depthVar * 0.40F);
+            progressiveDepth = progressiveDepth * (1.0F + (widenMultiplier - 1.0F) * lakeDepthMulti * lakeVariance);
+        }
+
+        // 3. Combine the base floor with progressive depth, scaled by the regional flatness.
+        // Low flatness = channel is compacted tightly against our textured shallow floor.
+        // High flatness = channel expands deeply away from the baseline.
+        float finalizedDepth = shallowNoiseFloor + (progressiveDepth * flatnessFactor);
+
+        // 4. Inject structural deep-pocket trenches specifically when flatness factor is high
+        if (flatnessFactor > 0.4F) {
+            float flatnessIntensity = (flatnessFactor - 0.4F) / 0.6F;
+            float trenchNoise = (depthVar * 0.5F + 0.5F); // Map signed noise safely to [0.0, 1.0]
+            float deepPocketBonus = flatnessIntensity * trenchNoise * 3.5F * this.levels.unit * currT;
+            finalizedDepth += deepPocketBonus;
+        }
+
+        // Hard protective structural guard to catch extreme negative noise spikes
+        float absoluteFloor = 2.0F * this.levels.unit;
+        if (finalizedDepth < absoluteFloor) {
+            finalizedDepth = absoluteFloor;
+        }
+
+        float bedHeight = targetWaterLevel - (finalizedDepth * bedInfluence);
 
         cell.moisture = 1.0F;
         this.tag(cell, targetWaterLevel);

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/wetland/Wetland.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/rivermap/wetland/Wetland.java
@@ -47,7 +47,11 @@ public class Wetland {
     public void apply(Cell cell, float rx, float rz, float x, float z) {
 
         // calculate the globally consistent water level at this cell
-        float upliftOffset = (ContinentalHydrology.getWeightedWaterHeight(cell.waterTable));
+        float upliftOffset = (ContinentalHydrology.getComplexWaterHeight(
+                cell.waterTable,
+                cell.globalContinentScale,
+                cell.continentSizeModifier)
+        );
         float oceanHeightOffset = levels.scale(levels.waterLevel);
         float localWaterSurface = oceanHeightOffset + upliftOffset;
 

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
@@ -80,8 +80,11 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                 );
 
                 float water =
-                        ContinentalHydrology.getWeightedWaterHeight(neighborCell.waterTable)
-                                + oceanHeightOffset;
+                        (ContinentalHydrology.getComplexWaterHeight(
+                                neighborCell.waterTable,
+                                neighborCell.globalContinentScale,
+                                neighborCell.continentSizeModifier)
+                        ) + oceanHeightOffset;
 
                 int waterY = levels.scale(water);
 
@@ -100,7 +103,12 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
 
                 worldLookup.applyCell(cell.reset(), blockX, blockZ, false, false);
 
-                float targetWaterLevel = ContinentalHydrology.getWeightedWaterHeight(cell.waterTable) + oceanHeightOffset;
+                float targetWaterLevel =
+                    (ContinentalHydrology.getComplexWaterHeight(
+                            cell.waterTable,
+                            cell.globalContinentScale,
+                            cell.continentSizeModifier)
+                    ) + oceanHeightOffset;
                 int localWaterY = levels.scale(targetWaterLevel);
                 int currentFloorHeight = levels.scale(cell.height);
 


### PR DESCRIPTION
Fixes uplift being bad on small continents.
Allows uplift to be higher across larger continent scales.

<img width="968" height="556" alt="image" src="https://github.com/user-attachments/assets/11f43bda-7238-47ed-8832-031a323a2501" />

Gradient changes described above
Fixes #115 
Small continents get comparatively small uplifts, and larger continents disproportionately benefit and look much better with the changes.

We also reviewed side by side results for realistic scales and removed the waving making rivers more deterministically sized and reducing gully artifacts tied to flatness factors in https://github.com/ETcodehome/ReTerraForged/pull/126/commits/b4d576ef059c768ed8a4f4eac190253eebf4cd49
which fixes #114 
