### PR TITLE
Fix Spawn Selector

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -82,6 +82,11 @@ public class Preview2D extends Button {
                     props.spawnType = SpawnType.USER_SELECTED;
                     props.spawnX = self.hoveredCoordX;
                     props.spawnZ = self.hoveredCoordZ;
+
+                    if (self.page instanceof WorldSettingsPage worldPage) {
+                        worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
+                    }
+
                     self.page.regenerate();
                 }
             }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -91,6 +91,11 @@ public class Preview3D extends Button {
                     props.spawnType = SpawnType.USER_SELECTED;
                     props.spawnX = self.hoveredCoordX;
                     props.spawnZ = self.hoveredCoordZ;
+
+                    if (self.page instanceof WorldSettingsPage worldPage) {
+                        worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
+                    }
+
                     self.page.regenerate();
                 }
             }


### PR DESCRIPTION
When you clicked a 2d or 3d preview while not in the user selected state the internal state would correctly change but the value on the button would not update correctly to user selected. This change fixes that.