### PR TITLE
Bypass structure screen

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/FilterSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/FilterSettingsPage.java
@@ -101,7 +101,7 @@ class FilterSettingsPage extends PresetEditorPage {
 
 	@Override
 	public Optional<Page> next() {
-		return Optional.of(new StructureSettingsPage(this.screen, this.preset));
+		return Optional.of(new MiscellaneousPage(this.screen, this.preset));
 	}
 
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/MiscellaneousPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/MiscellaneousPage.java
@@ -102,7 +102,7 @@ public class MiscellaneousPage extends PresetEditorPage {
 	
 	@Override
 	public Optional<Page> previous() {
-		return Optional.of(new StructureSettingsPage(this.screen, this.preset));
+		return Optional.of(new FilterSettingsPage(this.screen, this.preset));
 	}
 
 	@Override


### PR DESCRIPTION
Structure controls are just outright broken / not implemented.

We ideally don't want to be presenting broken options that players waste their time configuring. Bypassing the settings screen until a longer term decisions is made around structure modification support or a backport from 0.0.7 for the proper structure support happens.