### PR TITLE
fix: Heightmap induced stone worlds

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseFill.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseFill.java
@@ -1,13 +1,7 @@
 package raccoonman.reterraforged.mixin;
 
-import java.util.EnumSet;
-
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.server.level.WorldGenRegion;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.ChunkAccess;
-import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.minecraft.world.level.StructureManager;
 import net.minecraft.world.level.levelgen.RandomState;
@@ -38,17 +32,6 @@ public abstract class MixinNoiseFill {
         WorldGenTracker.PEAK_CONCURRENCY.updateAndGet(peak -> Math.max(peak, active));
     }
 
-    @WrapOperation(
-            method = "doFill",
-            at = @At(
-                    value = "INVOKE",
-                    target = "Lnet/minecraft/world/level/levelgen/Heightmap;update(IIILnet/minecraft/world/level/block/state/BlockState;)Z"))
-    private boolean rtf$skipPerBlockHeightmapUpdate(final Heightmap instance, final int x, final int y,
-                                                    final int z, final BlockState state,
-                                                    final Operation<Boolean> original) {
-        return false;
-    }
-
     @Inject(method = "doFill", at = @At("TAIL"))
     private void rtf$fillEnd(final Blender blender, final StructureManager structureManager,
                              final RandomState random, final ChunkAccess chunk,
@@ -59,7 +42,6 @@ public abstract class MixinNoiseFill {
             WorldGenTracker.TOTAL_NANOS.add(System.nanoTime() - start);
             WorldGenTracker.TOTAL_CHUNKS.increment(); // Register one completed chunk tally
         }
-        Heightmap.primeHeightmaps(chunk, EnumSet.of(Heightmap.Types.OCEAN_FLOOR_WG, Heightmap.Types.WORLD_SURFACE_WG));
         WorldGenTracker.ACTIVE_THREADS.decrementAndGet();
     }
 


### PR DESCRIPTION
In https://github.com/ETcodehome/ReTerraForged/pull/132 we did some aggressive optimizations. 
As a result we found some mod conflicts where this approach breaks down.

<img width="1257" height="523" alt="image" src="https://github.com/user-attachments/assets/b11fb287-2d72-4e87-b365-831b868d8911" />

Targeted Gemini analysis highlighted that the likely cause was the heightmap priming we added to batch process updates.

> How Vanilla Works: 
> During the doFill phase (where stone terrain is carved out), Vanilla updates the WORLD_SURFACE_WG and OCEAN_FLOOR_WG heightmaps block-by-block.

> What Our Mixin Did: 
> To save CPU cycles, we disabled that per-block update using @WrapOperation, and instead told the game to calculate the entire heightmap all at once at the very end of doFill using primeHeightmaps.

> The Noisium/Lithium Collision: 
> Noisium and Lithium completely overhaul the chunk generation and surface-building loops. Noisium specifically implements its own hyper-optimized heightmap calculations and bypasses standard vanilla loop structures.

> The Result: 
> Because Noisium rewrites the execution flow, our @TAIL injection either fails to fire or fires out of sync with Noisium's custom surface builder. The heightmaps are left completely empty (recording the surface at $Y = -64$). When the surface builder and feature decorators subsequently run, they check the heightmap to find the ground. Finding nothing, they skip the entire chunk, leaving you with plain, undecorated stone.

<img width="1540" height="533" alt="image" src="https://github.com/user-attachments/assets/764dff2d-9186-4dab-9e31-b1988b8566be" />

Updating this approach corrected the problematic behavior. Sacrificing the relatively negligible performance impact for improved compatibility / cross mod stability is a compromise I'm comfortable making.
