### PR TITLE
Fix: Ocean Fluid Discrepancies with Sea Level

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseChunk.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinNoiseChunk.java
@@ -105,9 +105,10 @@ class MixinNoiseChunk {
 				Aquifer.FluidStatus lava = new Aquifer.FluidStatus(globalLavaLevel, Blocks.LAVA.defaultBlockState());
 				Aquifer.FluidStatus defaultFluid = new Aquifer.FluidStatus(seaLevel, noiseGeneratorSettings.defaultFluid());
 
-				int oceanLavaLevel = Math.min(globalLavaLevel, seaLevel - oceanDepth - 5);
+				int oceanLavaLevel = seaLevel - oceanDepth - 5;
+				boolean oceanLavaAdjustmentNeeded = globalLavaLevel > oceanLavaLevel;
 
-				if (oceanLavaLevel == globalLavaLevel || globalLavaLevel >= seaLevel) {
+				if (!oceanLavaAdjustmentNeeded) {
 					return (x, y, z) -> {
 						if (y < Math.min(globalLavaLevel, seaLevel)) {
 							return lava;

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinOceanMonumentBuilding.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinOceanMonumentBuilding.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import net.minecraft.core.BlockPos;
@@ -23,6 +24,7 @@ import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.StructurePiece;
 import net.minecraft.world.level.levelgen.structure.structures.OceanMonumentPieces;
 import raccoonman.reterraforged.world.worldgen.structure.OceanMonumentBuildingFix;
+import raccoonman.reterraforged.world.worldgen.structure.OceanMonumentSeaLevel;
 
 @Mixin(OceanMonumentPieces.MonumentBuilding.class)
 public class MixinOceanMonumentBuilding implements OceanMonumentBuildingFix {
@@ -36,6 +38,22 @@ public class MixinOceanMonumentBuilding implements OceanMonumentBuildingFix {
 	@Unique
 	private final AtomicBoolean rtf$oceanDepthAdjusted = new AtomicBoolean(false);
 
+	@Unique
+	private volatile int rtf$configuredSeaLevel = Integer.MIN_VALUE;
+
+	@Redirect(
+		method = "postProcess",
+		at = @At(
+			value = "INVOKE",
+			target = "Ljava/lang/Math;max(II)I"
+		)
+	)
+	private int rtf$useConfiguredSeaLevel(int seaLevel, int vanillaMinimum) {
+		return this.rtf$configuredSeaLevel == Integer.MIN_VALUE
+			? Math.max(seaLevel, vanillaMinimum)
+			: this.rtf$configuredSeaLevel;
+	}
+
 	@Inject(method = "postProcess", at = @At("HEAD"))
 	private void rtf$fitToOceanFloor(
 		WorldGenLevel level,
@@ -47,6 +65,8 @@ public class MixinOceanMonumentBuilding implements OceanMonumentBuildingFix {
 		BlockPos blockPos,
 		CallbackInfo ci
 	) {
+		this.rtf$configuredSeaLevel = OceanMonumentSeaLevel.configured(level);
+
 		// CAS guards against concurrent postProcess() calls across this monument's chunks double-moving the piece.
 		if (!this.rtf$oceanDepthAdjusted.compareAndSet(false, true)) {
 			return;

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinOceanMonumentPiece.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinOceanMonumentPiece.java
@@ -1,0 +1,22 @@
+package raccoonman.reterraforged.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import net.minecraft.world.level.WorldGenLevel;
+import raccoonman.reterraforged.world.worldgen.structure.OceanMonumentSeaLevel;
+
+@Mixin(targets = "net.minecraft.world.level.levelgen.structure.structures.OceanMonumentPieces$OceanMonumentPiece")
+abstract class MixinOceanMonumentPiece {
+	@Redirect(
+		method = "generateWaterBox",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/world/level/WorldGenLevel;getSeaLevel()I"
+		)
+	)
+	private int rtf$useConfiguredSeaLevel(WorldGenLevel level) {
+		return OceanMonumentSeaLevel.effective(level);
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/structure/OceanMonumentSeaLevel.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/structure/OceanMonumentSeaLevel.java
@@ -1,0 +1,30 @@
+package raccoonman.reterraforged.world.worldgen.structure;
+
+import net.minecraft.world.level.WorldGenLevel;
+import net.minecraft.world.level.levelgen.RandomState;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
+import raccoonman.reterraforged.world.worldgen.RTFRandomState;
+
+public final class OceanMonumentSeaLevel {
+	private static final int NOT_RTF = Integer.MIN_VALUE;
+
+	private OceanMonumentSeaLevel() {
+	}
+
+	public static int configured(WorldGenLevel level) {
+		RandomState randomState = level.getLevel().getChunkSource().randomState();
+		if ((Object) randomState instanceof RTFRandomState rtfRandomState
+			&& rtfRandomState.generatorContext() != null) {
+			Preset preset = rtfRandomState.preset();
+			if (preset != null) {
+				return preset.world().properties.seaLevel;
+			}
+		}
+		return NOT_RTF;
+	}
+
+	public static int effective(WorldGenLevel level) {
+		int configured = configured(level);
+		return configured == NOT_RTF ? level.getSeaLevel() : configured;
+	}
+}

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -44,6 +44,7 @@
 		"LevelChunkSectionAccessor",
 		"StructurePiecesBuilderAccessor",
 		"MixinOceanMonumentBuilding",
+		"MixinOceanMonumentPiece",
 		"MixinOceanMonumentStructure",
 		"MixinJigsawStructure",
 		"terrablender.MixinParameterList",


### PR DESCRIPTION
> [!IMPORTANT]
> A few follow up fixes for #97 
> 
> - Fixes a vanilla Minecraft bug with ocean monuments (yet again)
> - Better lava level handling when lava level exceeds sea level

## Ocean Monument Fix

PR 97 [solved dynamic ocean monument placement](https://github.com/ETcodehome/FreeTerraForged/pull/97#issuecomment-5013945940), and monuments could even protrude out of the water in shallow ocean worlds. A distinct but related bug that wasn't addressed though, was that when sea level is below `y = 63` Minecraft generates a huge cube of water up to to `y=63`. 

Bug is now fixed:

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="50%">Before</th>
      <th width="50%">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/7a27eac6-1507-4e0a-8b0d-dc5e7e2ff3d2" width="95%"></kbd></td>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/dbc07150-06a9-4f68-a1ef-83491e608a56" width="95%"></kbd></td>
    </tr>
  </tbody>
</table>

## High Lava Level Fix

Another thing PR 97 [solved was conflicts between lava level and ocean floor](https://github.com/ETcodehome/FreeTerraForged/pull/97#issuecomment-4902617668). However, there was still an issue when lava level exceeded sea level specifically. Same class of problem as before (just at a different level this time), where the fluid picker would fill oceans with lava instead of water.

Applied the same fix, where lava is placed below oceans but keeps the configured level on the land: 

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="50%">Before</th>
      <th width="50%">After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/1e945e15-8995-4754-ad5f-339da4699d67" width="95%"></kbd></td>
      <td align="center" width="50%"><kbd><img src="https://github.com/user-attachments/assets/8e37fcc2-629f-4ff1-b068-e844d1417e97" width="95%"></kbd></td>
    </tr>
  </tbody>
</table>

Note that lava is still present on the land at the user's configured lava level, even on coastlines, but now correctly placed under oceans:

<p align="center"><kbd><img width="95%" src="https://github.com/user-attachments/assets/a4262d1b-3777-44d4-99fd-7fda25f86d66" /></kbd></p>
