### PR TITLE
Add navigable previews + small fixes

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -60,7 +60,8 @@ public class Preview2D extends Button {
             Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_SPAWN)
     };
 
-    private int offsetX, offsetZ;
+    static int globalOffsetX, globalOffsetZ;
+    static boolean globalNavigated = false;
 
     private CompletableFuture<FrameResult> pendingGeneration = null;
 
@@ -87,6 +88,7 @@ public class Preview2D extends Button {
                         worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
                     }
 
+                    self.globalNavigated = false;
                     self.page.regenerate();
                 }
             }
@@ -133,8 +135,9 @@ public class Preview2D extends Button {
 
         int seed = (int) settings.options().seed();
         int zoomLevel = this.getZoom();
-        int localOffsetX = this.offsetX;
-        int localOffsetZ = this.offsetZ;
+        int localOffsetX = this.globalOffsetX;
+        int localOffsetZ = this.globalOffsetZ;
+        boolean localNavigated = this.globalNavigated;
         RenderMode mode = this.page.renderMode2D.getValue();
         Levels levels = new Levels(properties.terrainScaler(), properties.seaLevel);
 
@@ -150,16 +153,27 @@ public class Preview2D extends Button {
                     .orElseGet(PerformanceConfig::makeDefault);
 
             GeneratorContext generatorContext = GeneratorContext.makeUncached(presetObj, noises, seed, FACTOR, 0, config.batchCount());
+            if (properties.spawnType == SpawnType.CONTINENT_CENTER) {
+                long baseContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(0, 0);
+                properties.spawnX = PosUtil.unpackLeft(baseContinentCenter);
+                properties.spawnZ = PosUtil.unpackRight(baseContinentCenter);
+            }
 
             int cx = 0;
             int cz = 0;
+
+            // Generalize coordinate selection for all spawn types
             if (presetObj.world().properties.spawnType == SpawnType.CONTINENT_CENTER) {
-                long nearestContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(localOffsetX, localOffsetZ);
+                long nearestContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(
+                        localNavigated ? localOffsetX : 0,
+                        localNavigated ? localOffsetZ : 0
+                );
                 cx = PosUtil.unpackLeft(nearestContinentCenter);
                 cz = PosUtil.unpackRight(nearestContinentCenter);
-            } else if (presetObj.world().properties.spawnType == SpawnType.USER_SELECTED) {
-                cx = presetObj.world().properties.spawnX;
-                cz = presetObj.world().properties.spawnZ;
+            } else {
+                // If navigated, center on the clicked spot; otherwise fallback to spawn values or origin depending on type
+                cx = localNavigated ? localOffsetX : (presetObj.world().properties.spawnType == SpawnType.USER_SELECTED ? presetObj.world().properties.spawnX : 0);
+                cz = localNavigated ? localOffsetZ : (presetObj.world().properties.spawnType == SpawnType.USER_SELECTED ? presetObj.world().properties.spawnZ : 0);
             }
 
             return new PreGenContext(generatorContext, cx, cz, zoomLevel);
@@ -245,6 +259,35 @@ public class Preview2D extends Button {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (this.isMouseOver(mouseX, mouseY)) {
+            // Right Click: Navigate to specific coordinates
+            if (button == 1) {
+                if (this.updateLegend((int) mouseX, (int) mouseY) && !this.hoveredCoords.isEmpty()) {
+                    this.playDownSound(Minecraft.getInstance().getSoundManager());
+
+                    WorldSettings.Properties props = this.page.preset.getPreset().world().properties;
+                    if (props.spawnType == SpawnType.CONTINENT_CENTER) {
+                        props.spawnType = SpawnType.USER_SELECTED;
+                        if (this.page instanceof WorldSettingsPage worldPage) {
+                            worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
+                        }
+                    }
+
+                    Preview2D.globalOffsetX = this.hoveredCoordX;
+                    Preview2D.globalOffsetZ = this.hoveredCoordZ;
+                    Preview2D.globalNavigated = true;
+                    this.regenerate();
+                    return true;
+                }
+            }
+            // Middle Click: Reset to current spawn coordinates
+            else if (button == 2) {
+                this.playDownSound(Minecraft.getInstance().getSoundManager());
+                Preview2D.globalNavigated = false;
+                this.regenerate();
+                return true;
+            }
+        }
         return super.mouseClicked(mouseX, mouseY, button);
     }
 

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -60,8 +60,6 @@ public class Preview3D extends Button {
             Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_SPAWN)
     };
 
-    private int offsetX, offsetZ;
-
     private DynamicTexture textureCache;
     private ResourceLocation cacheLocation;
     private boolean needsTextureRefresh = false;
@@ -96,6 +94,7 @@ public class Preview3D extends Button {
                         worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
                     }
 
+                    Preview2D.globalNavigated = false;
                     self.page.regenerate();
                 }
             }
