### PR TITLE
Force positive preset validation

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetConfigScreen.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetConfigScreen.java
@@ -31,7 +31,6 @@ import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetListPage.Pr
 import raccoonman.reterraforged.data.worldgen.Datapacks;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 
-//FIXME pressing the create world screen before the pack is copied will fuck the game up (surprisingly noone seems to have run into this?)
 public class PresetConfigScreen extends LinkedPageScreen {
 	private CreateWorldScreen parent;
 	

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinGuaranteeData.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinGuaranteeData.java
@@ -1,0 +1,90 @@
+package raccoonman.reterraforged.mixin;
+
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.server.packs.repository.PackRepository;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+
+@Mixin(CreateWorldScreen.class)
+public class MixinGuaranteeData {
+
+    @Inject(
+            method = {"createNewWorld", "onCreate"},
+            at = @At("HEAD"),
+            require = 0,
+            cancellable = true
+    )
+    private void rtf$verifyAndRetryPresetPresence(CallbackInfo ci) {
+        CreateWorldScreen screen = (CreateWorldScreen) (Object) this;
+
+        long timeoutMs = 10_000;
+        long startTime = System.currentTimeMillis();
+        boolean loadedSuccessfully = false;
+        Exception lastException = null;
+
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            try {
+                var uiState = screen.getUiState();
+                var settings = uiState.getSettings();
+
+                Pair<Path, PackRepository> pair = screen.getDataPackSelectionSettings(settings.dataConfiguration());
+                Path datapacksDir = pair.getFirst();
+                PackRepository repository = pair.getSecond();
+                Path presetZip = datapacksDir.resolve("reterraforged-preset.zip");
+
+                // Verify the preset file is physically written to disk and non-empty
+                if (Files.exists(presetZip) && Files.size(presetZip) > 0) {
+
+                    // Force repository scan
+                    repository.reload();
+
+                    // Check if repository indexed our pack
+                    var targetPack = repository.getAvailablePacks().stream()
+                            .filter(pack -> pack.getId().contains("reterraforged-preset"))
+                            .findFirst();
+
+                    if (targetPack.isPresent()) {
+                        String packId = targetPack.get().getId();
+                        var selectedPacks = new ArrayList<>(repository.getSelectedIds());
+
+                        // Ensure it's active in the current selected pack list
+                        if (!selectedPacks.contains(packId)) {
+                            selectedPacks.add(packId);
+                            repository.setSelected(selectedPacks);
+                        }
+
+                        loadedSuccessfully = true;
+                        break; // Preset verified, can proceed with world creation!
+                    }
+                }
+            } catch (Exception e) {
+                lastException = e;
+            }
+
+            // Wait 100ms before retrying disk / repository scan
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+
+        // Halt world creation explicitly
+        if (!loadedSuccessfully) {
+            ci.cancel(); // Cancel CreateWorldScreen execution completely
+
+            throw new IllegalStateException(
+                    "[ReTerraForged] Aborted world load because preset was not staged after 10 seconds.",
+                    lastException
+            );
+        }
+    }
+}

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -36,6 +36,7 @@
 		"terrablender.MixinNoiseChunk"
   	],
   	"client": [
+		"MixinGuaranteeData",
 		"ScreenInvoker"
   	],
   	"injectors": {


### PR DESCRIPTION
Several users (right since day one) have reported issues with the world generation proceeding despite a preset not having been completely staged resulting in it falling back to vanilla world generation.

This fixes that by providing a rigid validation pass that requires the preset to be there within a 10 second timeout / retry window (an eternity for a small discrete file IO operation). If this fails, an explicit failure mode triggers so that the end user isn't left playing a vanilla world silently.