### PR TITLE
Fix point cell cache

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/CellSampler.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/CellSampler.java
@@ -28,17 +28,25 @@ import raccoonman.reterraforged.world.worldgen.util.PosUtil;
 
 public record CellSampler(Supplier<WorldLookup> deferredLookup, Field field) implements MarkerFunction.Mapped {
 	private static final ThreadLocal<Cache2d> CELL = ThreadLocal.withInitial(Cache2d::new);
+	private static final ThreadLocal<Cell> SHARED_FAST_CELL = ThreadLocal.withInitial(Cell::new);
 
 	@Override
 	public double compute(DensityFunction.FunctionContext ctx) {
-
 		try {
 			WorldLookup lookup = this.deferredLookup.get();
 			if (lookup != null) {
-				Cell cell = PointCellCache.get(lookup, ctx.blockX(), ctx.blockZ());
+				// Grab the reusable cell for this specific worker thread
+				Cell cell = SHARED_FAST_CELL.get();
+
+				// Populate it via the zero-allocation fast path
+				PointCellCache.fill(lookup, ctx.blockX(), ctx.blockZ(), cell);
+
+				// Read and return the data
 				return this.field.read(cell, lookup.getHeightmap());
 			}
-		} catch (Throwable t) {	}
+		} catch (Throwable t) {
+			// Intentionally swallowed to fall through to original logic on failure
+		}
 
 		// Fallback to original single-slot Cache2d path if the cache fails/is uninitialized
 		WorldLookup worldLookup = this.deferredLookup.get();

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/PointCellCache.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/PointCellCache.java
@@ -6,6 +6,9 @@ import raccoonman.reterraforged.world.worldgen.cell.heightmap.WorldLookup;
 
 import java.util.Arrays;
 
+/**
+ * A strictly zero-allocation, thread-local cache for ReTerraForged cell math.
+ */
 public final class PointCellCache {
     private static final ThreadLocal<PointCellCache> LOCAL_CACHE = ThreadLocal.withInitial(PointCellCache::new);
     private static final int CACHE_SIZE = 4096; // Must be a power of two
@@ -15,42 +18,41 @@ public final class PointCellCache {
     private final long[] keys = new long[CACHE_SIZE];
     private final Cell[] cells = new Cell[CACHE_SIZE];
 
-    public static Cell get(WorldLookup lookup, int blockX, int blockZ) {
-        return LOCAL_CACHE.get().getOrCreate(lookup, blockX, blockZ);
+    private PointCellCache() {
+        for (int i = 0; i < CACHE_SIZE; i++) {
+            this.cells[i] = new Cell();
+        }
+        Arrays.fill(this.keys, Long.MIN_VALUE);
     }
 
-    private Cell getOrCreate(WorldLookup lookup, int blockX, int blockZ) {
+    public static void fill(WorldLookup lookup, int blockX, int blockZ, Cell target) {
+        LOCAL_CACHE.get().fillInternal(lookup, blockX, blockZ, target);
+    }
+
+    private void fillInternal(WorldLookup lookup, int blockX, int blockZ, Cell target) {
+        // Validates environment to prevent state-leaking across restarts
         if (this.boundLookup != lookup) {
             this.rebind(lookup);
         }
 
-        // Quart-snap coordinates (matching RTF's original Cache2d alignment)
-        int qx = blockX & ~3;
-        int qz = blockZ & ~3;
-        long key = ((long) qx << 32) | (qz & 0xFFFFFFFFL);
+        // Removed the ~3 masking. We now use EXACT 1:1 coordinates.
+        long key = ((long) blockX << 32) | (blockZ & 0xFFFFFFFFL);
         int idx = (int) (HashCommon.mix(key) & MASK);
 
-        Cell cell = this.cells[idx];
-        if (cell != null && this.keys[idx] == key) {
-            return cell; // Cache Hit!
-        }
+        Cell cachedCell = this.cells[idx];
 
         // Cache Miss
-        if (cell == null) {
-            cell = new Cell();
-            this.cells[idx] = cell;
+        if (this.keys[idx] != key) {
+            // Evaluates using exact coordinates, mirroring RTF's native getAndUpdate
+            lookup.applyCell(cachedCell.reset(), blockX, blockZ, true);
+            this.keys[idx] = key;
         }
 
-        // Evaluate the heavy pipeline natively
-        lookup.applyCell(cell.reset(), qx, qz, true);
-        this.keys[idx] = key;
-        return cell;
+        target.copyFrom(cachedCell);
     }
 
     private void rebind(WorldLookup lookup) {
-        Arrays.fill(this.cells, null); // Clear old entries safely
+        Arrays.fill(this.keys, Long.MIN_VALUE);
         this.boundLookup = lookup;
     }
-
-    private PointCellCache() {}
 }


### PR DESCRIPTION
In https://github.com/ETcodehome/ReTerraForged/pull/132 we made some aggressive optimizations, and as always when you're moving fast and breaking things, it seems to have broken some things.

This PR fixes some undesired behavior caused as a result of caching the cell math.

Specifically it fixes a reasonably reliably reproduced issue where cells around spawn generate sheer chunk walls when you save, exit the game fully, then rejoin the game. this seems to occur only when i used the legacy terraforged default preset and not with modern default (curiously).

---

### The fixes

Strict Zero-Allocation: 
We stopped creating new Cell objects so the cache now pre-allocates its own internal master cells and copies its data directly into a single, reusable Cell provided by the caller's thread, completely eliminating memory churn.

Exact 1:1 Coordinates: 
We removed the & ~3 bitwise masks that were rounding coordinates to a 4x4 grid. Evaluating the noise functions using exact block coordinates perfectly matches the native fallback logic, eliminating sheer cliffs around spawn.

Prevented Data Smearing:
We stopped caching direct memory references to mutable cells. By securely copying the terrain values (via .copyFrom()) instead of sharing object pointers, worker threads no longer accidentally overwrite the cached data of previously generated blocks.