### PR TITLE
Fix: Biome Banding, Climate Mapping, and Scaling for Underground Biomes

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -11,10 +11,15 @@ dependencies {
     modImplementation "com.github.glitchfiend:TerraBlender-neoforge:${rootProject.minecraft_version}-${rootProject.terrablender_version}"
 	compileOnly "com.electronwill.night-config:toml:3.6.7"
 	//compileOnly "lithostitched-forge:1.0.0"
+	testImplementation "org.junit.jupiter:junit-jupiter:5.11.4"
 }
 
 repositories {
 
+}
+
+test {
+	useJUnitPlatform()
 }
 
 remapJar {

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetNoiseRouterData.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetNoiseRouterData.java
@@ -19,6 +19,7 @@ import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.data.worldgen.preset.settings.CaveSettings;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
+import raccoonman.reterraforged.world.worldgen.biome.UndergroundBiomeBanding;
 import raccoonman.reterraforged.world.worldgen.densityfunction.CellSampler;
 import raccoonman.reterraforged.world.worldgen.densityfunction.RTFDensityFunctions;
 import raccoonman.reterraforged.world.worldgen.noise.module.Noise;
@@ -76,6 +77,7 @@ public class PresetNoiseRouterData {
     	
     	CaveSettings caves = preset.caves();
     	float cheeseCaveDepthOffset = caves.cheeseCaveDepthOffset;
+        double undergroundNoiseScale = UndergroundBiomeBanding.undergroundNoiseScale(preset);
     	
     	DensityFunction aquiferBarrier = DensityFunctions.noise(noiseParams.getOrThrow(Noises.AQUIFER_BARRIER), 0.5);
         DensityFunction aquiferFluidLevelFloodedness = DensityFunctions.noise(noiseParams.getOrThrow(Noises.AQUIFER_FLUID_LEVEL_FLOODEDNESS), 0.67);
@@ -88,16 +90,16 @@ public class PresetNoiseRouterData {
         DensityFunction temperature = blendClimateAxis(
             depth,
             RTFDensityFunctions.cell(CellSampler.Field.TEMPERATURE),
-            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.TEMPERATURE))
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, undergroundNoiseScale, noiseParams.getOrThrow(Noises.TEMPERATURE))
         );
         DensityFunction vegetation = blendClimateAxis(
             depth,
             RTFDensityFunctions.cell(CellSampler.Field.MOISTURE),
-            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.VEGETATION))
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, undergroundNoiseScale, noiseParams.getOrThrow(Noises.VEGETATION))
         );
         DensityFunction surfaceContinents = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.CONTINENTS);
         DensityFunction vanillaContinents = DensityFunctions.flatCache(
-            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.CONTINENTALNESS))
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, undergroundNoiseScale, noiseParams.getOrThrow(Noises.CONTINENTALNESS))
         );
         DensityFunction continents = blendClimateAxis(
             depth,
@@ -106,7 +108,7 @@ public class PresetNoiseRouterData {
         );
         DensityFunction surfaceErosion = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.EROSION);
         DensityFunction vanillaErosion = DensityFunctions.flatCache(
-            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.EROSION))
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, undergroundNoiseScale, noiseParams.getOrThrow(Noises.EROSION))
         );
         DensityFunction erosion = blendClimateAxis(
             depth,
@@ -120,7 +122,7 @@ public class PresetNoiseRouterData {
         DensityFunction ridges = blendClimateAxis(
             depth,
             NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.RIDGES),
-            DensityFunctions.flatCache(DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.RIDGE)))
+            DensityFunctions.flatCache(DensityFunctions.shiftedNoise2d(shiftX, shiftZ, undergroundNoiseScale, noiseParams.getOrThrow(Noises.RIDGE)))
         );
         DensityFunction initialDensity = NoiseRouterData.noiseGradientDensity(DensityFunctions.cache2d(factor), depth);
         DensityFunction slopedCheese = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.SLOPED_CHEESE);

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetNoiseRouterData.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/PresetNoiseRouterData.java
@@ -6,6 +6,7 @@ import net.minecraft.core.HolderGetter;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.levelgen.DensityFunction;
 import net.minecraft.world.level.levelgen.DensityFunctions;
@@ -28,9 +29,14 @@ public class PresetNoiseRouterData {
 	public static final ResourceKey<DensityFunction> GRADIENT = createKey("gradient");
 	public static final ResourceKey<DensityFunction> HEIGHT_EROSION = createKey("erosion");
 	public static final ResourceKey<DensityFunction> SEDIMENT = createKey("sediment");
+	private static final ResourceKey<DensityFunction> VANILLA_SHIFT_X = createMinecraftKey("shift_x");
+	private static final ResourceKey<DensityFunction> VANILLA_SHIFT_Z = createMinecraftKey("shift_z");
 	
 	private static final float SCALER = 128.0F;
 	private static final float UNIT = 1.0F / SCALER;
+	private static final double SURFACE_CLIMATE_DEPTH = 0.03D;
+	private static final double UNDERGROUND_CLIMATE_DEPTH = 0.125D;
+	private static final double UNDERGROUND_EROSION_VARIATION = 0.25D;
 	
     public static void bootstrap(Preset preset, BootstrapContext<DensityFunction> ctx) {
         HolderGetter<DensityFunction> densityFunctions = ctx.lookup(Registries.DENSITY_FUNCTION);
@@ -75,10 +81,47 @@ public class PresetNoiseRouterData {
         DensityFunction aquiferFluidLevelFloodedness = DensityFunctions.noise(noiseParams.getOrThrow(Noises.AQUIFER_FLUID_LEVEL_FLOODEDNESS), 0.67);
         DensityFunction aquiferFluidLevelSpread = DensityFunctions.noise(noiseParams.getOrThrow(Noises.AQUIFER_FLUID_LEVEL_SPREAD), 0.7142857142857143);
         DensityFunction aquiferLava = DensityFunctions.noise(noiseParams.getOrThrow(Noises.AQUIFER_LAVA));
-        DensityFunction temperature = RTFDensityFunctions.cell(CellSampler.Field.TEMPERATURE);
-        DensityFunction vegetation = RTFDensityFunctions.cell(CellSampler.Field.MOISTURE);
         DensityFunction factor = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.FACTOR);
         DensityFunction depth = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.DEPTH);
+        DensityFunction shiftX = NoiseRouterData.getFunction(densityFunctions, VANILLA_SHIFT_X);
+        DensityFunction shiftZ = NoiseRouterData.getFunction(densityFunctions, VANILLA_SHIFT_Z);
+        DensityFunction temperature = blendClimateAxis(
+            depth,
+            RTFDensityFunctions.cell(CellSampler.Field.TEMPERATURE),
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.TEMPERATURE))
+        );
+        DensityFunction vegetation = blendClimateAxis(
+            depth,
+            RTFDensityFunctions.cell(CellSampler.Field.MOISTURE),
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.VEGETATION))
+        );
+        DensityFunction surfaceContinents = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.CONTINENTS);
+        DensityFunction vanillaContinents = DensityFunctions.flatCache(
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.CONTINENTALNESS))
+        );
+        DensityFunction continents = blendClimateAxis(
+            depth,
+            surfaceContinents,
+            terrainAlignedUndergroundContinentalness(worldSettings, surfaceContinents, vanillaContinents)
+        );
+        DensityFunction surfaceErosion = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.EROSION);
+        DensityFunction vanillaErosion = DensityFunctions.flatCache(
+            DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.EROSION))
+        );
+        DensityFunction erosion = blendClimateAxis(
+            depth,
+            surfaceErosion,
+            terrainAlignedUndergroundErosion(
+                worldSettings,
+                RTFDensityFunctions.cell(CellSampler.Field.TERRAIN_EROSION),
+                vanillaErosion
+            )
+        );
+        DensityFunction ridges = blendClimateAxis(
+            depth,
+            NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.RIDGES),
+            DensityFunctions.flatCache(DensityFunctions.shiftedNoise2d(shiftX, shiftZ, 0.25D, noiseParams.getOrThrow(Noises.RIDGE)))
+        );
         DensityFunction initialDensity = NoiseRouterData.noiseGradientDensity(DensityFunctions.cache2d(factor), depth);
         DensityFunction slopedCheese = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.SLOPED_CHEESE);
 //        DensityFunction entrances = DensityFunctions.min(slopedCheese, DensityFunctions.mul(DensityFunctions.constant(5.0), NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.ENTRANCES)));
@@ -97,8 +140,67 @@ public class PresetNoiseRouterData {
         DensityFunction oreVeinB = NoiseRouterData.yLimitedInterpolatable(y, DensityFunctions.noise(noiseParams.getOrThrow(Noises.ORE_VEIN_B), 4.0, 4.0), minY, maxY, 0).abs();
         DensityFunction oreVein = DensityFunctions.add(DensityFunctions.constant(-0.08F), DensityFunctions.max(oreVeinA, oreVeinB));
         DensityFunction oreGap = DensityFunctions.noise(noiseParams.getOrThrow(Noises.ORE_GAP));
-        return new NoiseRouter(aquiferBarrier, aquiferFluidLevelFloodedness, aquiferFluidLevelSpread, aquiferLava, temperature, vegetation, NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.CONTINENTS), NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.EROSION), DensityFunctions.add(depth, DensityFunctions.constant(-0.205D)), NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.RIDGES), slideOverworld(DensityFunctions.add(initialDensity, DensityFunctions.constant(UNIT * -90)).clamp(-64.0, 64.0), -worldDepth), finalDensity, oreVeininess, oreVein, oreGap);
+        return new NoiseRouter(aquiferBarrier, aquiferFluidLevelFloodedness, aquiferFluidLevelSpread, aquiferLava, temperature, vegetation, continents, erosion, depth, ridges, slideOverworld(DensityFunctions.add(initialDensity, DensityFunctions.constant(UNIT * -90)).clamp(-64.0, 64.0), -worldDepth), finalDensity, oreVeininess, oreVein, oreGap);
 	}
