### PR TITLE
fix: Prevent villages spawning over rivers

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
@@ -208,8 +208,8 @@ public class MixinJigsawStructure {
 
 		BlockPos blockPos = new BlockPos(originX, target, originZ);
 		Holder<Biome> biome = generationContext.chunkGenerator()
-				.getBiomeSource()
-				.getNoiseBiome(QuartPos.fromBlock(blockPos.getX()), QuartPos.fromBlock(blockPos.getY()), QuartPos.fromBlock(blockPos.getZ()), generationContext.randomState().sampler());
+			.getBiomeSource()
+			.getNoiseBiome(QuartPos.fromBlock(blockPos.getX()), QuartPos.fromBlock(blockPos.getY()), QuartPos.fromBlock(blockPos.getZ()), generationContext.randomState().sampler());
 		if (!generationContext.validBiome().test(biome)) {
 			cir.setReturnValue(Optional.empty());
 			cir.cancel();
@@ -217,10 +217,10 @@ public class MixinJigsawStructure {
 		}
 
 		Optional<Structure.GenerationStub> result = JigsawPlacement.addPieces(
-				generationContext, this.startPool, this.startJigsawName, this.maxDepth, blockPos, this.useExpansionHack,
-				this.projectStartToHeightmap, this.maxDistanceFromCenter,
-				PoolAliasLookup.create(this.poolAliases, blockPos, generationContext.seed()),
-				this.dimensionPadding, this.liquidSettings
+			generationContext, this.startPool, this.startJigsawName, this.maxDepth, blockPos, this.useExpansionHack,
+			this.projectStartToHeightmap, this.maxDistanceFromCenter,
+			PoolAliasLookup.create(this.poolAliases, blockPos, generationContext.seed()),
+			this.dimensionPadding, this.liquidSettings
 		);
 		if (result.isEmpty()) {
 			cir.setReturnValue(result);
@@ -275,7 +275,7 @@ public class MixinJigsawStructure {
 				int x = originX + radius * xi / rtf$GRID_STEPS_PER_SIDE;
 				int z = originZ + radius * zi / rtf$GRID_STEPS_PER_SIDE;
 				int floor = generationContext.chunkGenerator()
-						.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
+					.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
 				if (floor < worst) {
 					worst = floor;
 				}
@@ -296,7 +296,7 @@ public class MixinJigsawStructure {
 			for (int zi = 0; zi <= steps; zi++) {
 				int z = realBbox.minZ() + (realBbox.maxZ() - realBbox.minZ()) * zi / steps;
 				int floor = generationContext.chunkGenerator()
-						.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
+					.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
 				if (floor < lowest) {
 					lowest = floor;
 				}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
@@ -47,8 +47,8 @@ import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 /**
  * 1) Keeps Trial Chamber and Ancient City jigsaw starts within a terrain-bounded vertical window, then validates the
  *    generated pieces against the dimension floor and the lowest surface over the resulting structure footprint.
- * 2) Retries Village placement with random offsets if the candidate origin lands on a river cell or produces a
- *    decimated piece list.
+ * 2) Retries Village placement with random offsets if the candidate origin lands on a river cell, or if the outer
+ *    boundary perimeter of the resulting structure footprint intersects a river.
  */
 @Mixin(JigsawStructure.class)
 public class MixinJigsawStructure {
@@ -131,7 +131,7 @@ public class MixinJigsawStructure {
 
 		RandomSource random = generationContext.random();
 		int maxAttempts = 8;
-		int minRequiredPieces = 5; // Rejects desolate village stubs pruned by river intersections
+		int minRequiredPieces = 5;
 
 		for (int attempt = 0; attempt < maxAttempts; attempt++) {
 			int offsetX = (attempt == 0) ? 0 : random.nextIntBetweenInclusive(-32, 32);
@@ -140,7 +140,7 @@ public class MixinJigsawStructure {
 			int candidateX = originX + offsetX;
 			int candidateZ = originZ + offsetZ;
 
-			// Quick 2D Cell pre-check: skip if origin lands on river terrain
+			// Quick 2D Cell pre-check: skip immediately if the center origin lands on river terrain
 			if (rtf$isRiverCell(candidateX, candidateZ, generationContext.randomState())) {
 				continue;
 			}
@@ -170,12 +170,19 @@ public class MixinJigsawStructure {
 			Structure.GenerationStub stub = result.get();
 			StructurePiecesBuilder builder = stub.getPiecesBuilder();
 
-			// Ensure the placement isn't a decimated stub
-			if (builder.build().pieces().size() >= minRequiredPieces) {
-				cir.setReturnValue(Optional.of(new Structure.GenerationStub(stub.position(), Either.right(builder))));
-				cir.cancel();
-				return;
+			// Reject if it generated too few pieces
+			if (builder.build().pieces().size() < minRequiredPieces) {
+				continue;
 			}
+
+			// Outer boundary check: ensure the resulting structure's perimeter does not intersect a river
+			if (rtf$footprintIntersectsRiver(builder.getBoundingBox(), generationContext.randomState())) {
+				continue;
+			}
+
+			cir.setReturnValue(Optional.of(new Structure.GenerationStub(stub.position(), Either.right(builder))));
+			cir.cancel();
+			return;
 		}
 
 		// Discard structure if all attempts land on rivers or produce desolate pieces
@@ -208,8 +215,8 @@ public class MixinJigsawStructure {
 
 		BlockPos blockPos = new BlockPos(originX, target, originZ);
 		Holder<Biome> biome = generationContext.chunkGenerator()
-			.getBiomeSource()
-			.getNoiseBiome(QuartPos.fromBlock(blockPos.getX()), QuartPos.fromBlock(blockPos.getY()), QuartPos.fromBlock(blockPos.getZ()), generationContext.randomState().sampler());
+				.getBiomeSource()
+				.getNoiseBiome(QuartPos.fromBlock(blockPos.getX()), QuartPos.fromBlock(blockPos.getY()), QuartPos.fromBlock(blockPos.getZ()), generationContext.randomState().sampler());
 		if (!generationContext.validBiome().test(biome)) {
 			cir.setReturnValue(Optional.empty());
 			cir.cancel();
@@ -217,10 +224,10 @@ public class MixinJigsawStructure {
 		}
 
 		Optional<Structure.GenerationStub> result = JigsawPlacement.addPieces(
-			generationContext, this.startPool, this.startJigsawName, this.maxDepth, blockPos, this.useExpansionHack,
-			this.projectStartToHeightmap, this.maxDistanceFromCenter,
-			PoolAliasLookup.create(this.poolAliases, blockPos, generationContext.seed()),
-			this.dimensionPadding, this.liquidSettings
+				generationContext, this.startPool, this.startJigsawName, this.maxDepth, blockPos, this.useExpansionHack,
+				this.projectStartToHeightmap, this.maxDistanceFromCenter,
+				PoolAliasLookup.create(this.poolAliases, blockPos, generationContext.seed()),
+				this.dimensionPadding, this.liquidSettings
 		);
 		if (result.isEmpty()) {
 			cir.setReturnValue(result);
@@ -228,12 +235,10 @@ public class MixinJigsawStructure {
 			return;
 		}
 
-		// Building twice advances the structure RNG and can select different pieces, so reuse one materialized builder.
 		Structure.GenerationStub stub = result.get();
 		StructurePiecesBuilder builder = stub.getPiecesBuilder();
 		BoundingBox realBbox = builder.getBoundingBox();
 
-		// The initial search radius can include unrelated high terrain; derive the ceiling from the resulting footprint.
 		int realMaxLocalY = rtf$sampleLocalCeiling(generationContext, realBbox) - rtf$MARGIN;
 		if (realBbox.minY() <= minWorldY || realBbox.maxY() >= realMaxLocalY) {
 			cir.setReturnValue(Optional.empty());
@@ -243,6 +248,40 @@ public class MixinJigsawStructure {
 
 		cir.setReturnValue(Optional.of(new Structure.GenerationStub(stub.position(), Either.right(builder))));
 		cir.cancel();
+	}
+
+	@Unique
+	private boolean rtf$footprintIntersectsRiver(BoundingBox box, RandomState randomState) {
+		int step = 3;
+
+		int minX = box.minX();
+		int maxX = box.maxX();
+		int minZ = box.minZ();
+		int maxZ = box.maxZ();
+
+		// 1. Scan northern (minZ) and southern (maxZ) perimeter edges along X
+		for (int x = minX; x <= maxX; x += step) {
+			if (rtf$isRiverCell(x, minZ, randomState) || rtf$isRiverCell(x, maxZ, randomState)) {
+				return true;
+			}
+		}
+		// Explicit check for the exact eastern corner bounds if (maxX - minX) isn't divisible by 3
+		if (rtf$isRiverCell(maxX, minZ, randomState) || rtf$isRiverCell(maxX, maxZ, randomState)) {
+			return true;
+		}
+
+		// 2. Scan western (minX) and eastern (maxX) perimeter edges along Z
+		for (int z = minZ; z <= maxZ; z += step) {
+			if (rtf$isRiverCell(minX, z, randomState) || rtf$isRiverCell(maxX, z, randomState)) {
+				return true;
+			}
+		}
+		// Explicit check for the exact southern corner bounds if (maxZ - minZ) isn't divisible by 3
+		if (rtf$isRiverCell(minX, maxZ, randomState) || rtf$isRiverCell(maxX, maxZ, randomState)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Unique
@@ -275,7 +314,7 @@ public class MixinJigsawStructure {
 				int x = originX + radius * xi / rtf$GRID_STEPS_PER_SIDE;
 				int z = originZ + radius * zi / rtf$GRID_STEPS_PER_SIDE;
 				int floor = generationContext.chunkGenerator()
-					.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
+						.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
 				if (floor < worst) {
 					worst = floor;
 				}
@@ -296,7 +335,7 @@ public class MixinJigsawStructure {
 			for (int zi = 0; zi <= steps; zi++) {
 				int z = realBbox.minZ() + (realBbox.maxZ() - realBbox.minZ()) * zi / steps;
 				int floor = generationContext.chunkGenerator()
-					.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
+						.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
 				if (floor < lowest) {
 					lowest = floor;
 				}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
@@ -19,6 +19,7 @@ import net.minecraft.core.QuartPos;
 import net.minecraft.core.SectionPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.StructureTags;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.biome.Biome;
@@ -102,9 +103,14 @@ public class MixinJigsawStructure {
 			Structure trialChambers = registry.get(BuiltinStructures.TRIAL_CHAMBERS);
 			Structure ancientCity = registry.get(BuiltinStructures.ANCIENT_CITY);
 
+			boolean isVillage = registry.getResourceKey(self)
+					.flatMap(registry::getHolder)
+					.map(holder -> holder.is(StructureTags.VILLAGE))
+					.orElse(false);
+
 			if (self == trialChambers || self == ancientCity) {
 				this.rtf$targetStatus = (byte) 1;
-			} else if (this.startPool.unwrapKey().map(k -> k.location().getPath().contains("village")).orElse(false)) {
+			} else if (isVillage) {
 				this.rtf$targetStatus = (byte) 2;
 			} else {
 				this.rtf$targetStatus = (byte) 3;

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
@@ -16,11 +16,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
+import net.minecraft.core.SectionPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.WorldGenerationContext;
 import net.minecraft.world.level.levelgen.heightproviders.HeightProvider;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
@@ -35,9 +38,17 @@ import net.minecraft.world.level.levelgen.structure.pools.alias.PoolAliasLookup;
 import net.minecraft.world.level.levelgen.structure.structures.JigsawStructure;
 import net.minecraft.world.level.levelgen.structure.templatesystem.LiquidSettings;
 
+import raccoonman.reterraforged.world.worldgen.cell.Cell;
+import raccoonman.reterraforged.world.worldgen.GeneratorContext;
+import raccoonman.reterraforged.world.worldgen.RTFRandomState;
+import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSettings;
+import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
+
 /**
- * Keeps Trial Chamber and Ancient City jigsaw starts within a terrain-bounded vertical window, then validates the
- * generated pieces against the dimension floor and the lowest surface over the resulting structure footprint.
+ * 1) Keeps Trial Chamber and Ancient City jigsaw starts within a terrain-bounded vertical window, then validates the
+ *    generated pieces against the dimension floor and the lowest surface over the resulting structure footprint.
+ * 2) Retries Village placement with random offsets if the candidate origin lands on a river cell or produces a
+ *    decimated piece list.
  */
 @Mixin(JigsawStructure.class)
 public class MixinJigsawStructure {
@@ -48,8 +59,7 @@ public class MixinJigsawStructure {
 	@Unique
 	private static final int rtf$GRID_STEPS_PER_SIDE = 3;
 
-	// 0 = not yet checked, 1 = target structure, 2 = not a target; cached per-instance so non-target
-	// structures skip the registry lookups after their first attempt.
+	// 0 = unchecked, 1 = subterranean (Trial Chambers / Ancient City), 2 = village, 3 = unhandled structure
 	@Unique
 	private byte rtf$targetStatus;
 
@@ -91,12 +101,90 @@ public class MixinJigsawStructure {
 			var registry = generationContext.registryAccess().registryOrThrow(Registries.STRUCTURE);
 			Structure trialChambers = registry.get(BuiltinStructures.TRIAL_CHAMBERS);
 			Structure ancientCity = registry.get(BuiltinStructures.ANCIENT_CITY);
-			this.rtf$targetStatus = (self == trialChambers || self == ancientCity) ? (byte) 1 : (byte) 2;
+
+			if (self == trialChambers || self == ancientCity) {
+				this.rtf$targetStatus = (byte) 1;
+			} else if (this.startPool.unwrapKey().map(k -> k.location().getPath().contains("village")).orElse(false)) {
+				this.rtf$targetStatus = (byte) 2;
+			} else {
+				this.rtf$targetStatus = (byte) 3;
+			}
 		}
-		if (this.rtf$targetStatus == 2) {
+
+		if (this.rtf$targetStatus == 3) {
 			return;
 		}
 
+		if (this.rtf$targetStatus == 2) {
+			rtf$handleVillageRetryPlacement(generationContext, cir);
+			return;
+		}
+
+		rtf$handleSubterraneanPlacement(generationContext, cir);
+	}
+
+	@Unique
+	private void rtf$handleVillageRetryPlacement(Structure.GenerationContext generationContext, CallbackInfoReturnable<Optional<Structure.GenerationStub>> cir) {
+		ChunkPos chunkPos = generationContext.chunkPos();
+		int originX = chunkPos.getMinBlockX();
+		int originZ = chunkPos.getMinBlockZ();
+
+		RandomSource random = generationContext.random();
+		int maxAttempts = 8;
+		int minRequiredPieces = 5; // Rejects desolate village stubs pruned by river intersections
+
+		for (int attempt = 0; attempt < maxAttempts; attempt++) {
+			int offsetX = (attempt == 0) ? 0 : random.nextIntBetweenInclusive(-32, 32);
+			int offsetZ = (attempt == 0) ? 0 : random.nextIntBetweenInclusive(-32, 32);
+
+			int candidateX = originX + offsetX;
+			int candidateZ = originZ + offsetZ;
+
+			// Quick 2D Cell pre-check: skip if origin lands on river terrain
+			if (rtf$isRiverCell(candidateX, candidateZ, generationContext.randomState())) {
+				continue;
+			}
+
+			int sampledY = this.startHeight.sample(random, new WorldGenerationContext(generationContext.chunkGenerator(), generationContext.heightAccessor()));
+			BlockPos blockPos = new BlockPos(candidateX, sampledY, candidateZ);
+
+			Holder<Biome> biome = generationContext.chunkGenerator()
+					.getBiomeSource()
+					.getNoiseBiome(QuartPos.fromBlock(blockPos.getX()), QuartPos.fromBlock(blockPos.getY()), QuartPos.fromBlock(blockPos.getZ()), generationContext.randomState().sampler());
+
+			if (!generationContext.validBiome().test(biome)) {
+				continue;
+			}
+
+			Optional<Structure.GenerationStub> result = JigsawPlacement.addPieces(
+					generationContext, this.startPool, this.startJigsawName, this.maxDepth, blockPos, this.useExpansionHack,
+					this.projectStartToHeightmap, this.maxDistanceFromCenter,
+					PoolAliasLookup.create(this.poolAliases, blockPos, generationContext.seed()),
+					this.dimensionPadding, this.liquidSettings
+			);
+
+			if (result.isEmpty()) {
+				continue;
+			}
+
+			Structure.GenerationStub stub = result.get();
+			StructurePiecesBuilder builder = stub.getPiecesBuilder();
+
+			// Ensure the placement isn't a decimated stub
+			if (builder.build().pieces().size() >= minRequiredPieces) {
+				cir.setReturnValue(Optional.of(new Structure.GenerationStub(stub.position(), Either.right(builder))));
+				cir.cancel();
+				return;
+			}
+		}
+
+		// Discard structure if all attempts land on rivers or produce desolate pieces
+		cir.setReturnValue(Optional.empty());
+		cir.cancel();
+	}
+
+	@Unique
+	private void rtf$handleSubterraneanPlacement(Structure.GenerationContext generationContext, CallbackInfoReturnable<Optional<Structure.GenerationStub>> cir) {
 		int sampledY = this.startHeight.sample(generationContext.random(), new WorldGenerationContext(generationContext.chunkGenerator(), generationContext.heightAccessor()));
 
 		ChunkPos chunkPos = generationContext.chunkPos();
@@ -120,8 +208,8 @@ public class MixinJigsawStructure {
 
 		BlockPos blockPos = new BlockPos(originX, target, originZ);
 		Holder<Biome> biome = generationContext.chunkGenerator()
-			.getBiomeSource()
-			.getNoiseBiome(QuartPos.fromBlock(blockPos.getX()), QuartPos.fromBlock(blockPos.getY()), QuartPos.fromBlock(blockPos.getZ()), generationContext.randomState().sampler());
+				.getBiomeSource()
+				.getNoiseBiome(QuartPos.fromBlock(blockPos.getX()), QuartPos.fromBlock(blockPos.getY()), QuartPos.fromBlock(blockPos.getZ()), generationContext.randomState().sampler());
 		if (!generationContext.validBiome().test(biome)) {
 			cir.setReturnValue(Optional.empty());
 			cir.cancel();
@@ -129,10 +217,10 @@ public class MixinJigsawStructure {
 		}
 
 		Optional<Structure.GenerationStub> result = JigsawPlacement.addPieces(
-			generationContext, this.startPool, this.startJigsawName, this.maxDepth, blockPos, this.useExpansionHack,
-			this.projectStartToHeightmap, this.maxDistanceFromCenter,
-			PoolAliasLookup.create(this.poolAliases, blockPos, generationContext.seed()),
-			this.dimensionPadding, this.liquidSettings
+				generationContext, this.startPool, this.startJigsawName, this.maxDepth, blockPos, this.useExpansionHack,
+				this.projectStartToHeightmap, this.maxDistanceFromCenter,
+				PoolAliasLookup.create(this.poolAliases, blockPos, generationContext.seed()),
+				this.dimensionPadding, this.liquidSettings
 		);
 		if (result.isEmpty()) {
 			cir.setReturnValue(result);
@@ -158,6 +246,26 @@ public class MixinJigsawStructure {
 	}
 
 	@Unique
+	private boolean rtf$isRiverCell(int x, int z, RandomState randomState) {
+		RTFRandomState rtfRandomState = (RTFRandomState) (Object) randomState;
+		GeneratorContext generatorContext = rtfRandomState.generatorContext();
+		if (generatorContext == null) {
+			return false;
+		}
+
+		int chunkX = SectionPos.blockToSectionCoord(x);
+		int chunkZ = SectionPos.blockToSectionCoord(z);
+		int localX = x & 15;
+		int localZ = z & 15;
+
+		Tile tile = generatorContext.cache.provideAtChunk(chunkX, chunkZ);
+		Tile.Chunk tileChunk = tile.getChunkReader(chunkX, chunkZ);
+		Cell cell = tileChunk.getCell(localX, localZ);
+
+		return cell.riverZone == RiverCarverSettings.RiverZone.Riverbed;
+	}
+
+	@Unique
 	private FloorRange rtf$sampleFloorRange(Structure.GenerationContext generationContext, int originX, int originZ) {
 		int radius = this.maxDistanceFromCenter;
 		int worst = Integer.MAX_VALUE;
@@ -167,7 +275,7 @@ public class MixinJigsawStructure {
 				int x = originX + radius * xi / rtf$GRID_STEPS_PER_SIDE;
 				int z = originZ + radius * zi / rtf$GRID_STEPS_PER_SIDE;
 				int floor = generationContext.chunkGenerator()
-					.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
+						.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
 				if (floor < worst) {
 					worst = floor;
 				}
@@ -188,7 +296,7 @@ public class MixinJigsawStructure {
 			for (int zi = 0; zi <= steps; zi++) {
 				int z = realBbox.minZ() + (realBbox.maxZ() - realBbox.minZ()) * zi / steps;
 				int floor = generationContext.chunkGenerator()
-					.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
+						.getFirstOccupiedHeight(x, z, Heightmap.Types.OCEAN_FLOOR_WG, generationContext.heightAccessor(), generationContext.randomState());
 				if (floor < lowest) {
 					lowest = floor;
 				}


### PR DESCRIPTION
Fixes villages spawning overlapping rivers as a result of the structure placement guards being relaxed to fix swamp hut spawns.

Tried a more discrete approach first where we just pruned children but the actual initial village spawns were still placing over rivers, or just failing to place at all resulting in decimated villages with just a couple of paths and two houses.

New approach is much better, essentially performing a bounded edge check every three blocks to see if it intersects a river and attempting placement again nearby if it intersects a river. Only impacts spawns overlapping rivers

---

- [x] Spawning immediately adjacent to river still possible
- [x] All village spawn types still possible
- [x] Modded village buildings still seem to work reasonably (where tagged appropriately)
- [x] Didnt break existing mixin target refinements around subterranean structures
- [x] Village frequencies on a macro scale slightly thinner but not problematically so

---

#### Village right on waters edge
<img width="2582" height="1388" alt="image" src="https://github.com/user-attachments/assets/7a8d8da7-5f31-485a-87a3-5e7623ce0e0f" />

#### Village density / existence checks (roughly matches vanilla)
<img width="2861" height="1561" alt="image" src="https://github.com/user-attachments/assets/5d5bf943-da6c-4ea9-9741-a77dbb8e09f5" />




