### PR TITLE
Improve world height truncation visibility

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -177,6 +177,8 @@ public class Preview2D extends Button {
                                 int color;
                                 if (bx < stroke || bz < stroke || bx >= tileWidth - stroke || bz >= tileWidth - stroke) {
                                     color = 0xFF000000; // Opaque Black
+                                } else if (levels.scale(cell.height) > properties.worldHeight) {
+                                    color = 0xFFFF00FF; // Missing asset purple (#FF00FF)
                                 } else {
                                     color = mode.getColor(cell, levels);
                                 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -239,30 +239,38 @@ public class Preview3D extends Button {
         float heightScale = getHeightScale((float) blockW);
         int halfTile = tileSize / 2;
 
+        float maxCellHeight = properties.worldHeight * levels.unit;
+
         for (int iz = 0; iz < tileSize; iz++) {
             for (int ix = 0; ix < tileSize; ix++) {
                 Cell cell = activeTile.lookup(ix, iz);
-                int color = mode.getColor(cell, levels);
+
+                // Clamp the geometry height if it exceeds world height boundaries
+                float effectiveHeight = cell.height;
+                int color;
+                if (levels.scale(cell.height) > properties.worldHeight) {
+                    color = 0xFFFF00FF; // Missing asset purple (#FF00FF)
+                    effectiveHeight = maxCellHeight;
+                } else {
+                    color = mode.getColor(cell, levels);
+                }
 
                 int r = (color >> 16) & 0xFF;
                 int g = (color >> 8) & 0xFF;
                 int b = color & 0xFF;
-
                 Color.RGBtoHSB(r, g, b, this.hsbCache);
 
                 int hash = ix * 31 + iz * 17;
                 float jitter = ((hash % 100) / 100.0f) * 0.06f - 0.03f;
-
                 this.hsbCache[2] = Math.max(0.0f, Math.min(1.0f, this.hsbCache[2] + jitter));
-
                 int jitteredColor = (color & 0xFF000000) | (Color.HSBtoRGB(this.hsbCache[0], this.hsbCache[1], this.hsbCache[2]) & 0x00FFFFFF);
-
                 int dx = ix - halfTile;
                 int dz = iz - halfTile;
-
                 int isoX = centerVisualX + (dx - dz) * halfW;
                 int isoY = centerVisualY + (dx + dz) * halfH;
-                int renderY = isoY - Math.round(cell.height * heightScale);
+
+                // We use effectiveHeight instead of cell.height to show when world height limits are truncating peaks
+                int renderY = isoY - Math.round(effectiveHeight * heightScale);
 
                 int topColor = jitteredColor;
                 int leftColor = getSideColor(jitteredColor, 0.75f, true, ix, iz, tileSize);


### PR DESCRIPTION
Previews currently don't make it obvious when world heights are being exceeded. This PR fixes that by transforming all height breaking cells into the standard "missing asset purple" that is commonly used to visually indicate problems in software.

The intent is to make it easier for laymans to more consistently spot when world generation values exceed the limits of the currently configured world height.

truncated mountain range closeup:
<img width="1179" height="1182" alt="image" src="https://github.com/user-attachments/assets/347c934e-7e1b-4e27-8bd7-464f244aea81" />

preview example showing broken height configs:
<img width="3840" height="2100" alt="image" src="https://github.com/user-attachments/assets/8a85e0f2-d885-4887-b536-64f9ede0ad09" />



