### PR TITLE
Feat: Sync RTF seed input with world creation seed

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetConfigScreen.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetConfigScreen.java
@@ -24,6 +24,7 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.repository.PackRepository;
+import net.minecraft.world.level.levelgen.WorldOptions;
 import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.client.gui.screen.page.LinkedPageScreen;
 import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetListPage.PresetEntry;
@@ -32,7 +33,10 @@ import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 
 public class PresetConfigScreen extends LinkedPageScreen {
 	private CreateWorldScreen parent;
-	
+	private String seed;
+	private boolean seedInitialized;
+	private boolean applySeedOnClose;
+
 	public PresetConfigScreen(CreateWorldScreen parent) {
 		this.parent = parent;
 		this.currentPage = new PresetListPage(this);
@@ -41,6 +45,9 @@ public class PresetConfigScreen extends LinkedPageScreen {
 	@Override
 	public void onClose() {
 		super.onClose();
+		if(this.applySeedOnClose) {
+			this.applySeedToParent();
+		}
 
 		this.minecraft.setScreen(this.parent);
 	}
@@ -54,11 +61,37 @@ public class PresetConfigScreen extends LinkedPageScreen {
 	}
 
 	public void setSeed(String seed) {
-		this.parent.getUiState().setSeed(seed);
+		this.seed = seed;
+		this.seedInitialized = true;
+	}
+
+	public String getSeed() {
+		if(!this.seedInitialized) {
+			String parentSeed = this.parent.getUiState().getSeed();
+			this.seed = parentSeed == null || parentSeed.trim().isEmpty() ? String.valueOf(this.parent.getUiState().getSettings().options().seed()) : parentSeed;
+			this.seedInitialized = true;
+		}
+		return this.seed;
 	}
 	
 	public WorldCreationContext getSettings() {
-		return this.parent.getUiState().getSettings();
+		WorldCreationContext settings = this.parent.getUiState().getSettings();
+		if(this.seedInitialized && this.seed != null && !this.seed.trim().isEmpty()) {
+			settings = settings.withOptions((options) -> options.withSeed(WorldOptions.parseSeed(this.seed)));
+		}
+		return settings;
+	}
+
+	@Override
+	public void onDone() {
+		this.applySeedOnClose = true;
+		this.applySeedToParent();
+		super.onDone();
+		this.applySeedToParent();
+	}
+
+	private void applySeedToParent() {
+		this.parent.getUiState().setSeed(this.getSeed());
 	}
 
 	public void applyPreset(PresetEntry preset) throws IOException {		

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetConfigScreen.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetConfigScreen.java
@@ -24,7 +24,6 @@ import net.minecraft.core.RegistryAccess;
 import net.minecraft.data.DataGenerator;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.repository.PackRepository;
-import net.minecraft.world.level.levelgen.WorldOptions;
 import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.client.gui.screen.page.LinkedPageScreen;
 import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetListPage.PresetEntry;
@@ -54,8 +53,8 @@ public class PresetConfigScreen extends LinkedPageScreen {
 		this.removeWidget(widget);
 	}
 
-	public void setSeed(long seed) {
-		this.parent.getUiState().setSeed(String.valueOf(seed));
+	public void setSeed(String seed) {
+		this.parent.getUiState().setSeed(seed);
 	}
 	
 	public WorldCreationContext getSettings() {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetEditorPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetEditorPage.java
@@ -143,7 +143,7 @@ public abstract class PresetEditorPage extends BisectedPage<PresetConfigScreen, 
 		}, RenderMode::name);
 
 		// Seed Text Input
-		long currentSeed = this.screen.getSettings().options().seed();
+		String currentSeed = this.getInitialSeedText();
 		this.seedEdit = new EditBox(Minecraft.getInstance().font, 0, 0, 0, 20, Component.translatable(RTFTranslationKeys.GUI_BUTTON_SEED)) {
 			@Override
 			public boolean mouseClicked(double mouseX, double mouseY, int button) {
@@ -159,14 +159,14 @@ public abstract class PresetEditorPage extends BisectedPage<PresetConfigScreen, 
 		};
 		this.seedEdit.setTextColor(0xFFFFFF);
 		this.seedEdit.setHint(Component.translatable(RTFTranslationKeys.GUI_BUTTON_SEED));
-		this.seedEdit.setValue(String.valueOf(currentSeed));
+		this.seedEdit.setValue(currentSeed);
 		this.seedEdit.setResponder((text) -> {
 			this.screen.setSeed(text);
 			this.regenerate();
 		});
 
 		// Randomize Seed Button
-		this.seedRandomize = Button.builder(Component.literal("R"), (button) -> {
+		this.seedRandomize = Button.builder(Component.literal("🎲"), (button) -> {
 					String newSeed = String.valueOf(WorldOptions.randomSeed());
 					this.seedEdit.setValue(newSeed);
 					this.seedEdit.moveCursorToStart(false);
@@ -174,6 +174,10 @@ public abstract class PresetEditorPage extends BisectedPage<PresetConfigScreen, 
 				.tooltip(Tooltip.create(Component.translatable(RTFTranslationKeys.GUI_BUTTON_RANDOMIZE_SEED)))
 				.bounds(0, 0, 20, 20)
 				.build();
+	}
+
+	private String getInitialSeedText() {
+		return this.screen.getSeed();
 	}
 
 	private void initLeftPreviewColumn(int columnX, int padding, int offset, int width, int yBase) {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetEditorPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetEditorPage.java
@@ -2,7 +2,6 @@ package raccoonman.reterraforged.client.gui.screen.presetconfig;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.Random;
 
 import com.google.common.collect.ImmutableList;
 
@@ -13,6 +12,7 @@ import net.minecraft.client.gui.components.CycleButton;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.level.levelgen.WorldOptions;
 import raccoonman.reterraforged.client.data.RTFTranslationKeys;
 import raccoonman.reterraforged.client.gui.screen.page.BisectedPage;
 import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetListPage.PresetEntry;
@@ -158,33 +158,22 @@ public abstract class PresetEditorPage extends BisectedPage<PresetConfigScreen, 
 			}
 		};
 		this.seedEdit.setTextColor(0xFFFFFF);
+		this.seedEdit.setHint(Component.translatable(RTFTranslationKeys.GUI_BUTTON_SEED));
 		this.seedEdit.setValue(String.valueOf(currentSeed));
 		this.seedEdit.setResponder((text) -> {
-			long seedValue = parseSeed(text);
-			this.screen.setSeed(seedValue);
+			this.screen.setSeed(text);
 			this.regenerate();
 		});
 
 		// Randomize Seed Button
-		this.seedRandomize = Button.builder(Component.literal("🎲"), (button) -> {
-					long newSeed = new Random().nextLong();
-					this.seedEdit.setValue(String.valueOf(newSeed));
+		this.seedRandomize = Button.builder(Component.literal("R"), (button) -> {
+					String newSeed = String.valueOf(WorldOptions.randomSeed());
+					this.seedEdit.setValue(newSeed);
 					this.seedEdit.moveCursorToStart(false);
 				})
 				.tooltip(Tooltip.create(Component.translatable(RTFTranslationKeys.GUI_BUTTON_RANDOMIZE_SEED)))
 				.bounds(0, 0, 20, 20)
 				.build();
-	}
-
-	private static long parseSeed(String text) {
-		if (text == null || text.trim().isEmpty()) {
-			return 0L;
-		}
-		try {
-			return Long.parseLong(text.trim());
-		} catch (NumberFormatException e) {
-			return text.hashCode();
-		}
 	}
 
 	private void initLeftPreviewColumn(int columnX, int padding, int offset, int width, int yBase) {

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinCreateWorldScreenWorldTab.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinCreateWorldScreenWorldTab.java
@@ -1,0 +1,30 @@
+package raccoonman.reterraforged.mixin;
+
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(targets = "net.minecraft.client.gui.screens.worldselection.CreateWorldScreen$WorldTab")
+public abstract class MixinCreateWorldScreenWorldTab {
+	@Shadow
+	@Final
+	private EditBox seedEdit;
+
+	@Inject(method = "<init>", at = @At("TAIL"))
+	private void rtf$syncSeedEditWithUiState(CreateWorldScreen screen, CallbackInfo callbackInfo) {
+		screen.getUiState().addListener((uiState) -> {
+			String seed = uiState.getSeed();
+			if(seed == null) {
+				seed = "";
+			}
+			if(!seed.equals(this.seedEdit.getValue())) {
+				this.seedEdit.setValue(seed);
+			}
+		});
+	}
+}

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -34,11 +34,12 @@
 		"terrablender.MixinClimateSampler",
 		"terrablender.MixinTargetPoint",
 		"terrablender.MixinNoiseChunk"
-  	],
-  	"client": [
-		"MixinGuaranteeData",
-		"ScreenInvoker"
-  	],
+		],
+		"client": [
+			"MixinCreateWorldScreenWorldTab",
+			"MixinGuaranteeData",
+			"ScreenInvoker"
+		],
   	"injectors": {
 		"defaultRequire": 1
   	}


### PR DESCRIPTION
# Sync RTF Seed Input With World Creation Seed

> [!IMPORTANT]
> **Main idea:**
> Build on the new RTF config screen seed input and keep it synced with the regular world seed input box

## 1. What is this?

This builds on the recent seed input work, which changed the preview seed randomizer on the config screen into an input box with a randomize button.

This PR keeps that input box in sync with the regular world creation screen input box, while still preserving the expected cancel behavior, as evidenced by the following cases and their accompanying GIF:

- You *don't* enter a seed on the world creation screen, go to the RTF config screen, select "Done", and then back to the world creation screen

<p align="center"><kbd><img width="90%" src="https://github.com/user-attachments/assets/a650d6f0-bb49-4bfa-886b-d68aa3fee999" /></kbd></p>

- You *do* enter a seed on the world creation screen, go to the RTF config screen, select "Done", and then back to the world creation screen

<p align="center"><kbd><img width="90%" src="https://github.com/user-attachments/assets/e9044a5e-b53d-48a9-979a-0679c2d46138" /></kbd></p>

- You *do* enter a seed on the world creation screen, go to the RTF config screen, *change the seed*, select "Done", and then back to the world creation screen

<p align="center"><kbd><img width="90%" src="https://github.com/user-attachments/assets/2654558e-5575-427a-8513-efbd46504011" /></kbd></p>

- Cancelling or otherwise closing out of the config screen without clicking "**Done**" will *not* persist the seed changes from the RTF config screen

<p align="center"><kbd><img width="90%" src="https://github.com/user-attachments/assets/a8e875f6-a341-4430-b047-2a94abaf18d6" /></kbd></p>

## 2. Why add it?

Its a small QoL tweak that clears up confusion on what seed the world will actually generate with. Should be especially useful when adjusting presets and comparing the changes against the same seed.

## 3. How does it work?

- The RTF config screen keeps its own staged seed value while the screen is open. This lets the previews update as you type or use the randomize button, without immediately changing the regular world creation seed field.
- When you click "**Done**", the staged RTF seed is applied back to the regular world creation seed. If you cancel or close the screen, that staged value is discarded.
- This uses Minecraft's normal world creation seed state, which should make it compatible with mods that change the world creation screen, like [Modern World Creation](https://modrinth.com/mod/modern-world-creation), as long as they still use the regular `CreateWorldScreen` and `WorldCreationUiState` seed flow.
- I did test Modern World Creation directly to verify, and it worked fine

---

<p align="center"><em><a href="https://discord.com/channels/687310840915165240/1507723783383814254/1517485173174964234">Link</a> to feature request from Discord</em></p>
