### PR TITLE
Improv: Decouple `mountainVariety` from `fancyMountains`

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/terrain/Populators.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/terrain/Populators.java
@@ -308,10 +308,10 @@ public class Populators {
 		height = Noises.mul(height, scaler);
 		height = Noises.warpPerlin(height, seed.next(), 350, 1, 150.0F);
 		if(makeFancy) {
-			height = makeFancy(seed, height, erosionStrength);
+			height = makeFancy(seed, height);
 		}
 		height = Noises.cache2d(height);
-		Noise climateErosion = parameterVariation(seed.offset(EROSION_VARIATION_SEED_OFFSET), Erosion.LEVEL_0, Erosion.LEVEL_3, EROSION_VARIATION_SCALE);
+		Noise climateErosion = mountainErosion(seed, erosionStrength);
 		return TerrainPopulator.make(terrainType, ground, Noises.mul(height, (legacyScaling ? 0.7F : MOUNTAINS_V) * verticalScale), climateErosion, Noises.min(Noises.mul(height, Noises.constant(-1.0F)), Noises.constant(-0.08F)), settings);
 	}
 
@@ -348,10 +348,10 @@ public class Populators {
 		height = Noises.mul(height, surface);
 		height = Noises.pow(height, 1.1F);
 		if(makeFancy) {
-			height = makeFancy(seed, height, erosionStrength);
+			height = makeFancy(seed, height);
 		}
 		height = Noises.cache2d(height);
-		Noise climateErosion = parameterVariation(seed.offset(EROSION_VARIATION_SEED_OFFSET), Erosion.LEVEL_0, Erosion.LEVEL_3, EROSION_VARIATION_SCALE);
+		Noise climateErosion = mountainErosion(seed, erosionStrength);
 		return TerrainPopulator.make(TerrainType.MOUNTAINS_2, ground, Noises.mul(height, 0.645F * verticalScale), climateErosion, Noises.min(Noises.mul(height, Noises.constant(-1.0F)), Noises.constant(-0.08F)), settings);
 	}
 
@@ -387,10 +387,10 @@ public class Populators {
 
     	Noise height = Noises.advancedTerrace(mountains, modulation, mask, slope, 0.20000000298023224F, 0.44999998807907104F, 24, 1);
     	if(makeFancy) {
-        	height = makeFancy(seed, height, erosionStrength);
+			height = makeFancy(seed, height);
     	}
 		height = Noises.cache2d(height);
-		Noise climateErosion = parameterVariation(seed.offset(EROSION_VARIATION_SEED_OFFSET), Erosion.LEVEL_0, Erosion.LEVEL_3, EROSION_VARIATION_SCALE);
+		Noise climateErosion = mountainErosion(seed, erosionStrength);
 		return TerrainPopulator.make(TerrainType.MOUNTAINS_3, ground, Noises.mul(height, (legacyScaling ? 0.645F : MOUNTAINS3_V) * verticalScale), climateErosion, Noises.min(Noises.mul(height, Noises.constant(-1.0F)), Noises.constant(-0.08F)), settings);
     }
 
@@ -398,14 +398,22 @@ public class Populators {
     	return makeMountains3(seed, ground, settings, verticalScale, makeFancy, legacyScaling, DEFAULT_EROSION_STRENGTH);
     }
 
-	public static Noise makeFancy(@Deprecated Seed seed, Noise input, float erosionStrength) {
+	public static Noise makeFancy(@Deprecated Seed seed, Noise input) {
 		Domain domain = Domains.direction(
 			Noises.perlin(seed.next(), 10, 1),
 			Noises.constant(2.0F)
 		);
-		Noise erosion = Noises.erosion(input, seed.next(), 2, erosionStrength, 128.0F, 0.15F, 3.1F, 0.8F, BlendMode.CONSTANT);
+		Noise erosion = Noises.erosion(input, seed.next(), 2, 0.65F, 128.0F, 0.15F, 3.1F, 0.8F, BlendMode.CONSTANT);
 		erosion = Noises.warp(erosion, domain);
 		return erosion;
+	}
+
+	private static Noise mountainErosion(Seed seed, float erosionStrength) {
+		Noise climateErosion = parameterVariation(seed.offset(EROSION_VARIATION_SEED_OFFSET), Erosion.LEVEL_0, Erosion.LEVEL_3, EROSION_VARIATION_SCALE);
+		if (erosionStrength == DEFAULT_EROSION_STRENGTH) {
+			return climateErosion;
+		}
+		return Noises.clamp(Noises.add(climateErosion, erosionStrength - DEFAULT_EROSION_STRENGTH), Erosion.LEVEL_0.min(), Erosion.LEVEL_6.max());
 	}
 
 	public static TerrainPopulator makeBorder(@Deprecated Seed seed, Noise ground, TerrainSettings.Terrain plainsSettings, TerrainSettings.Terrain steppeSettings, float verticalScale) {


### PR DESCRIPTION
# Decouple `mountainVariety` from `fancyMountains`

> [!IMPORTANT]
> Tl;dr:
> Small reversion for part of #95. The `fancyMountains` erosion value will no longer change with `mountainVariety`

---

This reversion is done for two main reasons:

1. `fancyMountains` needs to be reworked, as it currently has other issues. For example, mountains can't scale horizontally as discussed in [this Discord exchange](https://discord.com/channels/687310840915165240/1525484519363448932/1534779439014088855). It'd be best practice to avoid plugging this feature into an old/broken system, until its fixed or replaced with better mountain erosion settings.

1. When `mountainVariety` was turned all the way up, `fancyMountains` erosion would sometimes generate super smooth mountain sides/slopes:

<p align="center">
  <kbd>
    <img width="73%" src="https://github.com/user-attachments/assets/ae2f45e9-9a3b-4144-a561-6c49cbf2987c" />
    <img width="26%" src="https://github.com/user-attachments/assets/44f7f96d-07e6-42e7-9080-7cbf55cda8b1" />
  </kbd>
</p>