+
+    private static DensityFunction blendClimateAxis(DensityFunction depth, DensityFunction surface, DensityFunction underground) {
+        double transitionRange = UNDERGROUND_CLIMATE_DEPTH - SURFACE_CLIMATE_DEPTH;
+        DensityFunction alpha = DensityFunctions.mul(
+            DensityFunctions.add(depth, DensityFunctions.constant(-SURFACE_CLIMATE_DEPTH)),
+            DensityFunctions.constant(1.0D / transitionRange)
+        ).clamp(0.0D, 1.0D);
+        return DensityFunctions.lerp(alpha, surface, underground);
+    }
+
+    private static DensityFunction terrainAlignedUndergroundContinentalness(
+        WorldSettings worldSettings,
+        DensityFunction surfaceContinents,
+        DensityFunction vanillaContinents
+    ) {
+        double squeezeLimit = 11.0D / 24.0D;
+        DensityFunction unitNoise = DensityFunctions.mul(
+            DensityFunctions.add(vanillaContinents.squeeze(), DensityFunctions.constant(squeezeLimit)),
+            DensityFunctions.constant(1.0D / (squeezeLimit * 2.0D))
+        );
+        DensityFunction inland = DensityFunctions.add(
+            DensityFunctions.constant(-0.11D),
+            DensityFunctions.mul(DensityFunctions.constant(1.11D), unitNoise.square())
+        );
+        return blendCoastToInland(worldSettings, surfaceContinents, inland);
+    }
+
+    private static DensityFunction terrainAlignedUndergroundErosion(
+        WorldSettings worldSettings,
+        DensityFunction terrainErosion,
+        DensityFunction vanillaErosion
+    ) {
+        DensityFunction landErosion = DensityFunctions.add(
+            terrainErosion,
+            DensityFunctions.mul(DensityFunctions.constant(UNDERGROUND_EROSION_VARIATION), vanillaErosion)
+        );
+        return blendCoastToInland(worldSettings, vanillaErosion, landErosion);
+    }
+
+    private static DensityFunction blendCoastToInland(
+        WorldSettings worldSettings,
+        DensityFunction coast,
+        DensityFunction inland
+    ) {
+        WorldSettings.ControlPoints controlPoints = worldSettings.controlPoints;
+        double transitionRange = controlPoints.inland - controlPoints.beach;
+        DensityFunction alpha = DensityFunctions.mul(
+            DensityFunctions.add(
+                RTFDensityFunctions.cell(CellSampler.Field.CONTINENT_EDGE),
+                DensityFunctions.constant(-controlPoints.beach)
+            ),
+            DensityFunctions.constant(1.0D / transitionRange)
+        ).clamp(0.0D, 1.0D);
+        return DensityFunctions.lerp(
+            alpha,
+            coast,
+            inland
+        );
+    }
 
     private static DensityFunction underground(float cheeseCaveProbability, HolderGetter<DensityFunction> densityFunctions, HolderGetter<NormalNoise.NoiseParameters> noiseParams, DensityFunction slopedCheese) {
         DensityFunction spaghetti2d = NoiseRouterData.getFunction(densityFunctions, NoiseRouterData.SPAGHETTI_2D);
@@ -171,5 +273,9 @@ public class PresetNoiseRouterData {
     
     private static ResourceKey<DensityFunction> createKey(String string) {
         return ResourceKey.create(Registries.DENSITY_FUNCTION, RTFCommon.location(string));
+    }
+
+    private static ResourceKey<DensityFunction> createMinecraftKey(String string) {
+        return ResourceKey.create(Registries.DENSITY_FUNCTION, ResourceLocation.withDefaultNamespace(string));
     }
 }

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinClimateSampler.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinClimateSampler.java
@@ -6,12 +6,14 @@ import org.spongepowered.asm.mixin.Mixin;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.biome.Climate;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.world.worldgen.biome.RTFClimateSampler;
 
 @Mixin(Climate.Sampler.class)
 @Implements(@Interface(iface = RTFClimateSampler.class, prefix = "reterraforged$RTFClimateSampler$"))
 class MixinClimateSampler {
 	private BlockPos spawnSearchCenter = BlockPos.ZERO;
+	private Preset undergroundBiomeBandingPreset;
 	
 	public void reterraforged$RTFClimateSampler$setSpawnSearchCenter(BlockPos spawnSearchCenter) {
 		this.spawnSearchCenter = spawnSearchCenter;
@@ -19,5 +21,13 @@ class MixinClimateSampler {
 	
 	public BlockPos reterraforged$RTFClimateSampler$getSpawnSearchCenter() {
 		return this.spawnSearchCenter;
+	}
+
+	public void reterraforged$RTFClimateSampler$setUndergroundBiomeBandingPreset(Preset preset) {
+		this.undergroundBiomeBandingPreset = preset;
+	}
+
+	public Preset reterraforged$RTFClimateSampler$getUndergroundBiomeBandingPreset() {
+		return this.undergroundBiomeBandingPreset;
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinMultiNoiseBiomeSourceCache.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinMultiNoiseBiomeSourceCache.java
@@ -4,11 +4,17 @@ import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Climate;
 import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.world.worldgen.biome.ClimatePointCache;
+import raccoonman.reterraforged.world.worldgen.biome.RTFClimateSampler;
+import raccoonman.reterraforged.world.worldgen.biome.UndergroundBiomeBanding;
+import raccoonman.reterraforged.world.worldgen.terrablender.TBCompat;
 
 /**
  * Memoizes {@code MultiNoiseBiomeSource.getNoiseBiome(x, y, z, sampler)} per thread.
@@ -16,6 +22,13 @@ import raccoonman.reterraforged.world.worldgen.biome.ClimatePointCache;
  */
 @Mixin(MultiNoiseBiomeSource.class)
 public abstract class MixinMultiNoiseBiomeSourceCache {
+    @Unique
+    private volatile Climate.ParameterList<Holder<Biome>> rtf$undergroundBandedParameters;
+    @Unique
+    private Preset rtf$undergroundBandingPreset;
+
+    @Shadow
+    protected abstract Climate.ParameterList<Holder<Biome>> parameters();
 
     @Inject(
             method = "getNoiseBiome(IIILnet/minecraft/world/level/biome/Climate$Sampler;)Lnet/minecraft/core/Holder;",
@@ -27,6 +40,41 @@ public abstract class MixinMultiNoiseBiomeSourceCache {
         if (hit != null) {
             cir.setReturnValue(hit);
         }
+    }
+
+    @Inject(
+            method = "getNoiseBiome(IIILnet/minecraft/world/level/biome/Climate$Sampler;)Lnet/minecraft/core/Holder;",
+            at = @At("HEAD"),
+            cancellable = true)
+    private void rtf$bandedNoiseBiome(final int x, final int y, final int z, final Climate.Sampler sampler,
+                                      final CallbackInfoReturnable<Holder<Biome>> cir) {
+        if (TBCompat.isEnabled() || !((Object) sampler instanceof RTFClimateSampler rtfSampler)) {
+            return;
+        }
+
+        Preset preset = rtfSampler.getUndergroundBiomeBandingPreset();
+        if (preset == null) {
+            return;
+        }
+
+        Climate.TargetPoint target = sampler.sample(x, y, z);
+        if (!UndergroundBiomeBanding.appliesAt(target)) {
+            return;
+        }
+
+        Climate.ParameterList<Holder<Biome>> banded = this.rtf$undergroundBandedParameters;
+        if (banded == null || this.rtf$undergroundBandingPreset != preset) {
+            synchronized (this) {
+                banded = this.rtf$undergroundBandedParameters;
+                if (banded == null || this.rtf$undergroundBandingPreset != preset) {
+                    banded = new Climate.ParameterList<>(UndergroundBiomeBanding.apply(preset, this.parameters().values()));
+                    this.rtf$undergroundBandingPreset = preset;
+                    this.rtf$undergroundBandedParameters = banded;
+                }
+            }
+        }
+
+        cir.setReturnValue(banded.findValue(target));
     }
 
     @Inject(

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinMultiNoiseBiomeSourceCache.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinMultiNoiseBiomeSourceCache.java
@@ -23,7 +23,7 @@ import raccoonman.reterraforged.world.worldgen.terrablender.TBCompat;
 @Mixin(MultiNoiseBiomeSource.class)
 public abstract class MixinMultiNoiseBiomeSourceCache {
     @Unique
-    private volatile Climate.ParameterList<Holder<Biome>> rtf$undergroundBandedParameters;
+    private volatile UndergroundBiomeBanding.Layout<Holder<Biome>> rtf$undergroundBanding;
     @Unique
     private Preset rtf$undergroundBandingPreset;
 
@@ -58,23 +58,22 @@ public abstract class MixinMultiNoiseBiomeSourceCache {
         }
 
         Climate.TargetPoint target = sampler.sample(x, y, z);
-        if (!UndergroundBiomeBanding.appliesAt(target)) {
-            return;
-        }
-
-        Climate.ParameterList<Holder<Biome>> banded = this.rtf$undergroundBandedParameters;
-        if (banded == null || this.rtf$undergroundBandingPreset != preset) {
+        UndergroundBiomeBanding.Layout<Holder<Biome>> banding = this.rtf$undergroundBanding;
+        if (banding == null || this.rtf$undergroundBandingPreset != preset) {
             synchronized (this) {
-                banded = this.rtf$undergroundBandedParameters;
-                if (banded == null || this.rtf$undergroundBandingPreset != preset) {
-                    banded = new Climate.ParameterList<>(UndergroundBiomeBanding.apply(preset, this.parameters().values()));
+                banding = this.rtf$undergroundBanding;
+                if (banding == null || this.rtf$undergroundBandingPreset != preset) {
+                    banding = UndergroundBiomeBanding.apply(preset, this.parameters().values());
                     this.rtf$undergroundBandingPreset = preset;
-                    this.rtf$undergroundBandedParameters = banded;
+                    this.rtf$undergroundBanding = banding;
                 }
             }
         }
+        if (!banding.appliesAt(target)) {
+            return;
+        }
 
-        cir.setReturnValue(banded.findValue(target));
+        cir.setReturnValue(banding.findValue(target));
     }
 
     @Inject(

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseChunk.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseChunk.java
@@ -1,5 +1,7 @@
 package raccoonman.reterraforged.mixin;
 
+import java.util.List;
+
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,6 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.minecraft.core.SectionPos;
 import net.minecraft.util.Mth;
+import net.minecraft.world.level.biome.Climate;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.Aquifer;
 import net.minecraft.world.level.levelgen.DensityFunction;
@@ -29,6 +32,7 @@ import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.MaxHeightUtil;
 import raccoonman.reterraforged.world.worldgen.RTFChunk;
 import raccoonman.reterraforged.world.worldgen.RTFRandomState;
+import raccoonman.reterraforged.world.worldgen.biome.RTFClimateSampler;
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.densityfunction.CellSampler;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
@@ -165,6 +169,22 @@ class MixinNoiseChunk {
 			}
 		}
 		return fluidPicker;
+	}
+
+	@Inject(
+		at = @At("RETURN"),
+		method = "cachedClimateSampler"
+	)
+	private void reterraforged$configureUndergroundBiomeBanding(
+		NoiseRouter noiseRouter,
+		List<Climate.ParameterPoint> spawnTarget,
+		CallbackInfoReturnable<Climate.Sampler> callback
+	) {
+		if ((Object) this.randomState instanceof RTFRandomState randomState
+			&& randomState.preset() != null
+			&& (Object) callback.getReturnValue() instanceof RTFClimateSampler sampler) {
+			sampler.setUndergroundBiomeBandingPreset(randomState.preset());
+		}
 	}
 
 	@Inject(

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinRandomState.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinRandomState.java
@@ -35,6 +35,7 @@ import raccoonman.reterraforged.world.worldgen.densityfunction.MarkerFunction;
 import raccoonman.reterraforged.world.worldgen.densityfunction.NoiseFunction;
 import raccoonman.reterraforged.world.worldgen.noise.module.Noise;
 import raccoonman.reterraforged.world.worldgen.noise.module.Noises;
+import raccoonman.reterraforged.world.worldgen.biome.RTFClimateSampler;
 import raccoonman.reterraforged.world.worldgen.terrablender.TBClimateSampler;
 import raccoonman.reterraforged.world.worldgen.terrablender.TBCompat;
 
@@ -121,6 +122,10 @@ class MixinRandomState {
 		// Only compile global density tags and build a heavy Overworld GeneratorContext
 		// if the base router mapping verified that this instance is actually an RTF worldgen dimension.
 		if (this.reterraforged$isRTFDimension) {
+			if (this.preset != null && (Object) this.sampler instanceof RTFClimateSampler rtfClimateSampler) {
+				rtfClimateSampler.setUndergroundBiomeBandingPreset(this.preset);
+			}
+
 			RegistryLookup<Noise> noises = registries.lookupOrThrow(RTFRegistries.NOISE);
 			RegistryLookup<DensityFunction> functions = registries.lookupOrThrow(Registries.DENSITY_FUNCTION);
 

--- a/common/src/main/java/raccoonman/reterraforged/mixin/terrablender/MixinParameterList.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/terrablender/MixinParameterList.java
@@ -1,16 +1,32 @@
 package raccoonman.reterraforged.mixin.terrablender;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import com.mojang.datafixers.util.Pair;
+
+import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.world.level.biome.Climate;
+import raccoonman.reterraforged.RTFCommon;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
+import raccoonman.reterraforged.registries.RTFRegistries;
+import raccoonman.reterraforged.world.worldgen.biome.UndergroundBiomeBanding;
 import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
 import raccoonman.reterraforged.world.worldgen.terrablender.TBTargetPoint;
+import terrablender.api.Region;
 import terrablender.api.RegionType;
 import terrablender.api.Regions;
 
@@ -20,14 +36,33 @@ import terrablender.api.Regions;
 )
 class MixinParameterList<T> {
 	private int maxIndex;
+	@Unique
+	private Preset reterraforged$bandingPreset;
+	@Unique
+	private final List<Climate.ParameterList<T>> reterraforged$pendingBandings = new ArrayList<>();
+	@Unique
+	private final List<Climate.ParameterList<T>> reterraforged$bandedTrees = new ArrayList<>();
+	@Unique
+	private boolean reterraforged$bandingInitialized;
 
 	@Inject(
 		at = @At("HEAD"),
 		method = "initializeForTerraBlender",
-		require = 1	
+		require = 1
 	)
-    public void initializeForTerraBlender(RegistryAccess registryAccess, RegionType regionType, long seed, CallbackInfo callback) {
-    	this.maxIndex = Regions.getCount(regionType) - 1;
+	public void initializeForTerraBlender(RegistryAccess registryAccess, RegionType regionType, long seed, CallbackInfo callback) {
+		this.maxIndex = Regions.getCount(regionType) - 1;
+		if (this.reterraforged$bandingInitialized) {
+			return;
+		}
+		this.reterraforged$bandingPreset = null;
+		this.reterraforged$pendingBandings.clear();
+		this.reterraforged$bandedTrees.clear();
+		if (regionType == RegionType.OVERWORLD) {
+			registryAccess.lookup(RTFRegistries.PRESET)
+				.flatMap(registry -> registry.get(Preset.KEY))
+				.ifPresent(holder -> this.reterraforged$bandingPreset = holder.value());
+		}
 //
 //    	registryAccess.lookup(RTFRegistries.PRESET).flatMap((registry) -> {
 //    		return registry.get(Preset.KEY);
@@ -37,7 +72,110 @@ class MixinParameterList<T> {
 //        		return RTFSurfaceRuleData.overworld(preset, registryAccess.lookupOrThrow(Registries.DENSITY_FUNCTION), registryAccess.lookupOrThrow(RTFRegistries.NOISE), defaultRules);
 //            });
 //    	});
-    }
+	}
+
+	@ModifyArg(
+		method = "initializeForTerraBlender",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/world/level/biome/Climate$RTree;create(Ljava/util/List;)Lnet/minecraft/world/level/biome/Climate$RTree;"
+		),
+		index = 0,
+		require = 1
+	)
+	private List<Pair<Climate.ParameterPoint, T>> reterraforged$prepareUndergroundBanding(
+		List<Pair<Climate.ParameterPoint, T>> entries
+	) {
+		if (this.reterraforged$bandingPreset != null) {
+			List<Pair<Climate.ParameterPoint, T>> bandedEntries = UndergroundBiomeBanding.apply(
+				this.reterraforged$bandingPreset,
+				entries
+			);
+			this.reterraforged$pendingBandings.add(new Climate.ParameterList<>(bandedEntries));
+		}
+		return entries;
+	}
+
+	@Inject(
+		method = "initializeForTerraBlender",
+		at = @At("RETURN"),
+		require = 1
+	)
+	private void reterraforged$indexUndergroundBandings(
+		RegistryAccess registryAccess,
+		RegionType regionType,
+		long seed,
+		CallbackInfo callback
+	) {
+		if (this.reterraforged$bandingInitialized) {
+			return;
+		}
+		if (this.reterraforged$bandingPreset == null) {
+			this.reterraforged$bandingInitialized = true;
+			return;
+		}
+
+		try {
+			Field uniqueTreesField = this.getClass().getDeclaredField("uniqueTrees");
+			uniqueTreesField.setAccessible(true);
+			Object uniqueTrees = uniqueTreesField.get(this);
+			int pendingIndex = 0;
+
+			for (int index = 0; index < Array.getLength(uniqueTrees); index++) {
+				this.reterraforged$bandedTrees.add(
+					Array.get(uniqueTrees, index) == null
+						? null
+						: this.reterraforged$pendingBandings.get(pendingIndex++)
+				);
+			}
+		} catch (ReflectiveOperationException | RuntimeException exception) {
+			this.reterraforged$bandedTrees.clear();
+			RTFCommon.LOGGER.error(
+				"Failed to index TerraBlender underground biome banding; preserving TerraBlender's original biome trees",
+				exception
+			);
+		} finally {
+			this.reterraforged$pendingBandings.clear();
+			this.reterraforged$bandingInitialized = true;
+		}
+	}
+
+	@Inject(
+		method = "findValuePositional",
+		at = @At("HEAD"),
+		cancellable = true,
+		require = 1
+	)
+	private void reterraforged$selectUndergroundBandedBiome(
+		Climate.TargetPoint targetPoint,
+		int x,
+		int y,
+		int z,
+		CallbackInfoReturnable<T> callback
+	) {
+		if (this.reterraforged$bandingPreset == null || !UndergroundBiomeBanding.appliesAt(targetPoint)) {
+			return;
+		}
+
+		int treeIndex = this.reterraforged$getUniqueness(targetPoint, x, y, z);
+		if (treeIndex < 0 || treeIndex >= this.reterraforged$bandedTrees.size()) {
+			return;
+		}
+		Climate.ParameterList<T> banded = this.reterraforged$bandedTrees.get(treeIndex);
+		if (banded == null) {
+			return;
+		}
+
+		T value = banded.findValue(targetPoint);
+		if (value instanceof Holder<?> holder
+			&& holder.unwrapKey().filter(Region.DEFERRED_PLACEHOLDER::equals).isPresent()) {
+			Climate.ParameterList<T> defaultBanding = this.reterraforged$bandedTrees.getFirst();
+			if (defaultBanding != null) {
+				value = defaultBanding.findValue(targetPoint);
+			}
+		}
+		callback.setReturnValue(value);
+	}
 
 	@Redirect(
 		method = "findValuePositional",
@@ -45,22 +183,27 @@ class MixinParameterList<T> {
 			value = "INVOKE",
 			target = "Lnet/minecraft/world/level/biome/Climate$ParameterList;getUniqueness(III)I"
 		),
-		require = 0	
+		require = 0
 	)
-    public int getUniqueness(Climate.ParameterList<T> parameterList, int x, int y, int z, Climate.TargetPoint targetPoint) {
-		if((Object) targetPoint instanceof TBTargetPoint tbTargetPoint) {
+	public int getUniqueness(Climate.ParameterList<T> parameterList, int x, int y, int z, Climate.TargetPoint targetPoint) {
+		return this.reterraforged$getUniqueness(targetPoint, x, y, z);
+	}
+
+	@Unique
+	private int reterraforged$getUniqueness(Climate.TargetPoint targetPoint, int x, int y, int z) {
+		if ((Object) targetPoint instanceof TBTargetPoint tbTargetPoint) {
 			double uniqueness = tbTargetPoint.getUniqueness();
-			if(Double.isNaN(uniqueness)) {
+			if (Double.isNaN(uniqueness)) {
 				return this.getUniqueness(x, y, z);
 			}
 			return NoiseUtil.round(this.maxIndex * (float) uniqueness);
 		} else {
 			throw new IllegalStateException();
 		}
-    }
+	}
 
 	@Shadow
-    public int getUniqueness(int x, int y, int z) {
-    	throw new UnsupportedOperationException();
-    }
+	public int getUniqueness(int x, int y, int z) {
+		throw new UnsupportedOperationException();
+	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/mixin/terrablender/MixinParameterList.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/terrablender/MixinParameterList.java
@@ -39,9 +39,9 @@ class MixinParameterList<T> {
 	@Unique
 	private Preset reterraforged$bandingPreset;
 	@Unique
-	private final List<Climate.ParameterList<T>> reterraforged$pendingBandings = new ArrayList<>();
+	private final List<UndergroundBiomeBanding.Layout<T>> reterraforged$pendingBandings = new ArrayList<>();
 	@Unique
-	private final List<Climate.ParameterList<T>> reterraforged$bandedTrees = new ArrayList<>();
+	private final List<UndergroundBiomeBanding.Layout<T>> reterraforged$bandedTrees = new ArrayList<>();
 	@Unique
 	private boolean reterraforged$bandingInitialized;
 
@@ -87,11 +87,10 @@ class MixinParameterList<T> {
 		List<Pair<Climate.ParameterPoint, T>> entries
 	) {
 		if (this.reterraforged$bandingPreset != null) {
-			List<Pair<Climate.ParameterPoint, T>> bandedEntries = UndergroundBiomeBanding.apply(
+			this.reterraforged$pendingBandings.add(UndergroundBiomeBanding.apply(
 				this.reterraforged$bandingPreset,
 				entries
-			);
-			this.reterraforged$pendingBandings.add(new Climate.ParameterList<>(bandedEntries));
+			));
 		}
 		return entries;
 	}
@@ -153,7 +152,7 @@ class MixinParameterList<T> {
 		int z,
 		CallbackInfoReturnable<T> callback
 	) {
-		if (this.reterraforged$bandingPreset == null || !UndergroundBiomeBanding.appliesAt(targetPoint)) {
+		if (this.reterraforged$bandingPreset == null) {
 			return;
 		}
 
@@ -161,18 +160,22 @@ class MixinParameterList<T> {
 		if (treeIndex < 0 || treeIndex >= this.reterraforged$bandedTrees.size()) {
 			return;
 		}
-		Climate.ParameterList<T> banded = this.reterraforged$bandedTrees.get(treeIndex);
-		if (banded == null) {
+		UndergroundBiomeBanding.Layout<T> banding = this.reterraforged$bandedTrees.get(treeIndex);
+		if (banding == null) {
+			return;
+		}
+		if (!banding.appliesAt(targetPoint)) {
 			return;
 		}
 
-		T value = banded.findValue(targetPoint);
+		T value = banding.findValue(targetPoint);
 		if (value instanceof Holder<?> holder
 			&& holder.unwrapKey().filter(Region.DEFERRED_PLACEHOLDER::equals).isPresent()) {
-			Climate.ParameterList<T> defaultBanding = this.reterraforged$bandedTrees.getFirst();
-			if (defaultBanding != null) {
-				value = defaultBanding.findValue(targetPoint);
+			UndergroundBiomeBanding.Layout<T> defaultBanding = this.reterraforged$bandedTrees.getFirst();
+			if (defaultBanding == null || !defaultBanding.appliesAt(targetPoint)) {
+				return;
 			}
+			value = defaultBanding.findValue(targetPoint);
 		}
 		callback.setReturnValue(value);
 	}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/RTFClimateSampler.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/RTFClimateSampler.java
@@ -1,9 +1,17 @@
 package raccoonman.reterraforged.world.worldgen.biome;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.minecraft.core.BlockPos;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 
 public interface RTFClimateSampler {
 	void setSpawnSearchCenter(BlockPos center);
 	
 	BlockPos getSpawnSearchCenter();
+
+	void setUndergroundBiomeBandingPreset(@Nullable Preset preset);
+
+	@Nullable
+	Preset getUndergroundBiomeBandingPreset();
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/UndergroundBiomeBanding.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/UndergroundBiomeBanding.java
@@ -1,0 +1,171 @@
+package raccoonman.reterraforged.world.worldgen.biome;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.mojang.datafixers.util.Pair;
+
+import net.minecraft.world.level.biome.Climate;
+import raccoonman.reterraforged.RTFCommon;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
+import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
+
+/**
+ * Redistributes convention-following underground biome points through the usable world depth.
+ *
+ * <p>The original shallow cave points remain untouched. Dynamic bands begin at vanilla's bottom
+ * depth point, use weirdness partitions for horizontally coherent candidate rotation, and leave
+ * nonconforming mod registrations unchanged.</p>
+ */
+public final class UndergroundBiomeBanding {
+	public static final int DEFAULT_BIOME_SIZE = 225;
+
+	private static final float VANILLA_UNDERGROUND_DEPTH_START = 0.2F;
+	private static final float VANILLA_UNDERGROUND_DEPTH_END = 0.9F;
+	private static final float BANDING_DEPTH_START = 1.1F;
+	private static final float DEPTH_UNITS_PER_BLOCK = 1.0F / 128.0F;
+	private static final int DEFAULT_WORLD_DEPTH = 64;
+	private static final int MAX_TERRAIN_HEIGHT = 256;
+	private static final int MAX_BAND_COUNT = 32;
+	private static final long BAND_FALLBACK_OFFSET = 0L;
+
+	private static final Climate.Parameter VANILLA_UNDERGROUND_DEPTH = Climate.Parameter.span(VANILLA_UNDERGROUND_DEPTH_START, VANILLA_UNDERGROUND_DEPTH_END);
+	private static final Climate.Parameter VANILLA_BOTTOM_DEPTH = Climate.Parameter.point(1.1F);
+	private static final Climate.Parameter VANILLA_FULL_RANGE = Climate.Parameter.span(-1.0F, 1.0F);
+
+	private UndergroundBiomeBanding() {
+	}
+
+	public static <T> List<Pair<Climate.ParameterPoint, T>> apply(Preset preset, List<Pair<Climate.ParameterPoint, T>> entries) {
+		Map<T, List<Pair<Climate.ParameterPoint, T>>> candidates = new LinkedHashMap<>();
+		List<Pair<Climate.ParameterPoint, T>> retained = new ArrayList<>(entries.size());
+
+		for (Pair<Climate.ParameterPoint, T> entry : entries) {
+			Climate.ParameterPoint point = entry.getFirst();
+			if (isVanillaConventionUnderground(point)) {
+				candidates.computeIfAbsent(entry.getSecond(), ignored -> new ArrayList<>()).add(entry);
+				if (point.depth().equals(VANILLA_UNDERGROUND_DEPTH)) {
+					retained.add(entry);
+				}
+			} else {
+				retained.add(entry);
+			}
+		}
+
+		if (candidates.size() < 2) {
+			return entries;
+		}
+
+		int bandCount = bandCount(preset, candidates.size());
+		float endDepth = endDepth(preset);
+		float bandWidth = (endDepth - BANDING_DEPTH_START) / bandCount;
+		List<T> candidateValues = List.copyOf(candidates.keySet());
+		int regimeCount = candidateValues.size();
+		List<Pair<Climate.ParameterPoint, T>> result = new ArrayList<>(
+			retained.size() + entries.size() * Math.max(bandCount, regimeCount)
+		);
+		result.addAll(retained);
+
+		for (int regime = 0; regime < regimeCount; regime++) {
+			Climate.Parameter regimeRange = partition(VANILLA_FULL_RANGE, regime, regimeCount);
+
+			for (int band = 0; band < bandCount; band++) {
+				T value = candidateValues.get(Math.floorMod(band + regime, regimeCount));
+				Climate.Parameter bandRange = Climate.Parameter.span(
+					BANDING_DEPTH_START + bandWidth * band,
+					band == bandCount - 1 ? endDepth : BANDING_DEPTH_START + bandWidth * (band + 1)
+				);
+
+				for (Pair<Climate.ParameterPoint, T> source : candidates.get(value)) {
+					Climate.ParameterPoint point = source.getFirst();
+					result.add(Pair.of(
+						withDepthAndWeirdness(point, bandRange, regimeRange),
+						source.getSecond()
+					));
+				}
+				if (band > 0) {
+					result.add(Pair.of(
+						new Climate.ParameterPoint(
+							VANILLA_FULL_RANGE,
+							VANILLA_FULL_RANGE,
+							VANILLA_FULL_RANGE,
+							VANILLA_FULL_RANGE,
+							bandRange,
+							regimeRange,
+							BAND_FALLBACK_OFFSET
+						),
+						value
+					));
+				}
+			}
+		}
+
+		RTFCommon.LOGGER.info(
+			"Applied underground biome banding: {} candidate biomes, {} bands, {} regimes, depth {}..{}, {} -> {} parameter points",
+			candidates.size(),
+			bandCount,
+			regimeCount,
+			BANDING_DEPTH_START,
+			endDepth,
+			entries.size(),
+			result.size()
+		);
+		return List.copyOf(result);
+	}
+
+	public static double undergroundNoiseScale(Preset preset) {
+		int biomeSize = Math.max(1, preset.climate().biomeShape.biomeSize);
+		return 0.25D * DEFAULT_BIOME_SIZE / biomeSize;
+	}
+
+	public static boolean appliesAt(Climate.TargetPoint target) {
+		return target.depth() >= VANILLA_BOTTOM_DEPTH.min();
+	}
+
+	static int bandCount(Preset preset, int candidateCount) {
+		WorldSettings.Properties properties = preset.world().properties;
+		int terrainHeight = Math.min(properties.worldHeight, MAX_TERRAIN_HEIGHT);
+		float usableHeight = properties.worldDepth + terrainHeight - BANDING_DEPTH_START / DEPTH_UNITS_PER_BLOCK;
+		float defaultUsableHeight = DEFAULT_WORLD_DEPTH + MAX_TERRAIN_HEIGHT - BANDING_DEPTH_START / DEPTH_UNITS_PER_BLOCK;
+		// Square roots keep extreme depth and Biome Size settings useful without exploding the R-tree.
+		float verticalScale = (float) Math.sqrt(Math.max(1.0F, usableHeight) / defaultUsableHeight);
+		float biomeScale = (float) Math.sqrt((float) DEFAULT_BIOME_SIZE / Math.max(1, preset.climate().biomeShape.biomeSize));
+		return Math.clamp(Math.round(candidateCount * verticalScale * biomeScale), 1, MAX_BAND_COUNT);
+	}
+
+	static float endDepth(Preset preset) {
+		WorldSettings.Properties properties = preset.world().properties;
+		int terrainHeight = Math.min(properties.worldHeight, MAX_TERRAIN_HEIGHT);
+		return Math.max(BANDING_DEPTH_START + DEPTH_UNITS_PER_BLOCK, (properties.worldDepth + terrainHeight) * DEPTH_UNITS_PER_BLOCK);
+	}
+
+	private static boolean isVanillaConventionUnderground(Climate.ParameterPoint point) {
+		return point.weirdness().equals(VANILLA_FULL_RANGE)
+			&& (point.depth().equals(VANILLA_UNDERGROUND_DEPTH) || point.depth().equals(VANILLA_BOTTOM_DEPTH));
+	}
+
+	private static Climate.ParameterPoint withDepthAndWeirdness(
+		Climate.ParameterPoint point,
+		Climate.Parameter depth,
+		Climate.Parameter weirdness
+	) {
+		return new Climate.ParameterPoint(
+			point.temperature(),
+			point.humidity(),
+			point.continentalness(),
+			point.erosion(),
+			depth,
+			weirdness,
+			point.offset()
+		);
+	}
+
+	private static Climate.Parameter partition(Climate.Parameter range, int index, int count) {
+		long width = range.max() - range.min();
+		long min = range.min() + width * index / count;
+		long max = index == count - 1 ? range.max() : range.min() + width * (index + 1) / count;
+		return new Climate.Parameter(min, max);
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/UndergroundBiomeBanding.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/UndergroundBiomeBanding.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.mojang.datafixers.util.Pair;
 
 import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.levelgen.NoiseRouterData;
 import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
@@ -15,39 +16,46 @@ import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
 /**
  * Redistributes convention-following underground biome points through the usable world depth.
  *
- * <p>The original shallow cave points remain untouched. Dynamic bands begin at vanilla's bottom
- * depth point, use weirdness partitions for horizontally coherent candidate rotation, and leave
- * nonconforming mod registrations unchanged.</p>
+ * <p>A terrain-relative surface buffer keeps cave biomes away from the surface. Shallow cave
+ * candidates are then banded down to vanilla's bottom-biome threshold; below that threshold,
+ * shallow and bottom candidates are banded together. Weirdness partitions provide horizontally
+ * coherent candidate rotation, while nonconforming mod registrations remain unchanged.</p>
  */
 public final class UndergroundBiomeBanding {
 	public static final int DEFAULT_BIOME_SIZE = 225;
 
 	private static final float VANILLA_UNDERGROUND_DEPTH_START = 0.2F;
 	private static final float VANILLA_UNDERGROUND_DEPTH_END = 0.9F;
-	private static final float BANDING_DEPTH_START = 1.1F;
+	private static final float VANILLA_BOTTOM_DEPTH = 1.1F;
 	private static final float DEPTH_UNITS_PER_BLOCK = 1.0F / 128.0F;
+	private static final float SURFACE_DEPTH = NoiseRouterData.GLOBAL_OFFSET + 0.5F;
+	private static final float SHALLOW_STAGE_END = Climate.unquantizeCoord(Climate.quantizeCoord(VANILLA_BOTTOM_DEPTH) - 1L);
 	private static final int DEFAULT_WORLD_DEPTH = 64;
 	private static final int MAX_TERRAIN_HEIGHT = 256;
 	private static final int MAX_BAND_COUNT = 32;
+	static final int MAX_SURFACE_BUFFER_BLOCKS = 24;
 	private static final long BAND_FALLBACK_OFFSET = 0L;
+	private static final float DEFAULT_DYNAMIC_STAGE_BLOCKS =
+		DEFAULT_WORLD_DEPTH + MAX_TERRAIN_HEIGHT - VANILLA_BOTTOM_DEPTH / DEPTH_UNITS_PER_BLOCK;
 
 	private static final Climate.Parameter VANILLA_UNDERGROUND_DEPTH = Climate.Parameter.span(VANILLA_UNDERGROUND_DEPTH_START, VANILLA_UNDERGROUND_DEPTH_END);
-	private static final Climate.Parameter VANILLA_BOTTOM_DEPTH = Climate.Parameter.point(1.1F);
+	private static final Climate.Parameter VANILLA_BOTTOM = Climate.Parameter.point(VANILLA_BOTTOM_DEPTH);
 	private static final Climate.Parameter VANILLA_FULL_RANGE = Climate.Parameter.span(-1.0F, 1.0F);
 
 	private UndergroundBiomeBanding() {
 	}
 
-	public static <T> List<Pair<Climate.ParameterPoint, T>> apply(Preset preset, List<Pair<Climate.ParameterPoint, T>> entries) {
-		Map<T, List<Pair<Climate.ParameterPoint, T>>> candidates = new LinkedHashMap<>();
+	public static <T> Layout<T> apply(Preset preset, List<Pair<Climate.ParameterPoint, T>> entries) {
+		Map<T, Candidate<T>> candidates = new LinkedHashMap<>();
 		List<Pair<Climate.ParameterPoint, T>> retained = new ArrayList<>(entries.size());
 
 		for (Pair<Climate.ParameterPoint, T> entry : entries) {
 			Climate.ParameterPoint point = entry.getFirst();
 			if (isVanillaConventionUnderground(point)) {
-				candidates.computeIfAbsent(entry.getSecond(), ignored -> new ArrayList<>()).add(entry);
 				if (point.depth().equals(VANILLA_UNDERGROUND_DEPTH)) {
-					retained.add(entry);
+					candidates.computeIfAbsent(entry.getSecond(), Candidate::new).shallow = true;
+				} else {
+					candidates.computeIfAbsent(entry.getSecond(), Candidate::new).bottom = true;
 				}
 			} else {
 				retained.add(entry);
@@ -55,64 +63,48 @@ public final class UndergroundBiomeBanding {
 		}
 
 		if (candidates.size() < 2) {
-			return entries;
+			return Layout.unmodified(entries);
 		}
 
-		int bandCount = bandCount(preset, candidates.size());
 		float endDepth = endDepth(preset);
-		float bandWidth = (endDepth - BANDING_DEPTH_START) / bandCount;
-		List<T> candidateValues = List.copyOf(candidates.keySet());
-		int regimeCount = candidateValues.size();
+		List<T> shallowValues = candidates.values().stream()
+			.filter(candidate -> candidate.shallow)
+			.map(candidate -> candidate.value)
+			.toList();
+		List<T> deepValues = List.copyOf(candidates.keySet());
+		long bottomCandidateCount = candidates.values().stream()
+			.filter(candidate -> candidate.bottom)
+			.count();
+		float bandingStart = bandingStart(preset, shallowValues.size());
 		List<Pair<Climate.ParameterPoint, T>> result = new ArrayList<>(
-			retained.size() + entries.size() * Math.max(bandCount, regimeCount)
+			retained.size() + MAX_BAND_COUNT * (shallowValues.size() + deepValues.size())
 		);
 		result.addAll(retained);
 
-		for (int regime = 0; regime < regimeCount; regime++) {
-			Climate.Parameter regimeRange = partition(VANILLA_FULL_RANGE, regime, regimeCount);
-
-			for (int band = 0; band < bandCount; band++) {
-				T value = candidateValues.get(Math.floorMod(band + regime, regimeCount));
-				Climate.Parameter bandRange = Climate.Parameter.span(
-					BANDING_DEPTH_START + bandWidth * band,
-					band == bandCount - 1 ? endDepth : BANDING_DEPTH_START + bandWidth * (band + 1)
-				);
-
-				for (Pair<Climate.ParameterPoint, T> source : candidates.get(value)) {
-					Climate.ParameterPoint point = source.getFirst();
-					result.add(Pair.of(
-						withDepthAndWeirdness(point, bandRange, regimeRange),
-						source.getSecond()
-					));
-				}
-				if (band > 0) {
-					result.add(Pair.of(
-						new Climate.ParameterPoint(
-							VANILLA_FULL_RANGE,
-							VANILLA_FULL_RANGE,
-							VANILLA_FULL_RANGE,
-							VANILLA_FULL_RANGE,
-							bandRange,
-							regimeRange,
-							BAND_FALLBACK_OFFSET
-						),
-						value
-					));
-				}
-			}
+		float shallowEnd = Math.min(SHALLOW_STAGE_END, endDepth);
+		int shallowBands = addStage(preset, result, shallowValues, bandingStart, shallowEnd);
+		int deepBands = addStage(preset, result, deepValues, VANILLA_BOTTOM_DEPTH, endDepth);
+		if (shallowBands == 0 && deepBands == 0) {
+			return Layout.unmodified(entries);
 		}
 
 		RTFCommon.LOGGER.info(
-			"Applied underground biome banding: {} candidate biomes, {} bands, {} regimes, depth {}..{}, {} -> {} parameter points",
+			"Applied staged underground biome banding: {} shallow candidates / {} bands, {} total deep-stage candidates ({} bottom-role) / {} bands, surface buffer {} blocks, depth {}..{}, {} -> {} parameter points",
+			shallowValues.size(),
+			shallowBands,
 			candidates.size(),
-			bandCount,
-			regimeCount,
-			BANDING_DEPTH_START,
+			bottomCandidateCount,
+			deepBands,
+			(bandingStart - SURFACE_DEPTH) / DEPTH_UNITS_PER_BLOCK,
+			bandingStart,
 			endDepth,
 			entries.size(),
 			result.size()
 		);
-		return List.copyOf(result);
+		return new Layout<>(
+			new Climate.ParameterList<>(List.copyOf(result)),
+			Climate.quantizeCoord(bandingStart)
+		);
 	}
 
 	public static double undergroundNoiseScale(Preset preset) {
@@ -120,17 +112,13 @@ public final class UndergroundBiomeBanding {
 		return 0.25D * DEFAULT_BIOME_SIZE / biomeSize;
 	}
 
-	public static boolean appliesAt(Climate.TargetPoint target) {
-		return target.depth() >= VANILLA_BOTTOM_DEPTH.min();
-	}
-
-	static int bandCount(Preset preset, int candidateCount) {
-		WorldSettings.Properties properties = preset.world().properties;
-		int terrainHeight = Math.min(properties.worldHeight, MAX_TERRAIN_HEIGHT);
-		float usableHeight = properties.worldDepth + terrainHeight - BANDING_DEPTH_START / DEPTH_UNITS_PER_BLOCK;
-		float defaultUsableHeight = DEFAULT_WORLD_DEPTH + MAX_TERRAIN_HEIGHT - BANDING_DEPTH_START / DEPTH_UNITS_PER_BLOCK;
+	static int bandCount(Preset preset, int candidateCount, float startDepth, float endDepth) {
+		if (candidateCount == 0 || endDepth <= startDepth) {
+			return 0;
+		}
+		float stageBlocks = (endDepth - startDepth) / DEPTH_UNITS_PER_BLOCK;
 		// Square roots keep extreme depth and Biome Size settings useful without exploding the R-tree.
-		float verticalScale = (float) Math.sqrt(Math.max(1.0F, usableHeight) / defaultUsableHeight);
+		float verticalScale = (float) Math.sqrt(Math.max(1.0F, stageBlocks) / DEFAULT_DYNAMIC_STAGE_BLOCKS);
 		float biomeScale = (float) Math.sqrt((float) DEFAULT_BIOME_SIZE / Math.max(1, preset.climate().biomeShape.biomeSize));
 		return Math.clamp(Math.round(candidateCount * verticalScale * biomeScale), 1, MAX_BAND_COUNT);
 	}
@@ -138,28 +126,59 @@ public final class UndergroundBiomeBanding {
 	static float endDepth(Preset preset) {
 		WorldSettings.Properties properties = preset.world().properties;
 		int terrainHeight = Math.min(properties.worldHeight, MAX_TERRAIN_HEIGHT);
-		return Math.max(BANDING_DEPTH_START + DEPTH_UNITS_PER_BLOCK, (properties.worldDepth + terrainHeight) * DEPTH_UNITS_PER_BLOCK);
+		return Math.max(SURFACE_DEPTH + DEPTH_UNITS_PER_BLOCK, (properties.worldDepth + terrainHeight) * DEPTH_UNITS_PER_BLOCK);
+	}
+
+	static float bandingStart(Preset preset, int shallowCandidateCount) {
+		float shallowEnd = Math.min(VANILLA_BOTTOM_DEPTH, endDepth(preset));
+		if (shallowCandidateCount == 0 || shallowEnd <= SURFACE_DEPTH) {
+			return VANILLA_BOTTOM_DEPTH;
+		}
+		int naturalBandCount = bandCount(preset, shallowCandidateCount, SURFACE_DEPTH, shallowEnd);
+		float naturalBuffer = (shallowEnd - SURFACE_DEPTH) / (naturalBandCount + 1);
+		float cappedBuffer = Math.min(MAX_SURFACE_BUFFER_BLOCKS * DEPTH_UNITS_PER_BLOCK, naturalBuffer);
+		return SURFACE_DEPTH + cappedBuffer;
 	}
 
 	private static boolean isVanillaConventionUnderground(Climate.ParameterPoint point) {
 		return point.weirdness().equals(VANILLA_FULL_RANGE)
-			&& (point.depth().equals(VANILLA_UNDERGROUND_DEPTH) || point.depth().equals(VANILLA_BOTTOM_DEPTH));
+			&& (point.depth().equals(VANILLA_UNDERGROUND_DEPTH) || point.depth().equals(VANILLA_BOTTOM));
 	}
 
-	private static Climate.ParameterPoint withDepthAndWeirdness(
-		Climate.ParameterPoint point,
-		Climate.Parameter depth,
-		Climate.Parameter weirdness
+	private static <T> int addStage(
+		Preset preset,
+		List<Pair<Climate.ParameterPoint, T>> result,
+		List<T> candidateValues,
+		float startDepth,
+		float endDepth
 	) {
-		return new Climate.ParameterPoint(
-			point.temperature(),
-			point.humidity(),
-			point.continentalness(),
-			point.erosion(),
-			depth,
-			weirdness,
-			point.offset()
-		);
+		int bandCount = bandCount(preset, candidateValues.size(), startDepth, endDepth);
+		if (bandCount == 0) {
+			return 0;
+		}
+		float bandWidth = (endDepth - startDepth) / bandCount;
+		int regimeCount = candidateValues.size();
+		for (int regime = 0; regime < regimeCount; regime++) {
+			Climate.Parameter regimeRange = partition(VANILLA_FULL_RANGE, regime, regimeCount);
+			for (int band = 0; band < bandCount; band++) {
+				float bandStart = startDepth + bandWidth * band;
+				float bandEnd = band == bandCount - 1 ? endDepth : startDepth + bandWidth * (band + 1);
+				T value = candidateValues.get(Math.floorMod(band + regime, regimeCount));
+				result.add(Pair.of(
+					new Climate.ParameterPoint(
+						VANILLA_FULL_RANGE,
+						VANILLA_FULL_RANGE,
+						VANILLA_FULL_RANGE,
+						VANILLA_FULL_RANGE,
+						Climate.Parameter.span(bandStart, bandEnd),
+						regimeRange,
+						BAND_FALLBACK_OFFSET
+					),
+					value
+				));
+			}
+		}
+		return bandCount;
 	}
 
 	private static Climate.Parameter partition(Climate.Parameter range, int index, int count) {
@@ -167,5 +186,39 @@ public final class UndergroundBiomeBanding {
 		long min = range.min() + width * index / count;
 		long max = index == count - 1 ? range.max() : range.min() + width * (index + 1) / count;
 		return new Climate.Parameter(min, max);
+	}
+
+	private static final class Candidate<T> {
+		private final T value;
+		private boolean shallow;
+		private boolean bottom;
+
+		private Candidate(T value) {
+			this.value = value;
+		}
+	}
+
+	/**
+	 * Uses the untouched parameter list above the local surface buffer and a fully covered staged
+	 * parameter list below it. The hard switch keeps nearest-neighbor entries from bleeding upward.
+	 */
+	public record Layout<T>(
+		Climate.ParameterList<T> parameters,
+		long bandingStart
+	) {
+		private static <T> Layout<T> unmodified(List<Pair<Climate.ParameterPoint, T>> entries) {
+			return new Layout<>(
+				new Climate.ParameterList<>(entries),
+				Long.MAX_VALUE
+			);
+		}
+
+		public boolean appliesAt(Climate.TargetPoint target) {
+			return target.depth() >= this.bandingStart;
+		}
+
+		public T findValue(Climate.TargetPoint target) {
+			return this.parameters.findValue(target);
+		}
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
@@ -49,6 +49,8 @@ public class Cell {
     public BiomeType biome;
     public float erosion;
     public float weirdness;
+    // Terrain-selected erosion before rivers and climate apply biome-specific overrides.
+    public float terrainErosion;
     public float temperature;
     public float moisture;
 
@@ -92,6 +94,7 @@ public class Cell {
         this.biome = other.biome;
         this.erosion = other.erosion;
         this.weirdness = other.weirdness;
+        this.terrainErosion = other.terrainErosion;
         this.temperature = other.temperature;
         this.moisture = other.moisture;
         this.beachNoise = other.beachNoise;

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/heightmap/Heightmap.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/heightmap/Heightmap.java
@@ -55,6 +55,7 @@ public record Heightmap(CellPopulator terrain, CellPopulator region, Continent c
 	}
 	
 	public void applyRivers(Cell cell, float x, float z, Rivermap rivermap) {
+		cell.terrainErosion = cell.erosion;
         rivermap.apply(cell, x, z);
         VolcanoPopulator.modifyVolcanoType(cell, this.levels);
 	}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/CellSampler.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/densityfunction/CellSampler.java
@@ -178,11 +178,25 @@ public record CellSampler(Supplier<WorldLookup> deferredLookup, Field field) imp
 
 			}
 		},
+		CONTINENT_EDGE("continent_edge") {
+
+			@Override
+			public float read(Cell cell, Heightmap heightmap) {
+				return cell.continentEdge;
+			}
+		},
 		EROSION("erosion") {
 			
 			@Override
 			public float read(Cell cell, Heightmap heightmap) {
 				return cell.erosion;
+			}
+		},
+		TERRAIN_EROSION("terrain_erosion") {
+
+			@Override
+			public float read(Cell cell, Heightmap heightmap) {
+				return cell.terrainErosion;
 			}
 		},
 		WEIRDNESS("weirdness") {

--- a/common/src/test/java/raccoonman/reterraforged/world/worldgen/biome/UndergroundBiomeBandingTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/world/worldgen/biome/UndergroundBiomeBandingTest.java
@@ -1,0 +1,224 @@
+package raccoonman.reterraforged.world.worldgen.biome;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+
+import com.mojang.datafixers.util.Pair;
+
+import net.minecraft.world.level.biome.Climate;
+import net.minecraft.world.level.levelgen.NoiseRouterData;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Presets;
+
+class UndergroundBiomeBandingTest {
+	private static final float DEPTH_UNITS_PER_BLOCK = 1.0F / 128.0F;
+	private static final float SURFACE_DEPTH = NoiseRouterData.GLOBAL_OFFSET + 0.5F;
+	private static final float BOTTOM_DEPTH = 1.1F;
+	private static final Climate.Parameter FULL_RANGE = Climate.Parameter.span(-1.0F, 1.0F);
+	private static final Climate.Parameter SHALLOW_CAVE_DEPTH = Climate.Parameter.span(0.2F, 0.9F);
+	private static final Climate.Parameter BOTTOM_CAVE_DEPTH = Climate.Parameter.point(BOTTOM_DEPTH);
+	private static final Set<String> VANILLA_CAVES = Set.of("dripstone", "lush", "deep_dark");
+
+	@Test
+	void capsADeepWorldSurfaceBufferAtTwentyFourBlocks() {
+		Preset preset = preset(1024, 640, 50);
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, vanillaLikeEntries());
+		float startDepth = Climate.unquantizeCoord(banding.bandingStart());
+
+		assertEquals(SURFACE_DEPTH + 24.0F * DEPTH_UNITS_PER_BLOCK, startDepth, 0.0001F);
+		assertEquals(
+			UndergroundBiomeBanding.MAX_SURFACE_BUFFER_BLOCKS,
+			(startDepth - SURFACE_DEPTH) / DEPTH_UNITS_PER_BLOCK,
+			0.02F
+		);
+		assertFalse(banding.appliesAt(target(startDepth - 0.0001F, 0.0F)));
+		assertTrue(banding.appliesAt(target(startDepth, 0.0F)));
+	}
+
+	@Test
+	void compressesTheSurfaceBufferInAnExtremelyShallowWorld() {
+		Preset preset = preset(0, 16, 225);
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, vanillaLikeEntries());
+		float startDepth = Climate.unquantizeCoord(banding.bandingStart());
+		float bufferBlocks = (startDepth - SURFACE_DEPTH) / DEPTH_UNITS_PER_BLOCK;
+
+		assertTrue(bufferBlocks > 0.0F);
+		assertTrue(bufferBlocks < UndergroundBiomeBanding.MAX_SURFACE_BUFFER_BLOCKS);
+		assertTrue(startDepth < UndergroundBiomeBanding.endDepth(preset));
+		assertTrue(banding.appliesAt(target((startDepth + UndergroundBiomeBanding.endDepth(preset)) * 0.5F, 0.0F)));
+	}
+
+	@Test
+	void leavesTheOriginalLookupUntouchedAboveTheSurfaceBuffer() {
+		Preset preset = preset(1024, 640, 50);
+		List<Pair<Climate.ParameterPoint, String>> entries = vanillaLikeEntries();
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, entries);
+		Climate.TargetPoint target = target(0.1F, 0.0F);
+
+		assertFalse(banding.appliesAt(target));
+		assertEquals("surface", new Climate.ParameterList<>(entries).findValue(target));
+	}
+
+	@Test
+	void usesOnlyShallowRegisteredCandidatesBeforeBottomDepth() {
+		Preset preset = preset(1024, 640, 50);
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, vanillaLikeEntries());
+
+		assertEquals(Set.of("dripstone", "lush"), fallbackValuesAt(banding.parameters().values(), 0.3F));
+		assertEquals("dripstone", banding.findValue(target(0.3F, -0.8F)));
+		assertEquals("lush", banding.findValue(target(0.3F, 0.8F)));
+		for (float depth = Climate.unquantizeCoord(banding.bandingStart()); depth < BOTTOM_DEPTH; depth += 0.025F) {
+			float sampleDepth = depth;
+			for (float weirdness : List.of(-0.9F, 0.0F, 0.9F)) {
+				String value = banding.findValue(target(sampleDepth, weirdness));
+				assertTrue(Set.of("dripstone", "lush").contains(value), () -> "unexpected shallow value " + value + " at depth " + sampleDepth);
+			}
+		}
+	}
+
+	@Test
+	void introducesBottomRegisteredCandidatesAtBottomDepth() {
+		Preset preset = preset(1024, 640, 50);
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, vanillaLikeEntries());
+
+		assertEquals(VANILLA_CAVES, fallbackValuesAt(banding.parameters().values(), BOTTOM_DEPTH));
+		assertEquals("dripstone", banding.findValue(target(1.2F, -0.8F)));
+		assertEquals("lush", banding.findValue(target(1.2F, 0.0F)));
+		assertEquals("deep_dark", banding.findValue(target(1.2F, 0.8F)));
+	}
+
+	@Test
+	void fullyCoversEveryDynamicDepthWithoutSurfaceBiomeBleed() {
+		Preset preset = preset(1024, 640, 50);
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, vanillaLikeEntries());
+		float startDepth = Climate.unquantizeCoord(banding.bandingStart());
+		float endDepth = UndergroundBiomeBanding.endDepth(preset);
+
+		for (float depth = startDepth; depth <= endDepth; depth += 0.025F) {
+			float sampleDepth = depth;
+			for (float weirdness : List.of(-0.9F, 0.0F, 0.9F)) {
+				String value = banding.findValue(target(sampleDepth, weirdness));
+				assertTrue(VANILLA_CAVES.contains(value), () -> "surface value " + value + " at depth " + sampleDepth);
+			}
+		}
+	}
+
+	@Test
+	void rotatesCandidatesBetweenDeepBands() {
+		Preset preset = preset(1024, 640, 50);
+		float endDepth = UndergroundBiomeBanding.endDepth(preset);
+		int deepBandCount = UndergroundBiomeBanding.bandCount(preset, 3, BOTTOM_DEPTH, endDepth);
+		float deepBandWidth = (endDepth - BOTTOM_DEPTH) / deepBandCount;
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, vanillaLikeEntries());
+
+		assertEquals(16, deepBandCount);
+		assertEquals("lush", banding.findValue(target(BOTTOM_DEPTH + deepBandWidth * 0.5F, 0.0F)));
+		assertEquals("deep_dark", banding.findValue(target(BOTTOM_DEPTH + deepBandWidth * 1.5F, 0.0F)));
+	}
+
+	@Test
+	void classifiesModdedCandidatesByRegistrationShapeRatherThanBiomeId() {
+		Preset preset = preset(1024, 640, 50);
+		List<Pair<Climate.ParameterPoint, String>> entries = List.of(
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, FULL_RANGE, Climate.Parameter.point(0.0F), FULL_RANGE, "surface"),
+			entry(FULL_RANGE, FULL_RANGE, Climate.Parameter.span(0.8F, 1.0F), FULL_RANGE, SHALLOW_CAVE_DEPTH, FULL_RANGE, "dripstone"),
+			entry(FULL_RANGE, Climate.Parameter.span(0.7F, 1.0F), FULL_RANGE, FULL_RANGE, SHALLOW_CAVE_DEPTH, FULL_RANGE, "lush"),
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, Climate.Parameter.span(-1.0F, -0.375F), BOTTOM_CAVE_DEPTH, FULL_RANGE, "deep_dark"),
+			entry(FULL_RANGE, Climate.Parameter.span(-1.0F, -0.7F), FULL_RANGE, FULL_RANGE, SHALLOW_CAVE_DEPTH, FULL_RANGE, "mod_shallow"),
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, FULL_RANGE, BOTTOM_CAVE_DEPTH, FULL_RANGE, "mod_bottom"),
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, FULL_RANGE, Climate.Parameter.span(0.4F, 0.6F), Climate.Parameter.span(-0.5F, 0.5F), "custom")
+		);
+
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, entries);
+
+		assertEquals(Set.of("dripstone", "lush", "mod_shallow"), fallbackValuesAt(banding.parameters().values(), 0.3F));
+		assertEquals(Set.of("dripstone", "lush", "deep_dark", "mod_shallow", "mod_bottom"), fallbackValuesAt(banding.parameters().values(), 1.2F));
+		assertTrue(banding.parameters().values().stream().anyMatch(entry -> entry.getSecond().equals("custom")));
+	}
+
+	@Test
+	void leavesAParameterListWithOneRecognizedCandidateUnmodified() {
+		Preset preset = preset(1024, 640, 50);
+		List<Pair<Climate.ParameterPoint, String>> entries = List.of(
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, FULL_RANGE, Climate.Parameter.point(0.0F), FULL_RANGE, "surface"),
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, FULL_RANGE, SHALLOW_CAVE_DEPTH, FULL_RANGE, "lush"),
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, FULL_RANGE, BOTTOM_CAVE_DEPTH, FULL_RANGE, "lush")
+		);
+
+		UndergroundBiomeBanding.Layout<String> banding = UndergroundBiomeBanding.apply(preset, entries);
+
+		assertEquals(Long.MAX_VALUE, banding.bandingStart());
+		assertEquals(entries, banding.parameters().values());
+		assertFalse(banding.appliesAt(target(1.3F, 0.0F)));
+	}
+
+	private static Preset preset(int worldDepth, int worldHeight, int biomeSize) {
+		Preset preset = Presets.makeRTFDefault();
+		preset.world().properties.worldDepth = worldDepth;
+		preset.world().properties.worldHeight = worldHeight;
+		preset.climate().biomeShape.biomeSize = biomeSize;
+		return preset;
+	}
+
+	private static List<Pair<Climate.ParameterPoint, String>> vanillaLikeEntries() {
+		return List.of(
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, FULL_RANGE, Climate.Parameter.point(0.0F), FULL_RANGE, "surface"),
+			entry(FULL_RANGE, FULL_RANGE, Climate.Parameter.span(0.8F, 1.0F), FULL_RANGE, SHALLOW_CAVE_DEPTH, FULL_RANGE, "dripstone"),
+			entry(FULL_RANGE, Climate.Parameter.span(0.7F, 1.0F), FULL_RANGE, FULL_RANGE, SHALLOW_CAVE_DEPTH, FULL_RANGE, "lush"),
+			entry(FULL_RANGE, FULL_RANGE, FULL_RANGE, Climate.Parameter.span(-1.0F, -0.375F), BOTTOM_CAVE_DEPTH, FULL_RANGE, "deep_dark")
+		);
+	}
+
+	private static Pair<Climate.ParameterPoint, String> entry(
+		Climate.Parameter temperature,
+		Climate.Parameter humidity,
+		Climate.Parameter continentalness,
+		Climate.Parameter erosion,
+		Climate.Parameter depth,
+		Climate.Parameter weirdness,
+		String value
+	) {
+		return Pair.of(
+			new Climate.ParameterPoint(
+				temperature,
+				humidity,
+				continentalness,
+				erosion,
+				depth,
+				weirdness,
+				0L
+			),
+			value
+		);
+	}
+
+	private static Set<String> fallbackValuesAt(
+		List<Pair<Climate.ParameterPoint, String>> entries,
+		float depth
+	) {
+		long quantizedDepth = Climate.quantizeCoord(depth);
+		return entries.stream()
+			.filter(entry -> isFullClimate(entry.getFirst()))
+			.filter(entry -> entry.getFirst().depth().min() <= quantizedDepth && entry.getFirst().depth().max() >= quantizedDepth)
+			.map(Pair::getSecond)
+			.collect(Collectors.toSet());
+	}
+
+	private static Climate.TargetPoint target(float depth, float weirdness) {
+		return Climate.target(0.0F, 0.0F, 0.0F, 0.0F, depth, weirdness);
+	}
+
+	private static boolean isFullClimate(Climate.ParameterPoint point) {
+		return point.temperature().equals(FULL_RANGE)
+			&& point.humidity().equals(FULL_RANGE)
+			&& point.continentalness().equals(FULL_RANGE)
+			&& point.erosion().equals(FULL_RANGE);
+	}
+}


### PR DESCRIPTION
# Fix Underground Biome Distribution Issues

> [!IMPORTANT] 
> **Main idea:**
> This PR fixes three closely related problems with how ReTerraForged selects underground biomes. These issues became very obvious in deeper worlds and was originally noticed in PR #97, where I decided that a follow-up PR would be needed in [this comment](https://github.com/ETcodehome/ReTerraForged/pull/97#issuecomment-5053275766).
> 
> Surface biomes are unaffected.

## 1. Underground Climate Mapping

### Issue

The climate values feeding cave-biome selection did not line up with terrain or expected y-ranges:

- Depth was shifted about 26 blocks downward
- Inland continentalness was pinned around the range used by Dripstone Caves
- Humidity struggled to reach Lush Caves and some modded cave biomes. 

This means that perfectly good cave space could keep the surface biome or make some cave biomes much harder to reach than intended.

### Solution

RTF now keeps its surface climate unchanged, then gradually fades in corrected underground values with depth.

- Climate depth now uses the same surface-relative depth as the terrain, removing the extra 26-block shift.
- Temperature, humidity, and ridges use vanilla's shifted-noise fields underground, putting them back into the ranges cave biomes expect.
- Erosion keeps its relationship with RTF's terrain while restoring the local variation needed for Deep Dark.

### Examples

Actual cave biomes are properly placed rather than allowing the surface biome to continue underground:

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="50%">Before: Savanna</th>
      <th width="50%">After: Deep Dark</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/1c7e1257-4f71-4e20-8af7-2d0442632523" width="95%"></kbd></td>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/a38ecfbf-6d06-4c0e-83dc-c6bd42c4ed4f" width="95%"></kbd></td>
    </tr>
    <tr valign="top">
      <td width="50%" align="center">The unfixed generator still classifies this underground cave as the surface Savanna biome.</td>
      <td width="50%" align="center">The corrected climate mapping selects the Deep Dark at the same seed and coordinates</td>
    </tr>
  </tbody>
</table>

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="50%">Before: Savanna</th>
      <th width="50%">After: Multiple Cave Biomes</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/5dde9c34-82c0-49cd-a028-09649a1673d3" width="95%"></kbd></td>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/17745caf-6c34-4d28-995b-13921ace147a" width="95%"></kbd></td>
    </tr>
    <tr valign="top">
      <td width="50%" align="center">Savanna surface biome incorrectly placed far underground</td>
      <td width="50%" align="center">Both Lush Caves & Deep Dark at the same seed and coordinates</td>
    </tr>
  </tbody>
</table>

## 2. Dynamic Underground Biome Bands

### Issue

This was caused more due to a vanilla Minecraft limtiation. In vanilla, only two underground depth stages are needed:

- Everything before Deep Dark (Lush Caves, Dripstone Caves, most modded caves, etc)
- Then just Deep Dark to the bedrock

This doesn't work in RTF though, because underground can be huge. Once a the Deep Dark's depth target was reached, there was nothing below it to take over. So the same Deep Dark selection could continue uninterrupted for hundreds of blocks.

### Solution

Below the original cave-biome range, RTF now works out how much underground space the preset actually provides and repeats the registered cave-biome candidates in scaled vertical bands. 

- A very-deep world can move from Deep Dark, into Dripstone or Lush Caves, and back again. 
- This is dynamically based on whichever cave biomes are already registered. Its not a hardcoded
rotation of the three vanilla biomes. It keeps TerraBlender's region choice intact, so it will work with modded biomes.

### Examples

More biomes than just the Deep Dark can appear hundreds of blocks down in deep worlds:

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="50%">Before: Deep Dark</th>
      <th width="50%">After: Lush Caves</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/781d854c-1b59-42e3-a932-b1a973baeac6" width="95%"></kbd></td>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/6a283264-e2e4-4fae-8111-b743789d8266" width="95%"></kbd></td>
    </tr>
    <tr valign="top">
      <td width="50%" align="center">
        Deep Dark is the catch-all biome hundreds of blocks underground, occupying all of the vertical space.
      </td>
      <td width="50%" align="center">
        Lush Caves is present where it was just Deep Dark before. The banding adjusted to world depth.
      </td>
    </tr>
  </tbody>
</table>

## 3. Underground Biome Size Scaling

### Issue

Underground climate noise stayed at a hardcoded vanilla scale, and did not scale with a preset's biome size.

### Solution

Underground climate frequency now follows the preset using:

$0.25 * 225 / biomeSize$

At the default `Biome Size=225`, this is identical to the old default scale. Smaller values produce finer horizontal and vertical cave-biome regions, while larger values produce broader regions.

### Example

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="50%">Biome Size = 50</th>
      <th width="50%">Biome Size = 900</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/90da0a6a-e501-4142-bda1-4afc27d88b45" width="95%"></kbd></td>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/e48ecc1d-dd39-44c7-ba6e-97f071d16591" width="95%"></kbd></td>
    </tr>
    <tr valign="top">
      <td width="50%" align="center">Mixture of Dripstone Caves, Lush Caves, and Deep Dark fill the cavern</td>
      <td width="50%" align="center">Only the Dripstone Caves biome fills the cavern</td>
    </tr>
  </tbody>
</table>

## 4. Server-side Validation

Most of the QA was done server-side in freshly generated worlds, using matching seeds and presets apart from the exact setting being tested.

<details>
<summary>Here's more details if you want them</summary>
<br/>

- Compared 4,096 complete vertical biome profiles between the unfixed and fixed generators. All 4,096 changed once the fix reached the real chunk-generation path.
- Found 165 columns where both worlds had open cave space at a changed biome, covering 240 directly visitable points. The three before/after comparisons above came from this set.
- Repeated the finished-chunk comparison using the fixed generator at Biome Size `50` and `900` for the scaling example.
- Compared 1,050,625 surface columns, including beach and inland transitions, and found no surface-biome changes.
- Tested very deep, vanilla-depth, and unusually shallow presets, along with Biome Size values of `50`, `225`, and `900`.
- Tested Regions Unexplored on Fabric and TerraBlender with two separate YUNG's Cave Biomes regions on NeoForge.
</details>