### PR TITLE
Prevent control point crash

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/WorldSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/WorldSettingsPage.java
@@ -157,6 +157,7 @@ public class WorldSettingsPage extends PresetEditorPage {
 		});
 		this.inland = PresetWidgets.createFloatSlider(controlPoints.inland, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_INLAND, (slider, value) -> {
 			value = Math.max(value, this.coast.getValue());
+			value = Math.max(value, 0.001);
 			controlPoints.inland = (float) slider.scaleValue(value);
 			this.regenerate();
 			return value;


### PR DESCRIPTION
Setting all control points to 0 caused a crash. We now enforce a very tiny minimum value for inland final control value to prevent div by zero crashes.

fixes https://github.com/ETcodehome/FreeTerraForged/issues/156