### PR TITLE
Fix vanilla world generation

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinGuaranteeData.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinGuaranteeData.java
@@ -2,6 +2,7 @@ package raccoonman.reterraforged.mixin;
 
 import com.mojang.datafixers.util.Pair;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
 import net.minecraft.server.packs.repository.PackRepository;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,6 +24,13 @@ public class MixinGuaranteeData {
     )
     private void rtf$verifyAndRetryPresetPresence(CallbackInfo ci) {
         CreateWorldScreen screen = (CreateWorldScreen) (Object) this;
+        WorldCreationUiState uiState = screen.getUiState();
+
+        // Early exit guard to only validate preset staging if an RTF world type is currently selected
+        // We skip the check for Vanilla, Flat, Amplified, or other modded world types
+        if (!isRTFWorld(uiState)) {
+            return;
+        }
 
         long timeoutMs = 10_000;
         long startTime = System.currentTimeMillis();
@@ -31,7 +39,6 @@ public class MixinGuaranteeData {
 
         while (System.currentTimeMillis() - startTime < timeoutMs) {
             try {
-                var uiState = screen.getUiState();
                 var settings = uiState.getSettings();
 
                 Pair<Path, PackRepository> pair = screen.getDataPackSelectionSettings(settings.dataConfiguration());
@@ -77,7 +84,7 @@ public class MixinGuaranteeData {
             }
         }
 
-        // Halt world creation explicitly
+        // Halt world creation explicitly if RTF preset was expected but missing
         if (!loadedSuccessfully) {
             ci.cancel(); // Cancel CreateWorldScreen execution completely
 
@@ -86,5 +93,20 @@ public class MixinGuaranteeData {
                     lastException
             );
         }
+    }
+
+    /**
+     * Checks if the active world type preset in the Create World UI belongs to ReTerraForged.
+     */
+    private static boolean isRTFWorld(WorldCreationUiState uiState) {
+        if (uiState == null) return false;
+
+        var presetEntry = uiState.getWorldType();
+        if (presetEntry == null || presetEntry.preset() == null) return false;
+
+        return presetEntry.preset().unwrapKey()
+                .map(key -> key.location().getNamespace().equalsIgnoreCase("reterraforged")
+                        || key.location().getPath().contains("reterraforged"))
+                .orElse(false);
     }
 }


### PR DESCRIPTION
In https://github.com/ETcodehome/ReTerraForged/pull/138 I broke the vanilla world generation by forcing presets to always validate (even when it wasnt an RTF world and is jsut a vanilla world). Discovered while testing seed value persistance changes this morning.

We really need a better automated test harness...