@@ -128,8 +127,9 @@ public class Preview3D extends Button {
 
         int seed = (int) settings.options().seed();
         int zoomLevel = this.getZoom();
-        int localOffsetX = this.offsetX;
-        int localOffsetZ = this.offsetZ;
+        int localOffsetX = Preview2D.globalOffsetX;
+        int localOffsetZ = Preview2D.globalOffsetZ;
+        boolean localNavigated = Preview2D.globalNavigated;
 
         // Step 1: Offload disk IO and heavy context calculations to background executor
         CompletableFuture<PreGenContext> setupStage = CompletableFuture.supplyAsync(() -> {
@@ -143,16 +143,28 @@ public class Preview3D extends Button {
                     .orElseGet(PerformanceConfig::makeDefault);
 
             GeneratorContext generatorContext = GeneratorContext.makeUncached(currentPreset, noises, seed, FACTOR, 0, config.batchCount());
+            WorldSettings.Properties properties = currentPreset.world().properties;
+            if (properties.spawnType == SpawnType.CONTINENT_CENTER) {
+                long baseContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(0, 0);
+                properties.spawnX = PosUtil.unpackLeft(baseContinentCenter);
+                properties.spawnZ = PosUtil.unpackRight(baseContinentCenter);
+            }
 
             int cx = 0;
             int cz = 0;
+
+            // Generalize coordinate selection for all spawn types
             if (currentPreset.world().properties.spawnType == SpawnType.CONTINENT_CENTER) {
-                long nearestContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(localOffsetX, localOffsetZ);
+                long nearestContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(
+                        localNavigated ? localOffsetX : 0,
+                        localNavigated ? localOffsetZ : 0
+                );
                 cx = PosUtil.unpackLeft(nearestContinentCenter);
                 cz = PosUtil.unpackRight(nearestContinentCenter);
-            } else if (currentPreset.world().properties.spawnType == SpawnType.USER_SELECTED) {
-                cx = currentPreset.world().properties.spawnX;
-                cz = currentPreset.world().properties.spawnZ;
+            } else {
+                // If navigated, center on the clicked spot; otherwise fallback to spawn values or origin depending on type
+                cx = localNavigated ? localOffsetX : (currentPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? currentPreset.world().properties.spawnX : 0);
+                cz = localNavigated ? localOffsetZ : (currentPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? currentPreset.world().properties.spawnZ : 0);
             }
 
             return new PreGenContext(generatorContext, cx, cz, zoomLevel);
@@ -327,6 +339,39 @@ public class Preview3D extends Button {
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (this.isMouseOver(mouseX, mouseY)) {
+
+            // Right Click: Navigate to specific coordinates
+            if (button == 1) {
+                if (this.updateLegend((int) mouseX, (int) mouseY) && !this.hoveredCoords.isEmpty()) {
+                    this.playDownSound(Minecraft.getInstance().getSoundManager());
+
+                    WorldSettings.Properties props = this.page.preset.getPreset().world().properties;
+                    if (props.spawnType == SpawnType.CONTINENT_CENTER) {
+                        props.spawnType = SpawnType.USER_SELECTED;
+                        if (this.page instanceof WorldSettingsPage worldPage) {
+                            worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
+                        }
+                    }
+
+                    Preview2D.globalOffsetX = this.hoveredCoordX;
+                    Preview2D.globalOffsetZ = this.hoveredCoordZ;
+                    Preview2D.globalNavigated = true;
+                    this.regenerate();
+                    return true;
+                }
+            }
+
+            // Middle Click: Reset to current spawn coordinates
+            else if (button == 2) {
+                this.playDownSound(Minecraft.getInstance().getSoundManager());
+                Preview2D.globalNavigated = false;
+                this.regenerate();
+                return true;
+            }
+        }
+
+        // Left click set spawn coords
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
@@ -430,7 +475,7 @@ public class Preview3D extends Button {
                     int markerY = isoY + halfH;
 
                     int size = 6;
-                    int color = 0xFFFF2222;
+                    int color = 0xFFFFFFFF;
                     int shadow = 0xFF000000;
 
                     guiGraphics.fill(markerX - size + 1, markerY + 1, markerX + size + 2, markerY + 2, shadow);


### PR DESCRIPTION
Previews were previously only able to be navigated by left clicking which moved the spawn point for the world.

This PR adds
- right clicking to move without moving current spawn
- middle clicking to recenter on current spawn location

This PR fixes
- spawn coordinates not being synchronized between the two previews
- the 3d preview crosshair not being white as intended
- continent center type interacting poorly with all the above
- https://github.com/ETcodehome/ReTerraForged/issues/23