### PR TITLE
Hotfix: Resolve Previewer Bugs

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -66,6 +66,7 @@ public class Preview2D extends Button {
     private CompletableFuture<FrameResult> pendingGeneration = null;
     private volatile PreparedContext preparedContext;
     private volatile PreviewCancellation generationCancellation;
+    private volatile PreviewFailure previewFailure;
     private final AtomicLong pixelRequestVersion = new AtomicLong();
     private volatile PreviewCancellation pixelCancellation;
     private CompletableFuture<?> pendingPixelRasterization;
@@ -192,7 +193,10 @@ public class Preview2D extends Button {
             }
         } catch (RuntimeException | LinkageError error) {
             this.isRunning = false;
-            RTFCommon.LOGGER.error("Failed to prepare preview provider", error);
+            this.previewFailure = PreviewFailure.log("Failed to prepare 2D preview provider", error);
+            if (this.isDirty) {
+                this.scheduleRegeneration();
+            }
             return;
         }
         HolderLookup.Provider preparedProvider = provider;
@@ -225,8 +229,15 @@ public class Preview2D extends Button {
                 prepared = new PreparedContext(requestedKey, generatorContext, preparedProvider, preparedPreset, biomePipeline);
                 this.preparedContext = prepared;
             }
+            BiomePreview biomePreview = null;
+            PreviewFailure biomeFailure = null;
             if (biomePipeline) {
-                prepared.ensureBiomePreview(settings);
+                try {
+                    prepared.ensureBiomePreview(settings);
+                    biomePreview = prepared.biomePreview;
+                } catch (RuntimeException | LinkageError error) {
+                    biomeFailure = PreviewFailure.log("Failed to prepare 2D biome preview", error);
+                }
             }
             GeneratorContext generatorContext = prepared.context;
             if (properties.spawnType == SpawnType.CONTINENT_CENTER) {
@@ -255,7 +266,7 @@ public class Preview2D extends Button {
             PreviewComputationCache.TileKey tileKey = new PreviewComputationCache.TileKey(
                 requestedKey, cx, cz, zoomLevel, Preview2D.SIZE, biomePipeline
             );
-            return new PreGenContext(generatorContext, prepared.biomePreview, cx, cz, zoomLevel, tileKey);
+            return new PreGenContext(generatorContext, biomePreview, cx, cz, zoomLevel, tileKey, biomeFailure);
         }, net.minecraft.Util.backgroundExecutor());
 
         // Stage 2: Handle calculation maps and evaluate visual color tables entirely on worker pool
