### PR TITLE
Force obvious C2ME compatibility pathway by disabling density function compilation

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinC2MECompilerShield.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinC2MECompilerShield.java
@@ -1,0 +1,24 @@
+package raccoonman.reterraforged.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+@Pseudo
+@Mixin(targets = "com.ishland.c2me.opts.dfc.common.ast.McToAst", remap = false)
+public class MixinC2MECompilerShield {
+
+    @Inject(
+            method = "toAst(Lnet/minecraft/world/level/levelgen/DensityFunction;)Lcom/ishland/c2me/opts/dfc/common/ast/AstNode;",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private static void rtf$abortC2MECompilation(DensityFunction df, CallbackInfoReturnable<Object> cir) {
+        if (df.getClass().getName().startsWith("raccoonman.reterraforged")) {
+            throw new UnsupportedOperationException("C2ME Density Function Compilation is incompatible with ReTerraForged. \nEdit .minecraft\\config\\c2me.toml and set \nuseDensityFunctionCompiler = false");
+        }
+    }
+}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinC2MECompilerShield.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinC2MECompilerShield.java
@@ -18,7 +18,7 @@ public class MixinC2MECompilerShield {
     )
     private static void rtf$abortC2MECompilation(DensityFunction df, CallbackInfoReturnable<Object> cir) {
         if (df.getClass().getName().startsWith("raccoonman.reterraforged")) {
-            throw new UnsupportedOperationException("C2ME Density Function Compilation is incompatible with ReTerraForged. \nEdit .minecraft\\config\\c2me.toml and set \nuseDensityFunctionCompiler = false");
+            throw new UnsupportedOperationException("C2ME Density Function Compilation is incompatible with ReTerraForged. To fix edit .minecraft\\config\\c2me.toml and set useDensityFunctionCompiler = false");
         }
     }
 }

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -23,6 +23,7 @@
 		"MixinImposterProtoChunk",
 		"MixinNoiseBasedChunkGenerator",
 		"MixinFloatyBoaty",
+		"MixinC2MECompilerShield",
 		"BeardifierAccessor",
 		"LevelChunkSectionAccessor",
 		"terrablender.MixinParameterList",


### PR DESCRIPTION
Provides an explicit failure mode on world startup that indicates that C2ME config file changes need to be made to be compatible with ReTerraForged.

<img width="891" height="649" alt="image" src="https://github.com/user-attachments/assets/981aaacf-bc07-44b9-a87e-24d1f50d408d" />

Addresses silent ambiguous failure documented in #91 

I have tried a large (20+) number of more direct Mixin based intercepts and approaches but have been unable to successfully prevent dfc compilation such that worlds dont end up having their interpolation murdered. I even tried direct overwrites of settings and things but I've come back to this as most reasonable approach I've currently got for highlighting and addressing the issue. 