@@ -281,14 +292,17 @@ public class Preview2D extends Button {
                 Tile generatedTile = lease.tile();
                 try {
                     BiomePreview.Sidecar biomes = null;
-                    if (biomePipeline) {
+                    PreviewFailure failure = preGen.biomeFailure;
+                    if (failure == null && biomePipeline) {
                         biomes = preGen.biomePreview.resolveCached(
                             this.page.previewCache(), generatedTile, preGen.cx, preGen.cz, preGen.zoomLevel, levels, cancellation
                         );
                     }
 
-                    int[] bufferedPixels = this.createPixelData(generatedTile, biomes, mode, levels, properties);
-                    return new FrameResult(lease, biomes, preGen.cx, preGen.cz, bufferedPixels);
+                    int[] bufferedPixels = failure == null
+                        ? this.createPixelData(generatedTile, biomes, mode, levels, properties)
+                        : null;
+                    return new FrameResult(lease, biomes, preGen.cx, preGen.cz, bufferedPixels, failure);
                 } catch (Throwable throwable) {
                     lease.close();
                     throw throwable;
@@ -307,7 +321,7 @@ public class Preview2D extends Button {
 
             if (throwable != null) {
                 if (!PreviewCancellation.isCancellation(throwable)) {
-                RTFCommon.LOGGER.error("Failed handling 2D preview generation pipeline", throwable);
+                    this.previewFailure = PreviewFailure.log("Failed handling 2D preview generation pipeline", throwable);
                 }
             } else if (!this.isDirty && result != null && result.tile != null
                     && !cancellation.isCancelled()
@@ -320,10 +334,13 @@ public class Preview2D extends Button {
                 this.generatedWithBiomePipeline = biomePipeline;
                 this.centerX = result.centerX;
                 this.centerZ = result.centerZ;
+                this.previewFailure = result.failure;
                 this.legendValues[3] = getSpawnCoords();
 
                 // Safe structural upload across to GPU
-                this.uploadPixelData(result.pixelData);
+                if (result.failure == null) {
+                    this.uploadPixelData(result.pixelData);
+                }
                 if (previousLease != null) previousLease.close();
             } else if (result != null && result.tile != null) {
                 result.lease.close();
@@ -389,9 +406,14 @@ public class Preview2D extends Button {
             return this.createPixelData(retained.tile(), sidecar, mode, levels, properties);
         }, net.minecraft.Util.backgroundExecutor()).whenCompleteAsync((pixels, throwable) -> {
             try {
-                if (!this.closed && throwable == null && !cancellation.isCancelled()
+                if (!this.closed && throwable != null && !PreviewCancellation.isCancellation(throwable)
                         && version == this.pixelRequestVersion.get()
                         && mode == this.page.renderMode2D.getValue()) {
+                    this.previewFailure = PreviewFailure.log("Failed rasterizing 2D preview", throwable);
+                } else if (!this.closed && throwable == null && !cancellation.isCancelled()
+                        && version == this.pixelRequestVersion.get()
+                        && mode == this.page.renderMode2D.getValue()) {
+                    this.previewFailure = null;
                     this.uploadPixelData(pixels);
                 }
             } finally {
@@ -412,6 +434,7 @@ public class Preview2D extends Button {
             this.tileLease = null;
         }
         this.tile = null;
+        this.previewFailure = null;
         this.generatedWithBiomePipeline = false;
         this.preparedContext = null;
     }
@@ -475,6 +498,11 @@ public class Preview2D extends Button {
     public void renderWidget(GuiGraphics guiGraphics, int mx, int my, float partialTicks) {
         int xPos = this.getX();
         int yPos = this.getY();
+
+        if (this.previewFailure != null) {
+            PreviewFailure.renderUnavailable(guiGraphics, xPos, yPos, this.width, this.height);
+            return;
+        }
 
         if (this.tile == null) {
             guiGraphics.fill(xPos, yPos, xPos + this.width, yPos + this.height, 0xFF000000);
@@ -653,13 +681,16 @@ public class Preview2D extends Button {
         final int zoomLevel;
         final PreviewComputationCache.TileKey tileKey;
 
-        PreGenContext(GeneratorContext context, BiomePreview biomePreview, int cx, int cz, int zoomLevel, PreviewComputationCache.TileKey tileKey) {
+        final PreviewFailure biomeFailure;
+
+        PreGenContext(GeneratorContext context, BiomePreview biomePreview, int cx, int cz, int zoomLevel, PreviewComputationCache.TileKey tileKey, PreviewFailure biomeFailure) {
             this.context = context;
             this.biomePreview = biomePreview;
             this.cx = cx;
             this.cz = cz;
             this.zoomLevel = zoomLevel;
             this.tileKey = tileKey;
+            this.biomeFailure = biomeFailure;
         }
     }
 
@@ -698,14 +729,16 @@ public class Preview2D extends Button {
         final int centerX;
         final int centerZ;
         final int[] pixelData;
+        final PreviewFailure failure;
 
-        FrameResult(PreviewComputationCache.TileLease lease, BiomePreview.Sidecar biomes, int centerX, int centerZ, int[] pixelData) {
+        FrameResult(PreviewComputationCache.TileLease lease, BiomePreview.Sidecar biomes, int centerX, int centerZ, int[] pixelData, PreviewFailure failure) {
             this.lease = lease;
             this.tile = lease.tile();
             this.biomes = biomes;
             this.centerX = centerX;
             this.centerZ = centerZ;
             this.pixelData = pixelData;
+            this.failure = failure;
         }
     }
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -78,6 +78,7 @@ public class Preview3D extends Button {
     private CompletableFuture<FrameResult> pendingGeneration = null;
     private volatile PreparedContext preparedContext;
     private volatile PreviewCancellation generationCancellation;
+    private volatile PreviewFailure previewFailure;
 
     // Concurrency Gates
     private boolean isRunning = false;
@@ -194,7 +195,10 @@ public class Preview3D extends Button {
             }
         } catch (RuntimeException | LinkageError error) {
             this.isRunning = false;
-            RTFCommon.LOGGER.error("Failed to prepare preview provider", error);
+            this.previewFailure = PreviewFailure.log("Failed to prepare 3D preview provider", error);
+            if (this.isDirty) {
+                this.scheduleRegeneration();
+            }
             return;
         }
         HolderLookup.Provider preparedProvider = provider;
@@ -228,8 +232,15 @@ public class Preview3D extends Button {
                 prepared = new PreparedContext(requestedKey, generatorContext, preparedProvider, preparedPreset, biomePipeline);
                 this.preparedContext = prepared;
             }
+            BiomePreview biomePreview = null;
+            PreviewFailure biomeFailure = null;
             if (biomePipeline) {
-                prepared.ensureBiomePreview(settings);
+                try {
+                    prepared.ensureBiomePreview(settings);
+                    biomePreview = prepared.biomePreview();
+                } catch (RuntimeException | LinkageError error) {
+                    biomeFailure = PreviewFailure.log("Failed to prepare 3D biome preview", error);
+                }
             }
             GeneratorContext generatorContext = prepared.context;
             WorldSettings.Properties properties = preparedPreset.world().properties;
@@ -259,7 +270,7 @@ public class Preview3D extends Button {
             PreviewComputationCache.TileKey tileKey = new PreviewComputationCache.TileKey(
                 requestedKey, cx, cz, zoomLevel, Preview3D.SIZE, biomePipeline
             );
-            return new PreGenContext(generatorContext, prepared.biomePreview(), cx, cz, zoomLevel, tileKey);
+            return new PreGenContext(generatorContext, biomePreview, cx, cz, zoomLevel, tileKey, biomeFailure);
         }, net.minecraft.Util.backgroundExecutor());
 
         // Step 2: Compose into the chunk generator's pipeline
@@ -287,15 +298,18 @@ public class Preview3D extends Button {
                     WorldSettings.Properties properties = preparedPreset.world().properties;
                     Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
                     BiomePreview.Sidecar biomes = null;
-                    if (biomePipeline) {
+                    PreviewFailure failure = preGen.biomeFailure;
+                    if (failure == null && biomePipeline) {
                         biomes = preGen.biomePreview.resolveCached(
                             this.page.previewCache(), generatedTile, preGen.cx, preGen.cz, preGen.zoomLevel, levels, cancellation
                         );
                     }
-                    int[] texturePixels = createTexturePixels(
-                        generatedTile, biomes, requestedMode, levels, properties, renderWidth, renderHeight, renderZoom
-                    );
-                    return new FrameResult(lease, biomes, preGen.cx, preGen.cz, texturePixels, renderWidth, renderHeight);
+                    int[] texturePixels = failure == null
+                        ? createTexturePixels(
+                            generatedTile, biomes, requestedMode, levels, properties, renderWidth, renderHeight, renderZoom
+                        )
+                        : null;
+                    return new FrameResult(lease, biomes, preGen.cx, preGen.cz, texturePixels, renderWidth, renderHeight, failure);
                 } catch (Throwable throwable) {
                     lease.close();
                     throw throwable;
@@ -314,7 +328,7 @@ public class Preview3D extends Button {
 
             if (throwable != null) {
                 if (!PreviewCancellation.isCancellation(throwable)) {
-                    RTFCommon.LOGGER.error("Failed handling 3D preview generation pipeline", throwable);
+                    this.previewFailure = PreviewFailure.log("Failed handling 3D preview generation pipeline", throwable);
                 }
             } else if (!this.isDirty && result != null && result.tile != null
                     && !cancellation.isCancelled()
@@ -327,14 +341,15 @@ public class Preview3D extends Button {
                 this.generatedWithBiomePipeline = biomePipeline;
                 this.centerX = result.centerX;
                 this.centerZ = result.centerZ;
+                this.previewFailure = result.failure;
 
                 this.legendValues[3] = getSpawnCoords();
-                if (result.textureWidth == this.width && result.textureHeight == this.height) {
+                if (result.failure == null && result.textureWidth == this.width && result.textureHeight == this.height) {
                     this.pendingTexturePixels = result.texturePixels;
                     this.pendingTextureWidth = result.textureWidth;
                     this.pendingTextureHeight = result.textureHeight;
                     this.needsTextureRefresh = true;
-                } else {
+                } else if (result.failure == null) {
                     this.requestTextureRasterization();
                 }
 
@@ -452,9 +467,14 @@ public class Preview3D extends Button {
             return this.createTexturePixels(retained.tile(), sidecar, mode, levels, properties, width, height, zoomValue);
         }, net.minecraft.Util.backgroundExecutor()).whenCompleteAsync((pixels, throwable) -> {
             try {
-                if (!this.closed && throwable == null && !cancellation.isCancelled()
+                if (!this.closed && throwable != null && !PreviewCancellation.isCancellation(throwable)
                         && version == this.textureRequestVersion.get()
                         && mode == (this.page.renderMode3D == null ? currentMode : this.page.renderMode3D.getValue())) {
+                    this.previewFailure = PreviewFailure.log("Failed rasterizing 3D preview", throwable);
+                } else if (!this.closed && throwable == null && !cancellation.isCancelled()
+                        && version == this.textureRequestVersion.get()
+                        && mode == (this.page.renderMode3D == null ? currentMode : this.page.renderMode3D.getValue())) {
+                    this.previewFailure = null;
                     this.pendingTexturePixels = pixels;
                     this.pendingTextureWidth = width;
                     this.pendingTextureHeight = height;
@@ -514,6 +534,7 @@ public class Preview3D extends Button {
             this.tileLease = null;
         }
         this.tile = null;
+        this.previewFailure = null;
         this.generatedWithBiomePipeline = false;
         this.preparedContext = null;
     }
@@ -581,6 +602,11 @@ public class Preview3D extends Button {
     public void renderWidget(GuiGraphics guiGraphics, int mx, int my, float partialTicks) {
         int x = this.getX();
         int y = this.getY();
+
+        if (this.previewFailure != null) {
+            PreviewFailure.renderUnavailable(guiGraphics, x, y, this.width, this.height);
+            return;
+        }
 
         if (this.tile != null && this.needsTextureRefresh) {
             this.uploadPendingTexture();
@@ -845,13 +871,16 @@ public class Preview3D extends Button {
         final int zoomLevel;
         final PreviewComputationCache.TileKey tileKey;
 
-        PreGenContext(GeneratorContext context, BiomePreview biomePreview, int cx, int cz, int zoomLevel, PreviewComputationCache.TileKey tileKey) {
+        final PreviewFailure biomeFailure;
+
+        PreGenContext(GeneratorContext context, BiomePreview biomePreview, int cx, int cz, int zoomLevel, PreviewComputationCache.TileKey tileKey, PreviewFailure biomeFailure) {
             this.context = context;
             this.biomePreview = biomePreview;
             this.cx = cx;
             this.cz = cz;
             this.zoomLevel = zoomLevel;
             this.tileKey = tileKey;
+            this.biomeFailure = biomeFailure;
         }
     }
 
@@ -892,8 +921,9 @@ public class Preview3D extends Button {
         final int[] texturePixels;
         final int textureWidth;
         final int textureHeight;
+        final PreviewFailure failure;
 
-        FrameResult(PreviewComputationCache.TileLease lease, BiomePreview.Sidecar biomes, int centerX, int centerZ, int[] texturePixels, int textureWidth, int textureHeight) {
+        FrameResult(PreviewComputationCache.TileLease lease, BiomePreview.Sidecar biomes, int centerX, int centerZ, int[] texturePixels, int textureWidth, int textureHeight, PreviewFailure failure) {
             this.lease = lease;
             this.tile = lease.tile();
             this.biomes = biomes;
@@ -902,6 +932,7 @@ public class Preview3D extends Button {
             this.texturePixels = texturePixels;
             this.textureWidth = textureWidth;
             this.textureHeight = textureHeight;
+            this.failure = failure;
         }
     }
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewFailure.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewFailure.java
@@ -1,0 +1,60 @@
+package raccoonman.reterraforged.client.gui.screen.presetconfig;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.network.chat.Component;
+import raccoonman.reterraforged.RTFCommon;
+
+/** A recoverable failure in one preview pane. */
+final class PreviewFailure {
+    private PreviewFailure() {
+    }
+
+    static PreviewFailure log(String operation, Throwable throwable) {
+        RTFCommon.LOGGER.error(operation, unwrap(throwable));
+        return new PreviewFailure();
+    }
+
+    static void renderUnavailable(GuiGraphics graphics, int x, int y, int width, int height) {
+        graphics.fill(x, y, x + width, y + height, 0xFF151515);
+
+        int iconWidth = Math.min(48, Math.max(32, width - 16));
+        int iconHeight = Math.min(36, Math.max(28, height - 38));
+        int iconX = x + (width - iconWidth) / 2;
+        int iconY = y + Math.max(8, height / 2 - iconHeight - 8);
+
+        // A small broken-image glyph: frame, sun, mountains, and a diagonal break.
+        graphics.fill(iconX, iconY, iconX + iconWidth, iconY + 2, 0xFF777777);
+        graphics.fill(iconX, iconY + iconHeight - 2, iconX + iconWidth, iconY + iconHeight, 0xFF777777);
+        graphics.fill(iconX, iconY, iconX + 2, iconY + iconHeight, 0xFF777777);
+        graphics.fill(iconX + iconWidth - 2, iconY, iconX + iconWidth, iconY + iconHeight, 0xFF777777);
+        graphics.fill(iconX + 8, iconY + 8, iconX + 14, iconY + 14, 0xFFFFCC55);
+        graphics.fill(iconX + 6, iconY + iconHeight - 10, iconX + 16, iconY + iconHeight - 4, 0xFF6688AA);
+        graphics.fill(iconX + 13, iconY + iconHeight - 16, iconX + 23, iconY + iconHeight - 4, 0xFF6688AA);
+        graphics.fill(iconX + 22, iconY + iconHeight - 12, iconX + iconWidth - 6, iconY + iconHeight - 4, 0xFF6688AA);
+        for (int offset = 0; offset < iconWidth - 12; offset++) {
+            int slashY = iconY + 5 + offset * iconHeight / Math.max(1, iconWidth - 12);
+            graphics.fill(iconX + 6 + offset, slashY, iconX + 9 + offset, slashY + 3, 0xFFDD6666);
+        }
+
+        graphics.drawCenteredString(
+            Minecraft.getInstance().font,
+            Component.literal("Preview Unavailable"),
+            x + width / 2,
+            iconY + iconHeight + 8,
+            0xFFE0E0E0
+        );
+    }
+
+    private static Throwable unwrap(Throwable throwable) {
+        Throwable current = throwable;
+        while ((current instanceof CompletionException || current instanceof ExecutionException)
+                && current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current;
+    }
+}

--- a/common/src/main/java/raccoonman/reterraforged/compat/biolith/BiolithPreviewContext.java
+++ b/common/src/main/java/raccoonman/reterraforged/compat/biolith/BiolithPreviewContext.java
@@ -14,6 +14,7 @@ import com.mojang.datafixers.util.Pair;
 import com.mojang.serialization.JsonOps;
 import com.terraformersmc.biolith.api.biome.BiolithFittestNodes;
 import com.terraformersmc.biolith.api.biome.sub.Criterion;
+import com.terraformersmc.biolith.impl.biome.BiomeCoordinator;
 import com.terraformersmc.biolith.impl.biome.DimensionBiomePlacement;
 import com.terraformersmc.biolith.impl.noise.OpenSimplexNoise2;
 import net.minecraft.core.Holder;
@@ -37,6 +38,13 @@ public final class BiolithPreviewContext {
 	private static final ThreadLocal<State> ACTIVE = new ThreadLocal<>();
 
 	private BiolithPreviewContext() {
+	}
+
+	public static void preInitializeBiomeLookup(RegistryAccess registries) {
+		try {
+			BiomeCoordinator.setEarlyBiomeLookup(registries.lookupOrThrow(Registries.BIOME));
+		} catch (RuntimeException | LinkageError ignored) {
+		}
 	}
 
 	public static BiomePreviewIntegration.Session open(

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinMultiNoiseBiomeSource.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinMultiNoiseBiomeSource.java
@@ -1,11 +1,15 @@
 package raccoonman.reterraforged.mixin;
 
 import java.util.Objects;
+import java.util.function.Function;
 
+import com.mojang.datafixers.util.Either;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Climate;
 import net.minecraft.world.level.biome.MultiNoiseBiomeSource;
+import net.minecraft.world.level.biome.MultiNoiseBiomeSourceParameterList;
+import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -25,6 +29,10 @@ import raccoonman.reterraforged.world.worldgen.terrablender.TerraBlenderParamete
  */
 @Mixin(MultiNoiseBiomeSource.class)
 public abstract class MixinMultiNoiseBiomeSource implements RTFMultiNoiseBiomeSource {
+    @Shadow
+    @Final
+    private Either<Climate.ParameterList<Holder<Biome>>, Holder<MultiNoiseBiomeSourceParameterList>> parameters;
+
     @Unique
     private volatile UndergroundBiomeBanding.Layout<Holder<Biome>> rtf$undergroundBanding;
     @Unique
@@ -37,7 +45,7 @@ public abstract class MixinMultiNoiseBiomeSource implements RTFMultiNoiseBiomeSo
 
     @Override
     public Climate.ParameterList<Holder<Biome>> reterraforged$getParameters() {
-        return this.parameters();
+        return this.parameters.map(Function.identity(), holder -> holder.value().parameters());
     }
 
     @Inject(

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
@@ -28,6 +28,8 @@ import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.densityfunction.CellSampler;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
+import raccoonman.reterraforged.compat.biolith.BiolithCompat;
+import raccoonman.reterraforged.compat.biolith.BiolithPreviewContext;
 import raccoonman.reterraforged.world.worldgen.terrablender.TBCompat;
 import raccoonman.reterraforged.world.worldgen.terrablender.TBClimateSampler;
 import raccoonman.reterraforged.world.worldgen.terrablender.TerraBlenderParameterList;
@@ -78,11 +80,16 @@ public final class BiomePreviewResolver {
 		Holder<NoiseGeneratorSettings> noiseSettings = provider.lookupOrThrow(Registries.NOISE_SETTINGS)
 			.getOrThrow(NoiseGeneratorSettings.OVERWORLD);
 		NoiseBasedChunkGenerator previewGenerator = new NoiseBasedChunkGenerator(biomeSource, noiseSettings);
-		LevelStem previewStem = new LevelStem(dimensionType, previewGenerator);
+
+		if (BiolithCompat.isEnabled()) {
+			BiolithPreviewContext.preInitializeBiomeLookup(registries);
+		}
 
 		if (TBCompat.isEnabled()) {
-			initializeTerraBlender(registries, previewStem, previewGenerator, biomeSource, preset, seed);
+			initializeTerraBlender(registries, dimensionType, previewGenerator, biomeSource, preset, seed);
 		}
+
+		LevelStem previewStem = new LevelStem(dimensionType, previewGenerator);
 
 		Climate.Sampler sampler = surfaceClimateSampler(noiseSettings.value(), preset, generatorContext, seed);
 		TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters = terraBlenderParameters(biomeSource);
@@ -139,7 +146,7 @@ public final class BiomePreviewResolver {
 
 	private static void initializeTerraBlender(
 		RegistryAccess registries,
-		LevelStem previewStem,
+		Holder<DimensionType> dimensionType,
 		NoiseBasedChunkGenerator previewGenerator,
 		BiomeSource biomeSource,
 		Preset preset,
@@ -152,7 +159,7 @@ public final class BiomePreviewResolver {
 		}
 		LevelUtils.initializeBiomes(
 			registries,
-			previewStem.type(),
+			dimensionType,
 			LevelStem.OVERWORLD,
 			previewGenerator,
 			seed


### PR DESCRIPTION
> [!IMPORTANT]
> **TL;DR**
> Just some small tweaks to make the previewer robust, should also resolve [the issue](https://discordapp.com/channels/687310840915165240/1525484519363448932/1539356827605667952) Julek and Broke reported on Discord

---

## List of Fixes

1. Prepares Biolith before the preview starts: 
    - The preview uses a temporary copy of Minecraft’s biome registry.
    - Biolith now receives that copy early enough to look up biomes safely instead  of seeing an uninitialized registry.

1. Supports both ways Minecraft stores biome mappings
    - Minecraft can store its climate-to-biome mapping directly or store it behind a deferred "holder."
    - The preview now reads both forms, so custom biome mappings are not skipped or mishandled.

1. Initializes TerraBlender against the correct preview world
    - TerraBlender is now initialized in the right order and with the preview’s temporary dimension settings.
    - This lets regional biome rules use the same context as the preview instead of an incomplete or mismatched one.

---

## Small Addition: Better Crashing

- Prints a better error report to the logs if it crashes
- Adds a 404/image unavailable type screen if the Biome Previewer crashes. Looks like this:

<p align="center"><kbd><img width="95%" src="https://github.com/user-attachments/assets/aca15c55-6ade-484a-8e96-e896fa7dd916" /></kbd></p>
