### PR TITLE
Fix: Dynamic Ore Placement

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/RTFCommon.java
+++ b/common/src/main/java/raccoonman/reterraforged/RTFCommon.java
@@ -11,6 +11,7 @@ import raccoonman.reterraforged.registries.RTFRegistries;
 import raccoonman.reterraforged.world.worldgen.biome.modifier.BiomeModifiers;
 import raccoonman.reterraforged.world.worldgen.densityfunction.RTFDensityFunctions;
 import raccoonman.reterraforged.world.worldgen.feature.RTFFeatures;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOreLifecycle;
 import raccoonman.reterraforged.world.worldgen.feature.chance.RTFChanceModifiers;
 import raccoonman.reterraforged.world.worldgen.feature.placement.RTFPlacementModifiers;
 import raccoonman.reterraforged.world.worldgen.feature.template.decorator.TemplateDecorators;
@@ -46,6 +47,7 @@ public class RTFCommon {
 		BiomeModifiers.bootstrap();
 		RTFSurfaceRules.bootstrap();
 		StructureRules.bootstrap();
+		DynamicOreLifecycle.bootstrap();
 
 		RegistryUtil.createDataRegistry(RTFRegistries.NOISE, Noise.DIRECT_CODEC, false);
 		RegistryUtil.createDataRegistry(RTFRegistries.PRESET, Preset.DIRECT_CODEC, false);
@@ -57,4 +59,3 @@ public class RTFCommon {
 		return ResourceLocation.fromNamespaceAndPath(RTFCommon.MOD_ID, name);
 	}
 }
-

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinHeightRangePlacement.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinHeightRangePlacement.java
@@ -12,6 +12,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacementContext;
 import raccoonman.reterraforged.world.worldgen.feature.placement.DynamicHeightRangePlacement;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlacement;
 
 @Mixin(HeightRangePlacement.class)
 class MixinHeightRangePlacement {
@@ -23,6 +24,22 @@ class MixinHeightRangePlacement {
 		BlockPos origin,
 		CallbackInfoReturnable<Stream<BlockPos>> callback
 	) {
+		var orePositions = DynamicOrePlacement.getHeightPositions(
+			(HeightRangePlacement)(Object)this,
+			context,
+			random,
+			origin
+		);
+		if (orePositions.isPresent()) {
+			callback.setReturnValue(orePositions.orElseThrow());
+			return;
+		}
+		if (DynamicOrePlacement.isStandardOrePlacement((HeightRangePlacement)(Object)this, context)) {
+			// A standard ore occurrence is either handled by its exact epoch plan or
+			// deliberately left to vanilla. It must not fall into the unrelated
+			// canonical surface-feature expansion path.
+			return;
+		}
 		DynamicHeightRangePlacement.getPositions(
 			(HeightRangePlacement)(Object)this,
 			context,

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinHeightRangePlacement.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinHeightRangePlacement.java
@@ -35,9 +35,6 @@ class MixinHeightRangePlacement {
 			return;
 		}
 		if (DynamicOrePlacement.isStandardOrePlacement((HeightRangePlacement)(Object)this, context)) {
-			// A standard ore occurrence is either handled by its exact epoch plan or
-			// deliberately left to vanilla. It must not fall into the unrelated
-			// canonical surface-feature expansion path.
 			return;
 		}
 		DynamicHeightRangePlacement.getPositions(

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinInSquarePlacement.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinInSquarePlacement.java
@@ -1,0 +1,34 @@
+package raccoonman.reterraforged.mixin;
+
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlacement;
+
+@Mixin(InSquarePlacement.class)
+class MixinInSquarePlacement {
+
+	@Inject(method = "getPositions", at = @At("HEAD"), cancellable = true)
+	private void reterraforged$fanOutDynamicOreHorizontalSamples(
+		PlacementContext context,
+		RandomSource random,
+		BlockPos origin,
+		CallbackInfoReturnable<Stream<BlockPos>> callback
+	) {
+		DynamicOrePlacement.getInSquarePositions(
+			(PlacementModifier)(Object)this,
+			context,
+			random,
+			origin
+		).ifPresent(callback::setReturnValue);
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinPlacementFilter.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinPlacementFilter.java
@@ -1,0 +1,39 @@
+package raccoonman.reterraforged.mixin;
+
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementFilter;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlacement;
+
+@Mixin(PlacementFilter.class)
+class MixinPlacementFilter {
+
+	@Inject(method = "getPositions", at = @At("RETURN"), cancellable = true)
+	private void reterraforged$fanOutDynamicOreRarity(
+		PlacementContext context,
+		RandomSource random,
+		BlockPos origin,
+		CallbackInfoReturnable<Stream<BlockPos>> callback
+	) {
+		if ((Object)this instanceof RarityFilter) {
+			DynamicOrePlacement.getFanoutPositions(
+				(PlacementModifier)(Object)this,
+				context,
+				random,
+				callback.getReturnValue(),
+				FanoutStage.RARITY
+			).ifPresent(callback::setReturnValue);
+		}
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinRepeatingPlacement.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinRepeatingPlacement.java
@@ -1,0 +1,39 @@
+package raccoonman.reterraforged.mixin;
+
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.RepeatingPlacement;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlacement;
+
+@Mixin(RepeatingPlacement.class)
+class MixinRepeatingPlacement {
+
+	@Inject(method = "getPositions", at = @At("RETURN"), cancellable = true)
+	private void reterraforged$fanOutDynamicOreCount(
+		PlacementContext context,
+		RandomSource random,
+		BlockPos origin,
+		CallbackInfoReturnable<Stream<BlockPos>> callback
+	) {
+		if ((Object)this instanceof CountPlacement) {
+			DynamicOrePlacement.getFanoutPositions(
+				(PlacementModifier)(Object)this,
+				context,
+				random,
+				callback.getReturnValue(),
+				FanoutStage.COUNT
+			).ifPresent(callback::setReturnValue);
+		}
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/server/RTFMinecraftServer.java
+++ b/common/src/main/java/raccoonman/reterraforged/server/RTFMinecraftServer.java
@@ -1,7 +1,12 @@
 package raccoonman.reterraforged.server;
 
 import raccoonman.reterraforged.world.worldgen.feature.template.template.FeatureTemplateManager;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan;
 
 public interface RTFMinecraftServer {
 	FeatureTemplateManager getFeatureTemplateManager();
+
+	DynamicOrePlan getDynamicOrePlan();
+
+	void publishDynamicOrePlan(DynamicOrePlan plan);
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreLifecycle.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreLifecycle.java
@@ -1,0 +1,100 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import dev.architectury.event.events.common.LifecycleEvent;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import raccoonman.reterraforged.RTFCommon;
+import raccoonman.reterraforged.server.RTFMinecraftServer;
+import raccoonman.reterraforged.world.worldgen.RTFRandomState;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
+
+/** Publishes one server-owned immutable plan for the current registry epoch. */
+public final class DynamicOreLifecycle {
+	private static boolean bootstrapped;
+
+	private DynamicOreLifecycle() {
+	}
+
+	public static synchronized void bootstrap() {
+		if (bootstrapped) {
+			return;
+		}
+		bootstrapped = true;
+		LifecycleEvent.SERVER_LEVEL_LOAD.register(DynamicOreLifecycle::onLevelLoad);
+		LifecycleEvent.SERVER_STARTED.register(DynamicOreLifecycle::onServerStarted);
+	}
+
+	private static void onLevelLoad(ServerLevel level) {
+		if (Level.OVERWORLD.equals(level.dimension())) {
+			refresh(level);
+		}
+	}
+
+	private static void onServerStarted(MinecraftServer server) {
+		if (server instanceof RTFMinecraftServer owner
+			&& owner.getDynamicOrePlan().occurrences().isEmpty()) {
+			refresh(server);
+		}
+	}
+
+	public static void refresh(MinecraftServer server) {
+		if (!(server instanceof RTFMinecraftServer owner)) {
+			return;
+		}
+		ServerLevel overworld = server.getLevel(Level.OVERWORLD);
+		if (overworld == null) {
+			owner.publishDynamicOrePlan(DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint()));
+			return;
+		}
+		refresh(overworld);
+	}
+
+	private static void refresh(ServerLevel overworld) {
+		MinecraftServer server = overworld.getServer();
+		if (!(server instanceof RTFMinecraftServer owner)) {
+			return;
+		}
+		if (!((Object)overworld.getChunkSource().randomState() instanceof RTFRandomState randomState)
+			|| randomState.generatorContext() == null) {
+			owner.publishDynamicOrePlan(DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint()));
+			return;
+		}
+
+		ChunkGenerator generator = overworld.getChunkSource().getGenerator();
+		DynamicOrePlan plan = new DynamicOrePlanner().build(
+			server.registryAccess(),
+			generator,
+			generator.getBiomeSource().possibleBiomes(),
+			new VerticalFrame(
+				overworld.getMinBuildHeight(),
+				overworld.getMaxBuildHeight() - 1,
+				generator.getSeaLevel()
+			)
+		);
+		owner.publishDynamicOrePlan(plan);
+		RTFCommon.LOGGER.info("Dynamic ore contract inventory: {}", plan.summary());
+		Map<String, Long> failures = plan.occurrences().stream()
+			.filter(occurrence -> occurrence.inspection().status() == DynamicOrePlan.InspectionStatus.FAILED)
+			.collect(Collectors.groupingBy(
+				occurrence -> occurrence.inspection().phase()
+					+ " | " + occurrence.inspection().failureType().orElse("<unknown>")
+					+ " | " + occurrence.inspection().failureMessage().orElse("<no message>"),
+				TreeMap::new,
+				Collectors.counting()
+			));
+		failures.forEach((failure, count) -> RTFCommon.LOGGER.warn(
+			"Dynamic ore contract inspection failure ({} occurrence(s)): {}", count, failure
+		));
+		if (RTFCommon.LOGGER.isDebugEnabled()) {
+			for (DynamicOrePlan.Occurrence occurrence : plan.occurrences()) {
+				RTFCommon.LOGGER.debug("Dynamic ore contract occurrence: {}", occurrence);
+			}
+		}
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreLifecycle.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreLifecycle.java
@@ -1,9 +1,5 @@
 package raccoonman.reterraforged.world.worldgen.feature.ore;
 
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.stream.Collectors;
-
 import dev.architectury.event.events.common.LifecycleEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
@@ -14,7 +10,6 @@ import raccoonman.reterraforged.server.RTFMinecraftServer;
 import raccoonman.reterraforged.world.worldgen.RTFRandomState;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
 
-/** Publishes one server-owned immutable plan for the current registry epoch. */
 public final class DynamicOreLifecycle {
 	private static boolean bootstrapped;
 
@@ -38,7 +33,7 @@ public final class DynamicOreLifecycle {
 
 	private static void onServerStarted(MinecraftServer server) {
 		if (server instanceof RTFMinecraftServer owner
-			&& owner.getDynamicOrePlan().occurrences().isEmpty()) {
+			&& owner.getDynamicOrePlan().verticalFrame().isEmpty()) {
 			refresh(server);
 		}
 	}
@@ -49,7 +44,7 @@ public final class DynamicOreLifecycle {
 		}
 		ServerLevel overworld = server.getLevel(Level.OVERWORLD);
 		if (overworld == null) {
-			owner.publishDynamicOrePlan(DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint()));
+			owner.publishDynamicOrePlan(DynamicOrePlan.empty());
 			return;
 		}
 		refresh(overworld);
@@ -62,7 +57,7 @@ public final class DynamicOreLifecycle {
 		}
 		if (!((Object)overworld.getChunkSource().randomState() instanceof RTFRandomState randomState)
 			|| randomState.generatorContext() == null) {
-			owner.publishDynamicOrePlan(DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint()));
+			owner.publishDynamicOrePlan(DynamicOrePlan.empty());
 			return;
 		}
 
@@ -79,22 +74,8 @@ public final class DynamicOreLifecycle {
 		);
 		owner.publishDynamicOrePlan(plan);
 		RTFCommon.LOGGER.info("Dynamic ore contract inventory: {}", plan.summary());
-		Map<String, Long> failures = plan.occurrences().stream()
-			.filter(occurrence -> occurrence.inspection().status() == DynamicOrePlan.InspectionStatus.FAILED)
-			.collect(Collectors.groupingBy(
-				occurrence -> occurrence.inspection().phase()
-					+ " | " + occurrence.inspection().failureType().orElse("<unknown>")
-					+ " | " + occurrence.inspection().failureMessage().orElse("<no message>"),
-				TreeMap::new,
-				Collectors.counting()
-			));
-		failures.forEach((failure, count) -> RTFCommon.LOGGER.warn(
-			"Dynamic ore contract inspection failure ({} occurrence(s)): {}", count, failure
+		plan.failures().forEach(failure -> RTFCommon.LOGGER.warn(
+			"Dynamic ore contract inspection failure: {}", failure
 		));
-		if (RTFCommon.LOGGER.isDebugEnabled()) {
-			for (DynamicOrePlan.Occurrence occurrence : plan.occurrences()) {
-				RTFCommon.LOGGER.debug("Dynamic ore contract occurrence: {}", occurrence);
-			}
-		}
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlacement.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlacement.java
@@ -21,7 +21,6 @@ import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Vertic
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalTransform;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.WeightedY;
 
-/** Applies only a precomputed, server-owned standard-ore vertical transform. */
 public final class DynamicOrePlacement {
 	private static final double INTEGER_TOLERANCE = 1.0E-12;
 
@@ -96,7 +95,6 @@ public final class DynamicOrePlacement {
 		)));
 	}
 
-	/** True only for the same public configured-feature contract owned here. */
 	public static boolean isStandardOrePlacement(HeightRangePlacement placement, PlacementContext context) {
 		return context.topFeature()
 			.filter(feature -> feature.placement().stream().anyMatch(modifier -> modifier == placement))

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlacement.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlacement.java
@@ -1,0 +1,180 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import raccoonman.reterraforged.server.RTFMinecraftServer;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalTransform;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.WeightedY;
+
+/** Applies only a precomputed, server-owned standard-ore vertical transform. */
+public final class DynamicOrePlacement {
+	private static final double INTEGER_TOLERANCE = 1.0E-12;
+
+	private DynamicOrePlacement() {
+	}
+
+	public static Optional<Stream<BlockPos>> getHeightPositions(
+		HeightRangePlacement placement,
+		PlacementContext context,
+		RandomSource random,
+		BlockPos origin
+	) {
+		Optional<Activation> activation = activation(placement, context);
+		if (activation.isEmpty()
+			|| activation.orElseThrow().modifierIndex() != activation.orElseThrow().transform().heightModifierIndex()) {
+			return Optional.empty();
+		}
+		VerticalTransform transform = activation.orElseThrow().transform();
+		int outputCount = transform.fanoutStage() == FanoutStage.HEIGHT
+			? stochasticRound(transform.expectedOutputsPerInput(), random)
+			: 1;
+		if (outputCount == 0) {
+			return Optional.of(Stream.empty());
+		}
+		if (outputCount == 1) {
+			return Optional.of(Stream.of(origin.atY(sampleY(transform, random))));
+		}
+		return Optional.of(IntStream.range(0, outputCount).mapToObj(ignored -> origin.atY(sampleY(transform, random))));
+	}
+
+	public static Optional<Stream<BlockPos>> getFanoutPositions(
+		PlacementModifier modifier,
+		PlacementContext context,
+		RandomSource random,
+		Stream<BlockPos> authoredPositions,
+		FanoutStage expectedStage
+	) {
+		Optional<Activation> activation = activation(modifier, context);
+		if (activation.isEmpty()) {
+			return Optional.empty();
+		}
+		VerticalTransform transform = activation.orElseThrow().transform();
+		if (transform.fanoutStage() != expectedStage
+			|| transform.fanoutModifierIndex() != activation.orElseThrow().modifierIndex()) {
+			return Optional.empty();
+		}
+		return Optional.of(authoredPositions.flatMap(position -> IntStream
+			.range(0, stochasticRound(transform.expectedOutputsPerInput(), random))
+			.mapToObj(ignored -> position)));
+	}
+
+	public static Optional<Stream<BlockPos>> getInSquarePositions(
+		PlacementModifier modifier,
+		PlacementContext context,
+		RandomSource random,
+		BlockPos origin
+	) {
+		Optional<Activation> activation = activation(modifier, context);
+		if (activation.isEmpty()) {
+			return Optional.empty();
+		}
+		VerticalTransform transform = activation.orElseThrow().transform();
+		if (transform.fanoutStage() != FanoutStage.IN_SQUARE
+			|| transform.fanoutModifierIndex() != activation.orElseThrow().modifierIndex()) {
+			return Optional.empty();
+		}
+		int outputCount = stochasticRound(transform.expectedOutputsPerInput(), random);
+		return Optional.of(IntStream.range(0, outputCount).mapToObj(ignored -> new BlockPos(
+			random.nextInt(16) + origin.getX(),
+			origin.getY(),
+			random.nextInt(16) + origin.getZ()
+		)));
+	}
+
+	/** True only for the same public configured-feature contract owned here. */
+	public static boolean isStandardOrePlacement(HeightRangePlacement placement, PlacementContext context) {
+		return context.topFeature()
+			.filter(feature -> feature.placement().stream().anyMatch(modifier -> modifier == placement))
+			.filter(DynamicOrePlacement::isStandardOre)
+			.isPresent();
+	}
+
+	private static boolean isStandardOre(PlacedFeature feature) {
+		Feature<?> configuredType = feature.feature().value().feature();
+		return configuredType == Feature.ORE || configuredType == Feature.SCATTERED_ORE;
+	}
+
+	private static Optional<Activation> activation(PlacementModifier modifier, PlacementContext context) {
+		if (!Level.OVERWORLD.equals(context.getLevel().getLevel().dimension())) {
+			return Optional.empty();
+		}
+		Optional<PlacedFeature> topFeature = context.topFeature().filter(DynamicOrePlacement::isStandardOre);
+		if (topFeature.isEmpty()) {
+			return Optional.empty();
+		}
+		int modifierIndex = identityIndex(topFeature.orElseThrow().placement(), modifier);
+		if (modifierIndex < 0) {
+			return Optional.empty();
+		}
+		ResourceLocation featureId = context.getLevel()
+			.registryAccess()
+			.registryOrThrow(Registries.PLACED_FEATURE)
+			.getKey(topFeature.orElseThrow());
+		if (featureId == null || !(context.getLevel().getServer() instanceof RTFMinecraftServer owner)) {
+			return Optional.empty();
+		}
+		DynamicOrePlan plan = owner.getDynamicOrePlan();
+		VerticalFrame currentFrame = new VerticalFrame(
+			context.getMinGenY(),
+			context.getMinGenY() + context.getGenDepth() - 1,
+			context.generator().getSeaLevel()
+		);
+		if (plan.verticalFrame().isEmpty() || !plan.verticalFrame().orElseThrow().equals(currentFrame)) {
+			return Optional.empty();
+		}
+		VerticalTransform transform = plan.verticalTransforms().get(featureId.toString());
+		return transform == null ? Optional.empty() : Optional.of(new Activation(transform, modifierIndex));
+	}
+
+	private static int identityIndex(List<PlacementModifier> modifiers, PlacementModifier target) {
+		for (int index = 0; index < modifiers.size(); index++) {
+			if (modifiers.get(index) == target) {
+				return index;
+			}
+		}
+		return -1;
+	}
+
+	static int stochasticRound(double expectation, RandomSource random) {
+		double nearest = Math.rint(expectation);
+		if (Math.abs(expectation - nearest) <= INTEGER_TOLERANCE) {
+			return Math.toIntExact((long)nearest);
+		}
+		int guaranteed = Math.toIntExact((long)Math.floor(expectation));
+		return guaranteed + (random.nextDouble() < expectation - guaranteed ? 1 : 0);
+	}
+
+	static int sampleY(VerticalTransform transform, RandomSource random) {
+		List<WeightedY> values = transform.cumulativeIntensity();
+		double target = random.nextDouble() * transform.expectedOutputsPerInput();
+		int low = 0;
+		int high = values.size() - 1;
+		while (low < high) {
+			int middle = (low + high) >>> 1;
+			if (target < values.get(middle).cumulativeIntensity()) {
+				high = middle;
+			} else {
+				low = middle + 1;
+			}
+		}
+		return values.get(low).y();
+	}
+
+	private record Activation(VerticalTransform transform, int modifierIndex) {
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlan.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlan.java
@@ -1,0 +1,226 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Immutable, registry-epoch-local description of ore contracts in the final
+ * Overworld biome feature graph. This model deliberately stores no registry
+ * holders or world-generation objects.
+ */
+public record DynamicOrePlan(
+	String schemaFingerprint,
+	String graphFingerprint,
+	List<Occurrence> occurrences,
+	Optional<VerticalFrame> verticalFrame,
+	Map<String, VerticalTransform> verticalTransforms
+) {
+	public DynamicOrePlan {
+		occurrences = List.copyOf(occurrences);
+		verticalFrame = verticalFrame == null ? Optional.empty() : verticalFrame;
+		verticalTransforms = Map.copyOf(verticalTransforms);
+	}
+
+	public DynamicOrePlan(String schemaFingerprint, String graphFingerprint, List<Occurrence> occurrences) {
+		this(schemaFingerprint, graphFingerprint, occurrences, Optional.empty(), Map.of());
+	}
+
+	public static DynamicOrePlan empty(String schemaFingerprint) {
+		return new DynamicOrePlan(schemaFingerprint, DynamicOrePlanner.fingerprint(List.of()), List.of());
+	}
+
+	public long count(Contract contract) {
+		return this.occurrences.stream().filter(occurrence -> occurrence.contract() == contract).count();
+	}
+
+	public long count(InspectionStatus status) {
+		return this.occurrences.stream().filter(occurrence -> occurrence.inspection().status() == status).count();
+	}
+
+	public String summary() {
+		return "schema=" + this.schemaFingerprint
+			+ ", graph=" + this.graphFingerprint
+			+ ", occurrences=" + this.occurrences.size()
+			+ ", standard=" + this.count(Contract.SUPPORTED_STANDARD)
+			+ ", custom_filters=" + this.count(Contract.STANDARD_WITH_CUSTOM_FILTER)
+			+ ", custom=" + this.count(Contract.CUSTOM_DIAGNOSTIC)
+			+ ", preserved=" + this.count(Contract.PRESERVE_UNKNOWN)
+			+ ", inactive=" + this.count(Contract.NO_ACTIVE_MEMBERSHIP)
+			+ ", inspection_failed=" + this.count(InspectionStatus.FAILED)
+			+ ", inspection_unsupported=" + this.count(InspectionStatus.UNSUPPORTED)
+			+ ", dynamic_transforms=" + this.verticalTransforms.size()
+			+ ", frame=" + this.verticalFrame.map(Object::toString).orElse("none");
+	}
+
+	public enum Contract {
+		SUPPORTED_STANDARD,
+		STANDARD_WITH_CUSTOM_FILTER,
+		CUSTOM_DIAGNOSTIC,
+		PRESERVE_UNKNOWN,
+		NO_ACTIVE_MEMBERSHIP
+	}
+
+	public enum InspectionStatus {
+		CLASSIFIED,
+		UNSUPPORTED,
+		FAILED
+	}
+
+	public enum Action {
+		REPORT_ONLY,
+		DYNAMIC_VERTICAL_DENSITY,
+		DELEGATE_REFERENCE_IDENTITY,
+		PRESERVE_UNCHANGED
+	}
+
+	public enum HeightProviderShape {
+		UNIFORM,
+		TRAPEZOID
+	}
+
+	public enum AnchorType {
+		ABSOLUTE,
+		ABOVE_BOTTOM,
+		BELOW_TOP
+	}
+
+	public enum FanoutStage {
+		COUNT,
+		RARITY,
+		IN_SQUARE,
+		HEIGHT
+	}
+
+	public record Membership(String biomeId, String step, int stepIndex, int order) {
+	}
+
+	public record Anchor(AnchorType type, int value) {
+	}
+
+	public record HeightSemantics(
+		HeightProviderShape provider,
+		Anchor minInclusive,
+		Anchor maxInclusive,
+		int plateau
+	) {
+	}
+
+	public record VerticalFrame(int minY, int maxY, int seaLevel) {
+		public VerticalFrame {
+			if (minY > maxY) {
+				throw new IllegalArgumentException("Minimum generation Y exceeds maximum generation Y");
+			}
+		}
+	}
+
+	/**
+	 * Value-only cumulative intensity table for one registered placed feature.
+	 * The final cumulative value is the expected number of output positions per
+	 * input position at the authored height modifier.
+	 */
+	public record VerticalTransform(
+		String placedFeatureId,
+		String contractFingerprint,
+		double expectedOutputsPerInput,
+		FanoutStage fanoutStage,
+		int fanoutModifierIndex,
+		int heightModifierIndex,
+		List<WeightedY> cumulativeIntensity
+	) {
+		public VerticalTransform {
+			cumulativeIntensity = List.copyOf(cumulativeIntensity);
+			if (!(expectedOutputsPerInput > 0.0) || !Double.isFinite(expectedOutputsPerInput)) {
+				throw new IllegalArgumentException("Expected outputs must be finite and positive");
+			}
+			if (cumulativeIntensity.isEmpty()) {
+				throw new IllegalArgumentException("A dynamic vertical transform requires at least one Y value");
+			}
+			if (fanoutModifierIndex < 0 || heightModifierIndex < 0) {
+				throw new IllegalArgumentException("Placement modifier indices must be non-negative");
+			}
+			double previous = 0.0;
+			for (WeightedY value : cumulativeIntensity) {
+				if (!(value.cumulativeIntensity() > previous) || !Double.isFinite(value.cumulativeIntensity())) {
+					throw new IllegalArgumentException("Cumulative intensity must be finite and strictly increasing");
+				}
+				previous = value.cumulativeIntensity();
+			}
+			if (Math.abs(previous - expectedOutputsPerInput) > Math.max(1.0, expectedOutputsPerInput) * 1.0E-12) {
+				throw new IllegalArgumentException("Final cumulative intensity must equal the output expectation");
+			}
+		}
+	}
+
+	public record WeightedY(int y, double cumulativeIntensity) {
+	}
+
+	public record Inspection(
+		InspectionStatus status,
+		String phase,
+		Optional<String> failureType,
+		Optional<String> failureMessage
+	) {
+		public Inspection {
+			failureType = failureType == null ? Optional.empty() : failureType;
+			failureMessage = failureMessage == null ? Optional.empty() : failureMessage;
+		}
+
+		public static Inspection classified() {
+			return new Inspection(InspectionStatus.CLASSIFIED, "complete", Optional.empty(), Optional.empty());
+		}
+
+		public static Inspection unsupported(String phase) {
+			return new Inspection(InspectionStatus.UNSUPPORTED, phase, Optional.empty(), Optional.empty());
+		}
+
+		public static Inspection failed(String phase, Throwable failure) {
+			return new Inspection(
+				InspectionStatus.FAILED,
+				phase,
+				Optional.of(failure.getClass().getName()),
+				Optional.ofNullable(failure.getMessage())
+			);
+		}
+	}
+
+	public record Occurrence(
+		String placedFeatureId,
+		Optional<Membership> membership,
+		String configuredFeatureType,
+		List<String> placementModifierTypes,
+		List<String> placementModifierConfigurations,
+		Optional<String> oreConfiguration,
+		Optional<HeightSemantics> height,
+		Contract contract,
+		Inspection inspection,
+		Action action,
+		String reasonCode,
+		String contractFingerprint
+	) {
+		public Occurrence {
+			membership = membership == null ? Optional.empty() : membership;
+			placementModifierTypes = List.copyOf(placementModifierTypes);
+			placementModifierConfigurations = List.copyOf(placementModifierConfigurations);
+			oreConfiguration = oreConfiguration == null ? Optional.empty() : oreConfiguration;
+			height = height == null ? Optional.empty() : height;
+		}
+
+		public Occurrence withAction(Action nextAction, String nextReasonCode) {
+			return new Occurrence(
+				this.placedFeatureId,
+				this.membership,
+				this.configuredFeatureType,
+				this.placementModifierTypes,
+				this.placementModifierConfigurations,
+				this.oreConfiguration,
+				this.height,
+				this.contract,
+				this.inspection,
+				nextAction,
+				nextReasonCode,
+				this.contractFingerprint
+			);
+		}
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlan.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlan.java
@@ -1,77 +1,39 @@
 package raccoonman.reterraforged.world.worldgen.feature.ore;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 
-/**
- * Immutable, registry-epoch-local description of ore contracts in the final
- * Overworld biome feature graph. This model deliberately stores no registry
- * holders or world-generation objects.
- */
 public record DynamicOrePlan(
-	String schemaFingerprint,
-	String graphFingerprint,
-	List<Occurrence> occurrences,
 	Optional<VerticalFrame> verticalFrame,
-	Map<String, VerticalTransform> verticalTransforms
+	Map<String, VerticalTransform> verticalTransforms,
+	int activeFeatures,
+	int standardOres,
+	int delegatedFeatures,
+	Map<String, Integer> skippedReasons,
+	List<String> failures
 ) {
 	public DynamicOrePlan {
-		occurrences = List.copyOf(occurrences);
 		verticalFrame = verticalFrame == null ? Optional.empty() : verticalFrame;
-		verticalTransforms = Map.copyOf(verticalTransforms);
+		verticalTransforms = Collections.unmodifiableMap(new TreeMap<>(verticalTransforms));
+		skippedReasons = Collections.unmodifiableMap(new TreeMap<>(skippedReasons));
+		failures = List.copyOf(failures);
 	}
 
-	public DynamicOrePlan(String schemaFingerprint, String graphFingerprint, List<Occurrence> occurrences) {
-		this(schemaFingerprint, graphFingerprint, occurrences, Optional.empty(), Map.of());
-	}
-
-	public static DynamicOrePlan empty(String schemaFingerprint) {
-		return new DynamicOrePlan(schemaFingerprint, DynamicOrePlanner.fingerprint(List.of()), List.of());
-	}
-
-	public long count(Contract contract) {
-		return this.occurrences.stream().filter(occurrence -> occurrence.contract() == contract).count();
-	}
-
-	public long count(InspectionStatus status) {
-		return this.occurrences.stream().filter(occurrence -> occurrence.inspection().status() == status).count();
+	public static DynamicOrePlan empty() {
+		return new DynamicOrePlan(Optional.empty(), Map.of(), 0, 0, 0, Map.of(), List.of());
 	}
 
 	public String summary() {
-		return "schema=" + this.schemaFingerprint
-			+ ", graph=" + this.graphFingerprint
-			+ ", occurrences=" + this.occurrences.size()
-			+ ", standard=" + this.count(Contract.SUPPORTED_STANDARD)
-			+ ", custom_filters=" + this.count(Contract.STANDARD_WITH_CUSTOM_FILTER)
-			+ ", custom=" + this.count(Contract.CUSTOM_DIAGNOSTIC)
-			+ ", preserved=" + this.count(Contract.PRESERVE_UNKNOWN)
-			+ ", inactive=" + this.count(Contract.NO_ACTIVE_MEMBERSHIP)
-			+ ", inspection_failed=" + this.count(InspectionStatus.FAILED)
-			+ ", inspection_unsupported=" + this.count(InspectionStatus.UNSUPPORTED)
+		return "active_features=" + this.activeFeatures
+			+ ", standard_ores=" + this.standardOres
 			+ ", dynamic_transforms=" + this.verticalTransforms.size()
+			+ ", delegated=" + this.delegatedFeatures
+			+ ", skipped=" + this.skippedReasons
+			+ ", failures=" + this.failures.size()
 			+ ", frame=" + this.verticalFrame.map(Object::toString).orElse("none");
-	}
-
-	public enum Contract {
-		SUPPORTED_STANDARD,
-		STANDARD_WITH_CUSTOM_FILTER,
-		CUSTOM_DIAGNOSTIC,
-		PRESERVE_UNKNOWN,
-		NO_ACTIVE_MEMBERSHIP
-	}
-
-	public enum InspectionStatus {
-		CLASSIFIED,
-		UNSUPPORTED,
-		FAILED
-	}
-
-	public enum Action {
-		REPORT_ONLY,
-		DYNAMIC_VERTICAL_DENSITY,
-		DELEGATE_REFERENCE_IDENTITY,
-		PRESERVE_UNCHANGED
 	}
 
 	public enum HeightProviderShape {
@@ -90,9 +52,6 @@ public record DynamicOrePlan(
 		RARITY,
 		IN_SQUARE,
 		HEIGHT
-	}
-
-	public record Membership(String biomeId, String step, int stepIndex, int order) {
 	}
 
 	public record Anchor(AnchorType type, int value) {
@@ -114,14 +73,7 @@ public record DynamicOrePlan(
 		}
 	}
 
-	/**
-	 * Value-only cumulative intensity table for one registered placed feature.
-	 * The final cumulative value is the expected number of output positions per
-	 * input position at the authored height modifier.
-	 */
 	public record VerticalTransform(
-		String placedFeatureId,
-		String contractFingerprint,
 		double expectedOutputsPerInput,
 		FanoutStage fanoutStage,
 		int fanoutModifierIndex,
@@ -153,74 +105,5 @@ public record DynamicOrePlan(
 	}
 
 	public record WeightedY(int y, double cumulativeIntensity) {
-	}
-
-	public record Inspection(
-		InspectionStatus status,
-		String phase,
-		Optional<String> failureType,
-		Optional<String> failureMessage
-	) {
-		public Inspection {
-			failureType = failureType == null ? Optional.empty() : failureType;
-			failureMessage = failureMessage == null ? Optional.empty() : failureMessage;
-		}
-
-		public static Inspection classified() {
-			return new Inspection(InspectionStatus.CLASSIFIED, "complete", Optional.empty(), Optional.empty());
-		}
-
-		public static Inspection unsupported(String phase) {
-			return new Inspection(InspectionStatus.UNSUPPORTED, phase, Optional.empty(), Optional.empty());
-		}
-
-		public static Inspection failed(String phase, Throwable failure) {
-			return new Inspection(
-				InspectionStatus.FAILED,
-				phase,
-				Optional.of(failure.getClass().getName()),
-				Optional.ofNullable(failure.getMessage())
-			);
-		}
-	}
-
-	public record Occurrence(
-		String placedFeatureId,
-		Optional<Membership> membership,
-		String configuredFeatureType,
-		List<String> placementModifierTypes,
-		List<String> placementModifierConfigurations,
-		Optional<String> oreConfiguration,
-		Optional<HeightSemantics> height,
-		Contract contract,
-		Inspection inspection,
-		Action action,
-		String reasonCode,
-		String contractFingerprint
-	) {
-		public Occurrence {
-			membership = membership == null ? Optional.empty() : membership;
-			placementModifierTypes = List.copyOf(placementModifierTypes);
-			placementModifierConfigurations = List.copyOf(placementModifierConfigurations);
-			oreConfiguration = oreConfiguration == null ? Optional.empty() : oreConfiguration;
-			height = height == null ? Optional.empty() : height;
-		}
-
-		public Occurrence withAction(Action nextAction, String nextReasonCode) {
-			return new Occurrence(
-				this.placedFeatureId,
-				this.membership,
-				this.configuredFeatureType,
-				this.placementModifierTypes,
-				this.placementModifierConfigurations,
-				this.oreConfiguration,
-				this.height,
-				this.contract,
-				this.inspection,
-				nextAction,
-				nextReasonCode,
-				this.contractFingerprint
-			);
-		}
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlanner.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlanner.java
@@ -1,73 +1,35 @@
 package raccoonman.reterraforged.world.worldgen.feature.ore;
 
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.IdentityHashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.biome.Biome;
-import net.minecraft.world.level.biome.BiomeGenerationSettings;
 import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Membership;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Occurrence;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.InspectionStatus;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalTransform;
+import raccoonman.reterraforged.world.worldgen.feature.ore.OreContractClassifier.Status;
 
-/** Builds a normalized value-only report from the final Overworld graph. */
 public final class DynamicOrePlanner {
-	private static final String SCHEMA_FINGERPRINT = fingerprint(List.of(
-		"ore-contract-classifier-v2",
-		"feature:ore|scattered_ore",
-		"height:one-range+uniform|trapezoid",
-		"modifiers:count|rarity|in_square|placement_filter",
-		"vertical-map:inclusive-cell-bands[-64..-1|0..8|9..62|63..319]",
-		"density:probability-weighted-mapped-cell-width-v1",
-		"action:pre-spatial-fanout+height-sampling+stochastic-rounding-v2"
-	));
-
 	private final OreContractClassifier classifier;
 
 	public DynamicOrePlanner() {
 		this(new OreContractClassifier());
 	}
 
-	DynamicOrePlanner(OreContractClassifier classifier) {
+	private DynamicOrePlanner(OreContractClassifier classifier) {
 		this.classifier = classifier;
-	}
-
-	public static String schemaFingerprint() {
-		return SCHEMA_FINGERPRINT;
-	}
-
-	public DynamicOrePlan build(
-		RegistryAccess registries,
-		ChunkGenerator generator,
-		Collection<Holder<Biome>> possibleBiomes
-	) {
-		return this.build(registries, generator, possibleBiomes, Optional.empty());
 	}
 
 	public DynamicOrePlan build(
@@ -76,225 +38,109 @@ public final class DynamicOrePlanner {
 		Collection<Holder<Biome>> possibleBiomes,
 		VerticalFrame verticalFrame
 	) {
-		return this.build(registries, generator, possibleBiomes, Optional.of(verticalFrame));
-	}
-
-	private DynamicOrePlan build(
-		RegistryAccess registries,
-		ChunkGenerator generator,
-		Collection<Holder<Biome>> possibleBiomes,
-		Optional<VerticalFrame> verticalFrame
-	) {
-		Registry<Biome> biomes = registries.registryOrThrow(Registries.BIOME);
 		Registry<PlacedFeature> placedFeatures = registries.registryOrThrow(Registries.PLACED_FEATURE);
-		List<BiomeInput> biomeInputs = possibleBiomes.stream().map(biome -> {
-			BiomeGenerationSettings settings = generator.getBiomeGenerationSettings(biome);
-			List<List<FeatureInput>> steps = settings.features().stream()
+		List<BiomeInput> biomes = possibleBiomes.stream().map(biome -> new BiomeInput(
+			generator.getBiomeGenerationSettings(biome).features().stream()
 				.map(step -> step.stream()
 					.map(holder -> new FeatureInput(featureId(holder, holder.value(), placedFeatures), holder.value()))
 					.toList())
-				.toList();
-			return new BiomeInput(biomeId(biome, biomes), steps);
-		}).toList();
-		List<FeatureInput> registeredInputs = placedFeatures.entrySet().stream()
-			.map(entry -> new FeatureInput(entry.getKey().location().toString(), entry.getValue()))
-			.toList();
-		return new DynamicOrePlanner(new OreContractClassifier(registries)).build(biomeInputs, registeredInputs, verticalFrame);
+				.toList()
+		)).toList();
+		return new DynamicOrePlanner(new OreContractClassifier(registries)).build(biomes, verticalFrame);
 	}
 
-	DynamicOrePlan build(List<BiomeInput> biomeInputs, List<FeatureInput> registeredInputs) {
-		return this.build(biomeInputs, registeredInputs, Optional.empty());
-	}
-
-	DynamicOrePlan build(
-		List<BiomeInput> biomeInputs,
-		List<FeatureInput> registeredInputs,
-		Optional<VerticalFrame> verticalFrame
-	) {
-		List<BiomeInput> orderedBiomes = biomeInputs.stream()
-			.sorted(Comparator.comparing(BiomeInput::biomeId))
-			.toList();
-		Set<PlacedFeature> activeFeatures = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
-		List<Occurrence> occurrences = new ArrayList<>();
-
-		for (BiomeInput biome : orderedBiomes) {
-			String biomeId = biome.biomeId();
-			List<List<FeatureInput>> steps = biome.steps();
-			for (int stepIndex = 0; stepIndex < steps.size(); stepIndex++) {
-				int order = 0;
-				for (FeatureInput input : steps.get(stepIndex)) {
-					PlacedFeature feature = input.feature();
-					activeFeatures.add(feature);
-					Membership membership = new Membership(biomeId, stepName(stepIndex), stepIndex, order++);
-					occurrences.add(this.classifier.classify(input.id(), membership, feature));
+	DynamicOrePlan build(List<BiomeInput> biomes, VerticalFrame frame) {
+		Map<String, PlacedFeature> active = new TreeMap<>();
+		Set<String> conflicts = new TreeSet<>();
+		for (BiomeInput biome : biomes) {
+			for (List<FeatureInput> step : biome.steps()) {
+				for (FeatureInput input : step) {
+					PlacedFeature previous = active.putIfAbsent(input.id(), input.feature());
+					if (previous != null && previous != input.feature()) {
+						conflicts.add(input.id());
+					}
 				}
 			}
 		}
 
-		registeredInputs.stream()
-			.sorted(Comparator.comparing(FeatureInput::id))
-			.filter(input -> !activeFeatures.contains(input.feature()))
-			.forEach(input -> occurrences.add(this.classifier.inactive(input.id(), input.feature())));
-
-		List<Occurrence> classified = List.copyOf(occurrences);
-		AppliedTransforms applied = verticalFrame
-			.map(frame -> applyTransforms(classified, frame))
-			.orElseGet(() -> new AppliedTransforms(classified, Map.of()));
-		return new DynamicOrePlan(
-			SCHEMA_FINGERPRINT,
-			fingerprint(classified),
-			applied.occurrences(),
-			verticalFrame,
-			applied.transforms()
-		);
-	}
-
-	private static AppliedTransforms applyTransforms(List<Occurrence> occurrences, VerticalFrame frame) {
-		Map<String, List<Occurrence>> byFeature = occurrences.stream()
-			.filter(DynamicOrePlanner::isTransformCandidate)
-			.collect(Collectors.groupingBy(
-				Occurrence::placedFeatureId,
-				LinkedHashMap::new,
-				Collectors.toList()
-			));
-		Map<String, VerticalTransform> transforms = new LinkedHashMap<>();
-		Map<String, ActionDecision> decisions = new LinkedHashMap<>();
-		for (Map.Entry<String, List<Occurrence>> entry : byFeature.entrySet()) {
+		Map<String, VerticalTransform> transforms = new TreeMap<>();
+		Map<String, Integer> skipped = new TreeMap<>();
+		List<String> failures = new ArrayList<>();
+		int standardOres = 0;
+		int delegated = 0;
+		for (Map.Entry<String, PlacedFeature> entry : active.entrySet()) {
 			String featureId = entry.getKey();
-			List<Occurrence> featureOccurrences = entry.getValue();
+			if (conflicts.contains(featureId)) {
+				increment(skipped, "CONFLICTING_FEATURES_FOR_ID");
+				continue;
+			}
+
+			OreContractClassifier.Result result = this.classifier.classify(entry.getValue());
+			if (result.status() == Status.NOT_ORE) {
+				continue;
+			}
+			standardOres++;
+			if (result.status() != Status.SUPPORTED) {
+				increment(skipped, result.reasonCode());
+				result.failure().ifPresent(failure -> failures.add(featureId + " | " + failure));
+				continue;
+			}
 			if ("<direct>".equals(featureId)) {
-				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, "DIRECT_FEATURE_HAS_NO_STABLE_IDENTITY"));
-				continue;
-			}
-			Map<String, Occurrence> contracts = featureOccurrences.stream().collect(Collectors.toMap(
-				Occurrence::contractFingerprint,
-				Function.identity(),
-				(first, ignored) -> first,
-				LinkedHashMap::new
-			));
-			if (contracts.size() != 1) {
-				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, "CONFLICTING_CONTRACTS_FOR_FEATURE_ID"));
-				continue;
-			}
-			Occurrence representative = contracts.values().iterator().next();
-			Optional<FanoutSelection> fanout = selectFanout(representative);
-			if (fanout.isEmpty()) {
-				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, "NO_SAFE_SPATIAL_FANOUT_BOUNDARY"));
+				increment(skipped, "DIRECT_FEATURE_HAS_NO_STABLE_IDENTITY");
 				continue;
 			}
 			if (DynamicOreVerticalTransform.isReferenceFrame(frame)) {
-				decisions.put(featureId, new ActionDecision(Action.DELEGATE_REFERENCE_IDENTITY, "REFERENCE_FRAME_DELEGATES_TO_VANILLA"));
+				delegated++;
 				continue;
 			}
+
+			OreContractClassifier.Contract contract = result.contract().orElseThrow();
 			DynamicOreVerticalTransform.Derivation derivation = DynamicOreVerticalTransform.derive(
-				featureId,
-				representative.contractFingerprint(),
-				representative.height().orElseThrow(),
+				contract.height(),
 				frame,
-				fanout.orElseThrow().stage(),
-				fanout.orElseThrow().modifierIndex(),
-				fanout.orElseThrow().heightModifierIndex()
+				contract.fanoutStage(),
+				contract.fanoutModifierIndex(),
+				contract.heightModifierIndex()
 			);
 			if (derivation.transform().isPresent()) {
-				VerticalTransform transform = derivation.transform().orElseThrow();
-				transforms.put(featureId, transform);
-				decisions.put(featureId, new ActionDecision(Action.DYNAMIC_VERTICAL_DENSITY, derivation.reasonCode()));
+				transforms.put(featureId, derivation.transform().orElseThrow());
+			} else if ("FEATURE_VERTICAL_MAPPING_IS_IDENTITY".equals(derivation.reasonCode())) {
+				delegated++;
 			} else {
-				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, derivation.reasonCode()));
+				increment(skipped, derivation.reasonCode());
 			}
 		}
 
-		List<Occurrence> planned = occurrences.stream().map(occurrence -> {
-			ActionDecision decision = decisions.get(occurrence.placedFeatureId());
-			return decision == null ? occurrence : occurrence.withAction(decision.action(), decision.reasonCode());
-		}).toList();
-		return new AppliedTransforms(planned, Collections.unmodifiableMap(new LinkedHashMap<>(transforms)));
+		return new DynamicOrePlan(
+			Optional.of(frame),
+			transforms,
+			active.size(),
+			standardOres,
+			delegated,
+			skipped,
+			failures
+		);
 	}
 
-	private static boolean isTransformCandidate(Occurrence occurrence) {
-		return occurrence.membership().isPresent()
-			&& occurrence.inspection().status() == InspectionStatus.CLASSIFIED
-			&& (occurrence.contract() == Contract.SUPPORTED_STANDARD
-				|| occurrence.contract() == Contract.STANDARD_WITH_CUSTOM_FILTER)
-			&& occurrence.height().isPresent();
-	}
-
-	private static Optional<FanoutSelection> selectFanout(Occurrence occurrence) {
-		List<String> types = occurrence.placementModifierTypes();
-		int heightIndex = types.indexOf("minecraft:height_range");
-		if (heightIndex < 0) {
-			return Optional.empty();
-		}
-		int inSquareIndex = types.indexOf("minecraft:in_square");
-		int firstSpatialIndex = inSquareIndex < 0 ? heightIndex : Math.min(heightIndex, inSquareIndex);
-		for (int index = firstSpatialIndex - 1; index >= 0; index--) {
-			String type = types.get(index);
-			if ("minecraft:count".equals(type)) {
-				return Optional.of(new FanoutSelection(FanoutStage.COUNT, index, heightIndex));
-			}
-			if ("minecraft:rarity_filter".equals(type)) {
-				return Optional.of(new FanoutSelection(FanoutStage.RARITY, index, heightIndex));
-			}
-		}
-		if (inSquareIndex >= 0 && inSquareIndex < heightIndex) {
-			return Optional.of(new FanoutSelection(FanoutStage.IN_SQUARE, inSquareIndex, heightIndex));
-		}
-		return Optional.of(new FanoutSelection(FanoutStage.HEIGHT, heightIndex, heightIndex));
-	}
-
-	private static String biomeId(Holder<Biome> holder, Registry<Biome> registry) {
-		return holder.unwrapKey()
-			.map(ResourceKey::location)
-			.orElseGet(() -> {
-				ResourceLocation id = registry.getKey(holder.value());
-				return id == null ? ResourceLocation.parse("reterraforged:direct_biome") : id;
-			})
-			.toString();
+	private static void increment(Map<String, Integer> counts, String reason) {
+		counts.merge(reason, 1, Integer::sum);
 	}
 
 	private static String featureId(Holder<PlacedFeature> holder, PlacedFeature feature, Registry<PlacedFeature> registry) {
 		return holder.unwrapKey()
-			.map(ResourceKey::location)
-			.map(ResourceLocation::toString)
+			.map(key -> key.location().toString())
 			.orElseGet(() -> {
 				ResourceLocation id = registry.getKey(feature);
 				return id == null ? "<direct>" : id.toString();
 			});
 	}
 
-	private static String stepName(int index) {
-		GenerationStep.Decoration[] steps = GenerationStep.Decoration.values();
-		return index < steps.length ? steps[index].getName() : "unknown_step_" + index;
-	}
-
-	static String fingerprint(List<?> values) {
-		try {
-			MessageDigest digest = MessageDigest.getInstance("SHA-256");
-			for (Object value : values) {
-				digest.update(String.valueOf(value).getBytes(StandardCharsets.UTF_8));
-				digest.update((byte)0);
-			}
-			return java.util.HexFormat.of().formatHex(digest.digest());
-		} catch (NoSuchAlgorithmException impossible) {
-			throw new IllegalStateException("SHA-256 is unavailable", impossible);
-		}
-	}
-
 	record FeatureInput(String id, PlacedFeature feature) {
 	}
 
-	record BiomeInput(String biomeId, List<List<FeatureInput>> steps) {
+	record BiomeInput(List<List<FeatureInput>> steps) {
 		BiomeInput {
 			steps = steps.stream().map(List::copyOf).toList();
 		}
-	}
-
-	private record ActionDecision(Action action, String reasonCode) {
-	}
-
-	private record AppliedTransforms(List<Occurrence> occurrences, Map<String, VerticalTransform> transforms) {
-	}
-
-	private record FanoutSelection(FanoutStage stage, int modifierIndex, int heightModifierIndex) {
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlanner.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlanner.java
@@ -1,0 +1,300 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.biome.BiomeGenerationSettings;
+import net.minecraft.world.level.chunk.ChunkGenerator;
+import net.minecraft.world.level.levelgen.GenerationStep;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Membership;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Occurrence;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.InspectionStatus;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalTransform;
+
+/** Builds a normalized value-only report from the final Overworld graph. */
+public final class DynamicOrePlanner {
+	private static final String SCHEMA_FINGERPRINT = fingerprint(List.of(
+		"ore-contract-classifier-v2",
+		"feature:ore|scattered_ore",
+		"height:one-range+uniform|trapezoid",
+		"modifiers:count|rarity|in_square|placement_filter",
+		"vertical-map:inclusive-cell-bands[-64..-1|0..8|9..62|63..319]",
+		"density:probability-weighted-mapped-cell-width-v1",
+		"action:pre-spatial-fanout+height-sampling+stochastic-rounding-v2"
+	));
+
+	private final OreContractClassifier classifier;
+
+	public DynamicOrePlanner() {
+		this(new OreContractClassifier());
+	}
+
+	DynamicOrePlanner(OreContractClassifier classifier) {
+		this.classifier = classifier;
+	}
+
+	public static String schemaFingerprint() {
+		return SCHEMA_FINGERPRINT;
+	}
+
+	public DynamicOrePlan build(
+		RegistryAccess registries,
+		ChunkGenerator generator,
+		Collection<Holder<Biome>> possibleBiomes
+	) {
+		return this.build(registries, generator, possibleBiomes, Optional.empty());
+	}
+
+	public DynamicOrePlan build(
+		RegistryAccess registries,
+		ChunkGenerator generator,
+		Collection<Holder<Biome>> possibleBiomes,
+		VerticalFrame verticalFrame
+	) {
+		return this.build(registries, generator, possibleBiomes, Optional.of(verticalFrame));
+	}
+
+	private DynamicOrePlan build(
+		RegistryAccess registries,
+		ChunkGenerator generator,
+		Collection<Holder<Biome>> possibleBiomes,
+		Optional<VerticalFrame> verticalFrame
+	) {
+		Registry<Biome> biomes = registries.registryOrThrow(Registries.BIOME);
+		Registry<PlacedFeature> placedFeatures = registries.registryOrThrow(Registries.PLACED_FEATURE);
+		List<BiomeInput> biomeInputs = possibleBiomes.stream().map(biome -> {
+			BiomeGenerationSettings settings = generator.getBiomeGenerationSettings(biome);
+			List<List<FeatureInput>> steps = settings.features().stream()
+				.map(step -> step.stream()
+					.map(holder -> new FeatureInput(featureId(holder, holder.value(), placedFeatures), holder.value()))
+					.toList())
+				.toList();
+			return new BiomeInput(biomeId(biome, biomes), steps);
+		}).toList();
+		List<FeatureInput> registeredInputs = placedFeatures.entrySet().stream()
+			.map(entry -> new FeatureInput(entry.getKey().location().toString(), entry.getValue()))
+			.toList();
+		return new DynamicOrePlanner(new OreContractClassifier(registries)).build(biomeInputs, registeredInputs, verticalFrame);
+	}
+
+	DynamicOrePlan build(List<BiomeInput> biomeInputs, List<FeatureInput> registeredInputs) {
+		return this.build(biomeInputs, registeredInputs, Optional.empty());
+	}
+
+	DynamicOrePlan build(
+		List<BiomeInput> biomeInputs,
+		List<FeatureInput> registeredInputs,
+		Optional<VerticalFrame> verticalFrame
+	) {
+		List<BiomeInput> orderedBiomes = biomeInputs.stream()
+			.sorted(Comparator.comparing(BiomeInput::biomeId))
+			.toList();
+		Set<PlacedFeature> activeFeatures = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+		List<Occurrence> occurrences = new ArrayList<>();
+
+		for (BiomeInput biome : orderedBiomes) {
+			String biomeId = biome.biomeId();
+			List<List<FeatureInput>> steps = biome.steps();
+			for (int stepIndex = 0; stepIndex < steps.size(); stepIndex++) {
+				int order = 0;
+				for (FeatureInput input : steps.get(stepIndex)) {
+					PlacedFeature feature = input.feature();
+					activeFeatures.add(feature);
+					Membership membership = new Membership(biomeId, stepName(stepIndex), stepIndex, order++);
+					occurrences.add(this.classifier.classify(input.id(), membership, feature));
+				}
+			}
+		}
+
+		registeredInputs.stream()
+			.sorted(Comparator.comparing(FeatureInput::id))
+			.filter(input -> !activeFeatures.contains(input.feature()))
+			.forEach(input -> occurrences.add(this.classifier.inactive(input.id(), input.feature())));
+
+		List<Occurrence> classified = List.copyOf(occurrences);
+		AppliedTransforms applied = verticalFrame
+			.map(frame -> applyTransforms(classified, frame))
+			.orElseGet(() -> new AppliedTransforms(classified, Map.of()));
+		return new DynamicOrePlan(
+			SCHEMA_FINGERPRINT,
+			fingerprint(classified),
+			applied.occurrences(),
+			verticalFrame,
+			applied.transforms()
+		);
+	}
+
+	private static AppliedTransforms applyTransforms(List<Occurrence> occurrences, VerticalFrame frame) {
+		Map<String, List<Occurrence>> byFeature = occurrences.stream()
+			.filter(DynamicOrePlanner::isTransformCandidate)
+			.collect(Collectors.groupingBy(
+				Occurrence::placedFeatureId,
+				LinkedHashMap::new,
+				Collectors.toList()
+			));
+		Map<String, VerticalTransform> transforms = new LinkedHashMap<>();
+		Map<String, ActionDecision> decisions = new LinkedHashMap<>();
+		for (Map.Entry<String, List<Occurrence>> entry : byFeature.entrySet()) {
+			String featureId = entry.getKey();
+			List<Occurrence> featureOccurrences = entry.getValue();
+			if ("<direct>".equals(featureId)) {
+				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, "DIRECT_FEATURE_HAS_NO_STABLE_IDENTITY"));
+				continue;
+			}
+			Map<String, Occurrence> contracts = featureOccurrences.stream().collect(Collectors.toMap(
+				Occurrence::contractFingerprint,
+				Function.identity(),
+				(first, ignored) -> first,
+				LinkedHashMap::new
+			));
+			if (contracts.size() != 1) {
+				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, "CONFLICTING_CONTRACTS_FOR_FEATURE_ID"));
+				continue;
+			}
+			Occurrence representative = contracts.values().iterator().next();
+			Optional<FanoutSelection> fanout = selectFanout(representative);
+			if (fanout.isEmpty()) {
+				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, "NO_SAFE_SPATIAL_FANOUT_BOUNDARY"));
+				continue;
+			}
+			if (DynamicOreVerticalTransform.isReferenceFrame(frame)) {
+				decisions.put(featureId, new ActionDecision(Action.DELEGATE_REFERENCE_IDENTITY, "REFERENCE_FRAME_DELEGATES_TO_VANILLA"));
+				continue;
+			}
+			DynamicOreVerticalTransform.Derivation derivation = DynamicOreVerticalTransform.derive(
+				featureId,
+				representative.contractFingerprint(),
+				representative.height().orElseThrow(),
+				frame,
+				fanout.orElseThrow().stage(),
+				fanout.orElseThrow().modifierIndex(),
+				fanout.orElseThrow().heightModifierIndex()
+			);
+			if (derivation.transform().isPresent()) {
+				VerticalTransform transform = derivation.transform().orElseThrow();
+				transforms.put(featureId, transform);
+				decisions.put(featureId, new ActionDecision(Action.DYNAMIC_VERTICAL_DENSITY, derivation.reasonCode()));
+			} else {
+				decisions.put(featureId, new ActionDecision(Action.PRESERVE_UNCHANGED, derivation.reasonCode()));
+			}
+		}
+
+		List<Occurrence> planned = occurrences.stream().map(occurrence -> {
+			ActionDecision decision = decisions.get(occurrence.placedFeatureId());
+			return decision == null ? occurrence : occurrence.withAction(decision.action(), decision.reasonCode());
+		}).toList();
+		return new AppliedTransforms(planned, Collections.unmodifiableMap(new LinkedHashMap<>(transforms)));
+	}
+
+	private static boolean isTransformCandidate(Occurrence occurrence) {
+		return occurrence.membership().isPresent()
+			&& occurrence.inspection().status() == InspectionStatus.CLASSIFIED
+			&& (occurrence.contract() == Contract.SUPPORTED_STANDARD
+				|| occurrence.contract() == Contract.STANDARD_WITH_CUSTOM_FILTER)
+			&& occurrence.height().isPresent();
+	}
+
+	private static Optional<FanoutSelection> selectFanout(Occurrence occurrence) {
+		List<String> types = occurrence.placementModifierTypes();
+		int heightIndex = types.indexOf("minecraft:height_range");
+		if (heightIndex < 0) {
+			return Optional.empty();
+		}
+		int inSquareIndex = types.indexOf("minecraft:in_square");
+		int firstSpatialIndex = inSquareIndex < 0 ? heightIndex : Math.min(heightIndex, inSquareIndex);
+		for (int index = firstSpatialIndex - 1; index >= 0; index--) {
+			String type = types.get(index);
+			if ("minecraft:count".equals(type)) {
+				return Optional.of(new FanoutSelection(FanoutStage.COUNT, index, heightIndex));
+			}
+			if ("minecraft:rarity_filter".equals(type)) {
+				return Optional.of(new FanoutSelection(FanoutStage.RARITY, index, heightIndex));
+			}
+		}
+		if (inSquareIndex >= 0 && inSquareIndex < heightIndex) {
+			return Optional.of(new FanoutSelection(FanoutStage.IN_SQUARE, inSquareIndex, heightIndex));
+		}
+		return Optional.of(new FanoutSelection(FanoutStage.HEIGHT, heightIndex, heightIndex));
+	}
+
+	private static String biomeId(Holder<Biome> holder, Registry<Biome> registry) {
+		return holder.unwrapKey()
+			.map(ResourceKey::location)
+			.orElseGet(() -> {
+				ResourceLocation id = registry.getKey(holder.value());
+				return id == null ? ResourceLocation.parse("reterraforged:direct_biome") : id;
+			})
+			.toString();
+	}
+
+	private static String featureId(Holder<PlacedFeature> holder, PlacedFeature feature, Registry<PlacedFeature> registry) {
+		return holder.unwrapKey()
+			.map(ResourceKey::location)
+			.map(ResourceLocation::toString)
+			.orElseGet(() -> {
+				ResourceLocation id = registry.getKey(feature);
+				return id == null ? "<direct>" : id.toString();
+			});
+	}
+
+	private static String stepName(int index) {
+		GenerationStep.Decoration[] steps = GenerationStep.Decoration.values();
+		return index < steps.length ? steps[index].getName() : "unknown_step_" + index;
+	}
+
+	static String fingerprint(List<?> values) {
+		try {
+			MessageDigest digest = MessageDigest.getInstance("SHA-256");
+			for (Object value : values) {
+				digest.update(String.valueOf(value).getBytes(StandardCharsets.UTF_8));
+				digest.update((byte)0);
+			}
+			return java.util.HexFormat.of().formatHex(digest.digest());
+		} catch (NoSuchAlgorithmException impossible) {
+			throw new IllegalStateException("SHA-256 is unavailable", impossible);
+		}
+	}
+
+	record FeatureInput(String id, PlacedFeature feature) {
+	}
+
+	record BiomeInput(String biomeId, List<List<FeatureInput>> steps) {
+		BiomeInput {
+			steps = steps.stream().map(List::copyOf).toList();
+		}
+	}
+
+	private record ActionDecision(Action action, String reasonCode) {
+	}
+
+	private record AppliedTransforms(List<Occurrence> occurrences, Map<String, VerticalTransform> transforms) {
+	}
+
+	private record FanoutSelection(FanoutStage stage, int modifierIndex, int heightModifierIndex) {
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransform.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransform.java
@@ -14,7 +14,6 @@ import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Vertic
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalTransform;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.WeightedY;
 
-/** Pure derivation of the reference-to-live vertical candidate-intensity map. */
 final class DynamicOreVerticalTransform {
 	static final int REFERENCE_MIN_Y = -64;
 	static final int REFERENCE_DEEPSLATE_START_Y = 0;
@@ -33,17 +32,13 @@ final class DynamicOreVerticalTransform {
 	}
 
 	static Derivation derive(
-		String placedFeatureId,
-		String contractFingerprint,
 		HeightSemantics height,
 		VerticalFrame frame
 	) {
-		return derive(placedFeatureId, contractFingerprint, height, frame, FanoutStage.HEIGHT, 0, 0);
+		return derive(height, frame, FanoutStage.HEIGHT, 0, 0);
 	}
 
 	static Derivation derive(
-		String placedFeatureId,
-		String contractFingerprint,
 		HeightSemantics height,
 		VerticalFrame frame,
 		FanoutStage fanoutStage,
@@ -117,8 +112,6 @@ final class DynamicOreVerticalTransform {
 			return Derivation.unsupported("INVALID_MAPPED_INTENSITY");
 		}
 		return Derivation.supported(new VerticalTransform(
-			placedFeatureId,
-			contractFingerprint,
 			cumulative,
 			fanoutStage,
 			fanoutModifierIndex,
@@ -184,9 +177,7 @@ final class DynamicOreVerticalTransform {
 	}
 
 	private static double map(double referenceY, VerticalFrame frame) {
-		// These are boundaries between inclusive integer block bands, not block
-		// centers. In particular, seaLevel is the first non-global-fluid block
-		// (vanilla fills y < seaLevel), so its boundary is seaLevel - 0.5.
+		// Inclusive integer bands meet at half-block boundaries; seaLevel is the first non-fluid block.
 		double[] reference = {
 			REFERENCE_MIN_Y - 0.5,
 			REFERENCE_DEEPSLATE_START_Y - 0.5,

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransform.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransform.java
@@ -1,0 +1,225 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Anchor;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightProviderShape;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightSemantics;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalTransform;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.WeightedY;
+
+/** Pure derivation of the reference-to-live vertical candidate-intensity map. */
+final class DynamicOreVerticalTransform {
+	static final int REFERENCE_MIN_Y = -64;
+	static final int REFERENCE_DEEPSLATE_START_Y = 0;
+	static final int REFERENCE_DEEPSLATE_END_Y = 8;
+	static final int REFERENCE_SEA_LEVEL = 63;
+	static final int REFERENCE_MAX_Y = 319;
+	private static final int MAX_OUTPUT_Y_VALUES = 16_384;
+
+	private DynamicOreVerticalTransform() {
+	}
+
+	static boolean isReferenceFrame(VerticalFrame frame) {
+		return frame.minY() == REFERENCE_MIN_Y
+			&& frame.maxY() == REFERENCE_MAX_Y
+			&& frame.seaLevel() == REFERENCE_SEA_LEVEL;
+	}
+
+	static Derivation derive(
+		String placedFeatureId,
+		String contractFingerprint,
+		HeightSemantics height,
+		VerticalFrame frame
+	) {
+		return derive(placedFeatureId, contractFingerprint, height, frame, FanoutStage.HEIGHT, 0, 0);
+	}
+
+	static Derivation derive(
+		String placedFeatureId,
+		String contractFingerprint,
+		HeightSemantics height,
+		VerticalFrame frame,
+		FanoutStage fanoutStage,
+		int fanoutModifierIndex,
+		int heightModifierIndex
+	) {
+		if (!validFrame(frame)) {
+			return Derivation.unsupported("NON_MONOTONIC_LIVE_LANDMARKS");
+		}
+		if (height.plateau() < 0) {
+			return Derivation.unsupported("NEGATIVE_TRAPEZOID_PLATEAU");
+		}
+
+		long referenceMinLong = resolve(height.minInclusive(), REFERENCE_MIN_Y, REFERENCE_MAX_Y);
+		long referenceMaxLong = resolve(height.maxInclusive(), REFERENCE_MIN_Y, REFERENCE_MAX_Y);
+		if (referenceMinLong < Integer.MIN_VALUE || referenceMinLong > Integer.MAX_VALUE
+			|| referenceMaxLong < Integer.MIN_VALUE || referenceMaxLong > Integer.MAX_VALUE) {
+			return Derivation.unsupported("REFERENCE_HEIGHT_OUTSIDE_INTEGER_RANGE");
+		}
+		int referenceMin = (int)referenceMinLong;
+		int referenceMax = (int)referenceMaxLong;
+		if (referenceMin > referenceMax) {
+			return Derivation.unsupported("EMPTY_REFERENCE_HEIGHT_RANGE");
+		}
+		if ((long)referenceMax - referenceMin + 1L > MAX_OUTPUT_Y_VALUES) {
+			return Derivation.unsupported("REFERENCE_HEIGHT_SUPPORT_TOO_LARGE");
+		}
+		Map<Integer, Double> referencePmf = probabilityMass(height.provider(), referenceMin, referenceMax, height.plateau());
+		TreeMap<Integer, Double> outputWeights = new TreeMap<>();
+		for (Map.Entry<Integer, Double> entry : referencePmf.entrySet()) {
+			double low = map(entry.getKey() - 0.5, frame);
+			double high = map(entry.getKey() + 0.5, frame);
+			if (high < low) {
+				double swap = low;
+				low = high;
+				high = swap;
+			}
+			if (!(high > low) || !Double.isFinite(low) || !Double.isFinite(high)) {
+				continue;
+			}
+			long first = (long)Math.floor(low - 0.5) - 1L;
+			long last = (long)Math.ceil(high + 0.5) + 1L;
+			if (first < Integer.MIN_VALUE || last > Integer.MAX_VALUE || last - first > MAX_OUTPUT_Y_VALUES + 4L) {
+				return Derivation.unsupported("MAPPED_HEIGHT_SUPPORT_TOO_LARGE");
+			}
+			for (long candidate = first; candidate <= last; candidate++) {
+				double overlap = Math.min(high, candidate + 0.5) - Math.max(low, candidate - 0.5);
+				if (overlap > 0.0) {
+					outputWeights.merge((int)candidate, entry.getValue() * overlap, Double::sum);
+				}
+			}
+		}
+		if (outputWeights.isEmpty() || outputWeights.size() > MAX_OUTPUT_Y_VALUES) {
+			return Derivation.unsupported("EMPTY_OR_OVERSIZED_MAPPED_HEIGHT_SUPPORT");
+		}
+		if (isIdentity(referencePmf, outputWeights)) {
+			return Derivation.unsupported("FEATURE_VERTICAL_MAPPING_IS_IDENTITY");
+		}
+
+		double cumulative = 0.0;
+		List<WeightedY> samples = new ArrayList<>(outputWeights.size());
+		for (Map.Entry<Integer, Double> entry : outputWeights.entrySet()) {
+			double weight = entry.getValue();
+			if (!(weight > 0.0) || !Double.isFinite(weight)) {
+				continue;
+			}
+			cumulative += weight;
+			samples.add(new WeightedY(entry.getKey(), cumulative));
+		}
+		if (!(cumulative > 0.0) || !Double.isFinite(cumulative) || samples.isEmpty()) {
+			return Derivation.unsupported("INVALID_MAPPED_INTENSITY");
+		}
+		return Derivation.supported(new VerticalTransform(
+			placedFeatureId,
+			contractFingerprint,
+			cumulative,
+			fanoutStage,
+			fanoutModifierIndex,
+			heightModifierIndex,
+			samples
+		));
+	}
+
+	private static boolean isIdentity(Map<Integer, Double> reference, Map<Integer, Double> output) {
+		if (!reference.keySet().equals(output.keySet())) {
+			return false;
+		}
+		for (Map.Entry<Integer, Double> entry : reference.entrySet()) {
+			double actual = output.get(entry.getKey());
+			if (Math.abs(actual - entry.getValue()) > Math.max(1.0, entry.getValue()) * 1.0E-12) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static boolean validFrame(VerticalFrame frame) {
+		return frame.minY() <= REFERENCE_DEEPSLATE_START_Y
+			&& REFERENCE_DEEPSLATE_START_Y <= REFERENCE_DEEPSLATE_END_Y
+			&& REFERENCE_DEEPSLATE_END_Y < frame.seaLevel()
+			&& frame.seaLevel() <= frame.maxY();
+	}
+
+	private static long resolve(Anchor anchor, int minY, int maxY) {
+		return switch (anchor.type()) {
+			case ABSOLUTE -> anchor.value();
+			case ABOVE_BOTTOM -> (long)minY + anchor.value();
+			case BELOW_TOP -> (long)maxY - anchor.value();
+		};
+	}
+
+	private static Map<Integer, Double> probabilityMass(
+		HeightProviderShape provider,
+		int minY,
+		int maxY,
+		int plateau
+	) {
+		int width = Math.subtractExact(maxY, minY);
+		TreeMap<Integer, Double> probabilities = new TreeMap<>();
+		if (provider == HeightProviderShape.UNIFORM || plateau >= width) {
+			double probability = 1.0 / (width + 1.0);
+			for (int y = minY; y <= maxY; y++) {
+				probabilities.put(y, probability);
+			}
+			return probabilities;
+		}
+
+		int left = (width - plateau) / 2;
+		int right = width - left;
+		double denominator = (left + 1.0) * (right + 1.0);
+		for (int offset = 0; offset <= width; offset++) {
+			int lowerFirst = Math.max(0, offset - left);
+			int upperFirst = Math.min(right, offset);
+			int combinations = Math.max(0, upperFirst - lowerFirst + 1);
+			probabilities.put(minY + offset, combinations / denominator);
+		}
+		return probabilities;
+	}
+
+	private static double map(double referenceY, VerticalFrame frame) {
+		// These are boundaries between inclusive integer block bands, not block
+		// centers. In particular, seaLevel is the first non-global-fluid block
+		// (vanilla fills y < seaLevel), so its boundary is seaLevel - 0.5.
+		double[] reference = {
+			REFERENCE_MIN_Y - 0.5,
+			REFERENCE_DEEPSLATE_START_Y - 0.5,
+			REFERENCE_DEEPSLATE_END_Y + 0.5,
+			REFERENCE_SEA_LEVEL - 0.5,
+			REFERENCE_MAX_Y + 0.5
+		};
+		double[] live = {
+			frame.minY() - 0.5,
+			REFERENCE_DEEPSLATE_START_Y - 0.5,
+			REFERENCE_DEEPSLATE_END_Y + 0.5,
+			frame.seaLevel() - 0.5,
+			frame.maxY() + 0.5
+		};
+		int segment = reference.length - 2;
+		if (referenceY < reference[reference.length - 1]) {
+			segment = 0;
+			while (segment < reference.length - 2 && referenceY >= reference[segment + 1]) {
+				segment++;
+			}
+		}
+		double referenceSpan = reference[segment + 1] - reference[segment];
+		double liveSpan = live[segment + 1] - live[segment];
+		return live[segment] + (referenceY - reference[segment]) * liveSpan / referenceSpan;
+	}
+
+	record Derivation(Optional<VerticalTransform> transform, String reasonCode) {
+		private static Derivation supported(VerticalTransform transform) {
+			return new Derivation(Optional.of(transform), "DYNAMIC_VERTICAL_DENSITY");
+		}
+
+		private static Derivation unsupported(String reasonCode) {
+			return new Derivation(Optional.empty(), reasonCode);
+		}
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifier.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifier.java
@@ -1,17 +1,11 @@
 package raccoonman.reterraforged.world.worldgen.feature.ore;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import com.mojang.serialization.JsonOps;
-import com.google.gson.JsonElement;
-import com.mojang.serialization.DynamicOps;
 
 import net.minecraft.core.HolderLookup;
-import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
@@ -20,180 +14,84 @@ import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.placement.PlacementFilter;
 import net.minecraft.world.level.levelgen.placement.PlacementModifier;
-import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
 import net.minecraft.world.level.levelgen.placement.RarityFilter;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightSemantics;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Inspection;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Membership;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Occurrence;
 
-/** Contract-based classifier with no linkage to optional mod classes. */
 public final class OreContractClassifier {
-	private final HeightInspection heightInspection;
-	private final DynamicOps<JsonElement> ops;
+	private final OreHeightInspector heightInspector;
 
 	OreContractClassifier() {
-		this(JsonOps.INSTANCE);
+		this.heightInspector = new OreHeightInspector(JsonOps.INSTANCE);
 	}
 
 	public OreContractClassifier(HolderLookup.Provider registries) {
-		this(net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registries));
+		this.heightInspector = new OreHeightInspector(
+			net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registries)
+		);
 	}
 
-	private OreContractClassifier(DynamicOps<JsonElement> ops) {
-		this(new OreHeightInspector(ops)::inspect, ops);
-	}
-
-	OreContractClassifier(HeightInspection heightInspection) {
-		this(heightInspection, JsonOps.INSTANCE);
-	}
-
-	private OreContractClassifier(HeightInspection heightInspection, DynamicOps<JsonElement> ops) {
-		this.heightInspection = heightInspection;
-		this.ops = ops;
-	}
-
-	public Occurrence classify(String placedFeatureId, Membership membership, PlacedFeature placedFeature) {
-		String phase = "feature_contract";
-		String configuredFeatureType = "<inspection-failed>";
-		List<String> modifierTypes = new ArrayList<>();
-		List<String> modifierConfigurations = new ArrayList<>();
-		Optional<String> oreConfiguration = Optional.empty();
+	public Result classify(PlacedFeature placedFeature) {
+		String phase = "configured_feature";
 		try {
-			ConfiguredFeature<?, ?> configured = placedFeature.feature().value();
-			configuredFeatureType = featureType(configured);
-
-			phase = "modifier_types";
-			for (PlacementModifier modifier : placedFeature.placement()) {
-				modifierTypes.add(modifierType(modifier));
-				modifierConfigurations.add(modifierConfiguration(modifier));
-			}
-
+			var configured = placedFeature.feature().value();
 			if (configured.feature() != Feature.ORE && configured.feature() != Feature.SCATTERED_ORE) {
-				return occurrence(
-					placedFeatureId,
-					Optional.of(membership),
-					configuredFeatureType,
-					modifierTypes,
-					modifierConfigurations,
-					Optional.empty(),
-					Optional.empty(),
-					Contract.CUSTOM_DIAGNOSTIC,
-					Inspection.unsupported("configured_feature"),
-					Action.PRESERVE_UNCHANGED,
-					"CUSTOM_CONFIGURED_FEATURE"
-				);
+				return Result.notOre();
 			}
-			if (!(configured.config() instanceof OreConfiguration ore)) {
-				return occurrence(
-					placedFeatureId,
-					Optional.of(membership),
-					configuredFeatureType,
-					modifierTypes,
-					modifierConfigurations,
-					Optional.empty(),
-					Optional.empty(),
-					Contract.PRESERVE_UNKNOWN,
-					Inspection.unsupported("ore_configuration"),
-					Action.PRESERVE_UNCHANGED,
-					"INVALID_ORE_CONFIGURATION_SHAPE"
-				);
+			if (!(configured.config() instanceof OreConfiguration)) {
+				return Result.skipped("INVALID_ORE_CONFIGURATION_SHAPE");
 			}
-
-			phase = "ore_configuration";
-			oreConfiguration = Optional.of(
-				OreConfiguration.CODEC.encodeStart(this.ops, ore)
-					.getOrThrow(message -> new OreHeightInspector.InspectionFailure("ore_configuration", message))
-					.toString()
-			);
 
 			phase = "placement_contract";
+			List<PlacementModifier> modifiers = placedFeature.placement();
 			HeightRangePlacement heightPlacement = null;
-			boolean customFilter = false;
-			for (PlacementModifier modifier : placedFeature.placement()) {
+			for (PlacementModifier modifier : modifiers) {
 				if (modifier instanceof HeightRangePlacement height) {
 					if (heightPlacement != null) {
-						return preserved(
-							placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
-							"MULTIPLE_HEIGHT_RANGES", "placement_contract"
-						);
+						return Result.skipped("MULTIPLE_HEIGHT_RANGES");
 					}
 					heightPlacement = height;
-					continue;
-				}
-				if (modifier instanceof PlacementFilter filter) {
-					customFilter |= !isVanillaFilter(filter);
-					continue;
-				}
-				if (!(modifier instanceof CountPlacement)
+				} else if (!(modifier instanceof CountPlacement)
 					&& !(modifier instanceof RarityFilter)
-					&& !(modifier instanceof InSquarePlacement)) {
-					return preserved(
-						placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
-						"UNSUPPORTED_POSITION_MODIFIER", "placement_contract"
-					);
+					&& !(modifier instanceof InSquarePlacement)
+					&& !(modifier instanceof PlacementFilter)) {
+					return Result.skipped("UNSUPPORTED_POSITION_MODIFIER");
 				}
 			}
 			if (heightPlacement == null) {
-				return preserved(
-					placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
-					"MISSING_HEIGHT_RANGE", "placement_contract"
-				);
+				return Result.skipped("MISSING_HEIGHT_RANGE");
 			}
-			int fanoutIndex = safeFanoutIndex(placedFeature.placement());
-			for (int index = 0; index < fanoutIndex; index++) {
-				if (placedFeature.placement().get(index) instanceof PlacementFilter) {
-					return preserved(
-						placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
-						"UPSTREAM_FILTER_BEFORE_SAFE_FANOUT", "placement_contract"
-					);
+
+			Fanout fanout = selectFanout(modifiers);
+			for (int index = 0; index < fanout.modifierIndex(); index++) {
+				if (modifiers.get(index) instanceof PlacementFilter) {
+					return Result.skipped("UPSTREAM_FILTER_BEFORE_SAFE_FANOUT");
 				}
 			}
 
 			phase = "height_provider";
-			HeightSemantics height = this.heightInspection.inspect(heightPlacement);
-			Contract contract = customFilter ? Contract.STANDARD_WITH_CUSTOM_FILTER : Contract.SUPPORTED_STANDARD;
-			return occurrence(
-				placedFeatureId,
-				Optional.of(membership),
-				configuredFeatureType,
-				modifierTypes,
-				modifierConfigurations,
-				oreConfiguration,
-				Optional.of(height),
-				contract,
-				Inspection.classified(),
-				Action.REPORT_ONLY,
-				customFilter ? "SUPPORTED_CUSTOM_PLACEMENT_FILTER" : "SUPPORTED_STANDARD_ORE"
-			);
+			HeightSemantics height = this.heightInspector.inspect(heightPlacement);
+			return Result.supported(new Contract(
+				height,
+				fanout.stage(),
+				fanout.modifierIndex(),
+				fanout.heightModifierIndex()
+			));
 		} catch (OreHeightInspector.UnsupportedHeightProvider unsupported) {
-			return preserved(
-				placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
-				"UNSUPPORTED_HEIGHT_PROVIDER:" + unsupported.provider(), "height_provider"
-			);
+			return Result.skipped("UNSUPPORTED_HEIGHT_PROVIDER:" + unsupported.provider());
 		} catch (RuntimeException | LinkageError failure) {
 			String failurePhase = failure instanceof OreHeightInspector.InspectionFailure inspectionFailure
 				? inspectionFailure.phase()
 				: phase;
-			return occurrence(
-				placedFeatureId,
-				Optional.of(membership),
-				configuredFeatureType,
-				modifierTypes,
-				modifierConfigurations,
-				oreConfiguration,
-				Optional.empty(),
-				Contract.PRESERVE_UNKNOWN,
-				Inspection.failed(failurePhase, failure),
-				Action.PRESERVE_UNCHANGED,
-				"INSPECTION_FAILED"
+			return Result.failed(
+				"INSPECTION_FAILED",
+				failurePhase + " | " + failure.getClass().getName() + " | "
+					+ Optional.ofNullable(failure.getMessage()).orElse("<no message>")
 			);
 		}
 	}
 
-	private static int safeFanoutIndex(List<PlacementModifier> modifiers) {
+	private static Fanout selectFanout(List<PlacementModifier> modifiers) {
 		int heightIndex = -1;
 		int inSquareIndex = -1;
 		for (int index = 0; index < modifiers.size(); index++) {
@@ -208,148 +106,51 @@ public final class OreContractClassifier {
 		int firstSpatialIndex = inSquareIndex < 0 ? heightIndex : Math.min(heightIndex, inSquareIndex);
 		for (int index = firstSpatialIndex - 1; index >= 0; index--) {
 			PlacementModifier modifier = modifiers.get(index);
-			if (modifier instanceof CountPlacement || modifier instanceof RarityFilter) {
-				return index;
+			if (modifier instanceof CountPlacement) {
+				return new Fanout(FanoutStage.COUNT, index, heightIndex);
+			}
+			if (modifier instanceof RarityFilter) {
+				return new Fanout(FanoutStage.RARITY, index, heightIndex);
 			}
 		}
-		return inSquareIndex >= 0 && inSquareIndex < heightIndex ? inSquareIndex : heightIndex;
+		return inSquareIndex >= 0 && inSquareIndex < heightIndex
+			? new Fanout(FanoutStage.IN_SQUARE, inSquareIndex, heightIndex)
+			: new Fanout(FanoutStage.HEIGHT, heightIndex, heightIndex);
 	}
 
-	public Occurrence inactive(String placedFeatureId, PlacedFeature placedFeature) {
-		String configuredFeatureType = "<inspection-failed>";
-		List<String> modifierTypes = new ArrayList<>();
-		List<String> modifierConfigurations = new ArrayList<>();
-		try {
-			configuredFeatureType = featureType(placedFeature.feature().value());
-			for (PlacementModifier modifier : placedFeature.placement()) {
-				modifierTypes.add(modifierType(modifier));
-				modifierConfigurations.add(this.modifierConfiguration(modifier));
-			}
-			return occurrence(
-				placedFeatureId,
-				Optional.empty(),
-				configuredFeatureType,
-				modifierTypes,
-				modifierConfigurations,
-				Optional.empty(),
-				Optional.empty(),
-				Contract.NO_ACTIVE_MEMBERSHIP,
-				Inspection.unsupported("final_membership"),
-				Action.PRESERVE_UNCHANGED,
-				"NO_ACTIVE_MEMBERSHIP"
-			);
-		} catch (RuntimeException | LinkageError failure) {
-			return occurrence(
-				placedFeatureId,
-				Optional.empty(),
-				configuredFeatureType,
-				modifierTypes,
-				modifierConfigurations,
-				Optional.empty(),
-				Optional.empty(),
-				Contract.NO_ACTIVE_MEMBERSHIP,
-				Inspection.failed("inactive_snapshot", failure),
-				Action.PRESERVE_UNCHANGED,
-				"INACTIVE_INSPECTION_FAILED"
-			);
+	public enum Status {
+		NOT_ORE,
+		SUPPORTED,
+		SKIPPED,
+		FAILED
+	}
+
+	public record Result(Status status, Optional<Contract> contract, String reasonCode, Optional<String> failure) {
+		private static Result notOre() {
+			return new Result(Status.NOT_ORE, Optional.empty(), "NOT_STANDARD_ORE", Optional.empty());
+		}
+
+		private static Result supported(Contract contract) {
+			return new Result(Status.SUPPORTED, Optional.of(contract), "SUPPORTED_STANDARD_ORE", Optional.empty());
+		}
+
+		private static Result skipped(String reasonCode) {
+			return new Result(Status.SKIPPED, Optional.empty(), reasonCode, Optional.empty());
+		}
+
+		private static Result failed(String reasonCode, String failure) {
+			return new Result(Status.FAILED, Optional.empty(), reasonCode, Optional.of(failure));
 		}
 	}
 
-	private static Occurrence preserved(
-		String placedFeatureId,
-		Membership membership,
-		String configuredFeatureType,
-		List<String> modifierTypes,
-		List<String> modifierConfigurations,
-		Optional<String> oreConfiguration,
-		String reason,
-		String phase
+	public record Contract(
+		HeightSemantics height,
+		FanoutStage fanoutStage,
+		int fanoutModifierIndex,
+		int heightModifierIndex
 	) {
-		return occurrence(
-			placedFeatureId,
-			Optional.of(membership),
-			configuredFeatureType,
-			modifierTypes,
-			modifierConfigurations,
-			oreConfiguration,
-			Optional.empty(),
-			Contract.PRESERVE_UNKNOWN,
-			Inspection.unsupported(phase),
-			Action.PRESERVE_UNCHANGED,
-			reason
-		);
 	}
 
-	private static Occurrence occurrence(
-		String placedFeatureId,
-		Optional<Membership> membership,
-		String configuredFeatureType,
-		List<String> modifierTypes,
-		List<String> modifierConfigurations,
-		Optional<String> oreConfiguration,
-		Optional<HeightSemantics> height,
-		Contract contract,
-		Inspection inspection,
-		Action action,
-		String reason
-	) {
-		List<String> semanticParts = List.of(
-			configuredFeatureType,
-			String.join(",", modifierTypes),
-			String.join(",", modifierConfigurations),
-			oreConfiguration.orElse(""),
-			height.map(Object::toString).orElse(""),
-			contract.name(),
-			inspection.status().name(),
-			reason
-		);
-		return new Occurrence(
-			placedFeatureId,
-			membership,
-			configuredFeatureType,
-			modifierTypes,
-			modifierConfigurations,
-			oreConfiguration,
-			height,
-			contract,
-			inspection,
-			action,
-			reason,
-			DynamicOrePlanner.fingerprint(semanticParts)
-		);
-	}
-
-	private static String featureType(ConfiguredFeature<?, ?> configured) {
-		ResourceLocation id = BuiltInRegistries.FEATURE.getKey(configured.feature());
-		return id == null ? "<unregistered:" + configured.feature().getClass().getName() + ">" : id.toString();
-	}
-
-	private static String modifierType(PlacementModifier modifier) {
-		ResourceLocation id = BuiltInRegistries.PLACEMENT_MODIFIER_TYPE.getKey(modifier.type());
-		return id == null ? "<unregistered:" + modifier.getClass().getName() + ">" : id.toString();
-	}
-
-	@SuppressWarnings("unchecked")
-	private String modifierConfiguration(PlacementModifier modifier) {
-		com.mojang.serialization.Codec<PlacementModifier> codec =
-			(com.mojang.serialization.Codec<PlacementModifier>)(com.mojang.serialization.Codec<?>)modifier.type().codec().codec();
-		return codec
-			.encodeStart(this.ops, modifier)
-			.getOrThrow(message -> new OreHeightInspector.InspectionFailure("modifier_configuration", message))
-			.toString();
-	}
-
-	private static boolean isVanillaFilter(PlacementFilter filter) {
-		PlacementModifierType<?> type = filter.type();
-		return type == PlacementModifierType.BLOCK_PREDICATE_FILTER
-			|| type == PlacementModifierType.RARITY_FILTER
-			|| type == PlacementModifierType.SURFACE_RELATIVE_THRESHOLD_FILTER
-			|| type == PlacementModifierType.SURFACE_WATER_DEPTH_FILTER
-			|| type == PlacementModifierType.BIOME_FILTER;
-	}
-
-	@FunctionalInterface
-	interface HeightInspection {
-		HeightSemantics inspect(HeightRangePlacement placement);
+	private record Fanout(FanoutStage stage, int modifierIndex, int heightModifierIndex) {
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifier.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifier.java
@@ -1,0 +1,355 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.mojang.serialization.JsonOps;
+import com.google.gson.JsonElement;
+import com.mojang.serialization.DynamicOps;
+
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementFilter;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightSemantics;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Inspection;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Membership;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Occurrence;
+
+/** Contract-based classifier with no linkage to optional mod classes. */
+public final class OreContractClassifier {
+	private final HeightInspection heightInspection;
+	private final DynamicOps<JsonElement> ops;
+
+	OreContractClassifier() {
+		this(JsonOps.INSTANCE);
+	}
+
+	public OreContractClassifier(HolderLookup.Provider registries) {
+		this(net.minecraft.resources.RegistryOps.create(JsonOps.INSTANCE, registries));
+	}
+
+	private OreContractClassifier(DynamicOps<JsonElement> ops) {
+		this(new OreHeightInspector(ops)::inspect, ops);
+	}
+
+	OreContractClassifier(HeightInspection heightInspection) {
+		this(heightInspection, JsonOps.INSTANCE);
+	}
+
+	private OreContractClassifier(HeightInspection heightInspection, DynamicOps<JsonElement> ops) {
+		this.heightInspection = heightInspection;
+		this.ops = ops;
+	}
+
+	public Occurrence classify(String placedFeatureId, Membership membership, PlacedFeature placedFeature) {
+		String phase = "feature_contract";
+		String configuredFeatureType = "<inspection-failed>";
+		List<String> modifierTypes = new ArrayList<>();
+		List<String> modifierConfigurations = new ArrayList<>();
+		Optional<String> oreConfiguration = Optional.empty();
+		try {
+			ConfiguredFeature<?, ?> configured = placedFeature.feature().value();
+			configuredFeatureType = featureType(configured);
+
+			phase = "modifier_types";
+			for (PlacementModifier modifier : placedFeature.placement()) {
+				modifierTypes.add(modifierType(modifier));
+				modifierConfigurations.add(modifierConfiguration(modifier));
+			}
+
+			if (configured.feature() != Feature.ORE && configured.feature() != Feature.SCATTERED_ORE) {
+				return occurrence(
+					placedFeatureId,
+					Optional.of(membership),
+					configuredFeatureType,
+					modifierTypes,
+					modifierConfigurations,
+					Optional.empty(),
+					Optional.empty(),
+					Contract.CUSTOM_DIAGNOSTIC,
+					Inspection.unsupported("configured_feature"),
+					Action.PRESERVE_UNCHANGED,
+					"CUSTOM_CONFIGURED_FEATURE"
+				);
+			}
+			if (!(configured.config() instanceof OreConfiguration ore)) {
+				return occurrence(
+					placedFeatureId,
+					Optional.of(membership),
+					configuredFeatureType,
+					modifierTypes,
+					modifierConfigurations,
+					Optional.empty(),
+					Optional.empty(),
+					Contract.PRESERVE_UNKNOWN,
+					Inspection.unsupported("ore_configuration"),
+					Action.PRESERVE_UNCHANGED,
+					"INVALID_ORE_CONFIGURATION_SHAPE"
+				);
+			}
+
+			phase = "ore_configuration";
+			oreConfiguration = Optional.of(
+				OreConfiguration.CODEC.encodeStart(this.ops, ore)
+					.getOrThrow(message -> new OreHeightInspector.InspectionFailure("ore_configuration", message))
+					.toString()
+			);
+
+			phase = "placement_contract";
+			HeightRangePlacement heightPlacement = null;
+			boolean customFilter = false;
+			for (PlacementModifier modifier : placedFeature.placement()) {
+				if (modifier instanceof HeightRangePlacement height) {
+					if (heightPlacement != null) {
+						return preserved(
+							placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
+							"MULTIPLE_HEIGHT_RANGES", "placement_contract"
+						);
+					}
+					heightPlacement = height;
+					continue;
+				}
+				if (modifier instanceof PlacementFilter filter) {
+					customFilter |= !isVanillaFilter(filter);
+					continue;
+				}
+				if (!(modifier instanceof CountPlacement)
+					&& !(modifier instanceof RarityFilter)
+					&& !(modifier instanceof InSquarePlacement)) {
+					return preserved(
+						placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
+						"UNSUPPORTED_POSITION_MODIFIER", "placement_contract"
+					);
+				}
+			}
+			if (heightPlacement == null) {
+				return preserved(
+					placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
+					"MISSING_HEIGHT_RANGE", "placement_contract"
+				);
+			}
+			int fanoutIndex = safeFanoutIndex(placedFeature.placement());
+			for (int index = 0; index < fanoutIndex; index++) {
+				if (placedFeature.placement().get(index) instanceof PlacementFilter) {
+					return preserved(
+						placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
+						"UPSTREAM_FILTER_BEFORE_SAFE_FANOUT", "placement_contract"
+					);
+				}
+			}
+
+			phase = "height_provider";
+			HeightSemantics height = this.heightInspection.inspect(heightPlacement);
+			Contract contract = customFilter ? Contract.STANDARD_WITH_CUSTOM_FILTER : Contract.SUPPORTED_STANDARD;
+			return occurrence(
+				placedFeatureId,
+				Optional.of(membership),
+				configuredFeatureType,
+				modifierTypes,
+				modifierConfigurations,
+				oreConfiguration,
+				Optional.of(height),
+				contract,
+				Inspection.classified(),
+				Action.REPORT_ONLY,
+				customFilter ? "SUPPORTED_CUSTOM_PLACEMENT_FILTER" : "SUPPORTED_STANDARD_ORE"
+			);
+		} catch (OreHeightInspector.UnsupportedHeightProvider unsupported) {
+			return preserved(
+				placedFeatureId, membership, configuredFeatureType, modifierTypes, modifierConfigurations, oreConfiguration,
+				"UNSUPPORTED_HEIGHT_PROVIDER:" + unsupported.provider(), "height_provider"
+			);
+		} catch (RuntimeException | LinkageError failure) {
+			String failurePhase = failure instanceof OreHeightInspector.InspectionFailure inspectionFailure
+				? inspectionFailure.phase()
+				: phase;
+			return occurrence(
+				placedFeatureId,
+				Optional.of(membership),
+				configuredFeatureType,
+				modifierTypes,
+				modifierConfigurations,
+				oreConfiguration,
+				Optional.empty(),
+				Contract.PRESERVE_UNKNOWN,
+				Inspection.failed(failurePhase, failure),
+				Action.PRESERVE_UNCHANGED,
+				"INSPECTION_FAILED"
+			);
+		}
+	}
+
+	private static int safeFanoutIndex(List<PlacementModifier> modifiers) {
+		int heightIndex = -1;
+		int inSquareIndex = -1;
+		for (int index = 0; index < modifiers.size(); index++) {
+			PlacementModifier modifier = modifiers.get(index);
+			if (modifier instanceof HeightRangePlacement && heightIndex < 0) {
+				heightIndex = index;
+			}
+			if (modifier instanceof InSquarePlacement && inSquareIndex < 0) {
+				inSquareIndex = index;
+			}
+		}
+		int firstSpatialIndex = inSquareIndex < 0 ? heightIndex : Math.min(heightIndex, inSquareIndex);
+		for (int index = firstSpatialIndex - 1; index >= 0; index--) {
+			PlacementModifier modifier = modifiers.get(index);
+			if (modifier instanceof CountPlacement || modifier instanceof RarityFilter) {
+				return index;
+			}
+		}
+		return inSquareIndex >= 0 && inSquareIndex < heightIndex ? inSquareIndex : heightIndex;
+	}
+
+	public Occurrence inactive(String placedFeatureId, PlacedFeature placedFeature) {
+		String configuredFeatureType = "<inspection-failed>";
+		List<String> modifierTypes = new ArrayList<>();
+		List<String> modifierConfigurations = new ArrayList<>();
+		try {
+			configuredFeatureType = featureType(placedFeature.feature().value());
+			for (PlacementModifier modifier : placedFeature.placement()) {
+				modifierTypes.add(modifierType(modifier));
+				modifierConfigurations.add(this.modifierConfiguration(modifier));
+			}
+			return occurrence(
+				placedFeatureId,
+				Optional.empty(),
+				configuredFeatureType,
+				modifierTypes,
+				modifierConfigurations,
+				Optional.empty(),
+				Optional.empty(),
+				Contract.NO_ACTIVE_MEMBERSHIP,
+				Inspection.unsupported("final_membership"),
+				Action.PRESERVE_UNCHANGED,
+				"NO_ACTIVE_MEMBERSHIP"
+			);
+		} catch (RuntimeException | LinkageError failure) {
+			return occurrence(
+				placedFeatureId,
+				Optional.empty(),
+				configuredFeatureType,
+				modifierTypes,
+				modifierConfigurations,
+				Optional.empty(),
+				Optional.empty(),
+				Contract.NO_ACTIVE_MEMBERSHIP,
+				Inspection.failed("inactive_snapshot", failure),
+				Action.PRESERVE_UNCHANGED,
+				"INACTIVE_INSPECTION_FAILED"
+			);
+		}
+	}
+
+	private static Occurrence preserved(
+		String placedFeatureId,
+		Membership membership,
+		String configuredFeatureType,
+		List<String> modifierTypes,
+		List<String> modifierConfigurations,
+		Optional<String> oreConfiguration,
+		String reason,
+		String phase
+	) {
+		return occurrence(
+			placedFeatureId,
+			Optional.of(membership),
+			configuredFeatureType,
+			modifierTypes,
+			modifierConfigurations,
+			oreConfiguration,
+			Optional.empty(),
+			Contract.PRESERVE_UNKNOWN,
+			Inspection.unsupported(phase),
+			Action.PRESERVE_UNCHANGED,
+			reason
+		);
+	}
+
+	private static Occurrence occurrence(
+		String placedFeatureId,
+		Optional<Membership> membership,
+		String configuredFeatureType,
+		List<String> modifierTypes,
+		List<String> modifierConfigurations,
+		Optional<String> oreConfiguration,
+		Optional<HeightSemantics> height,
+		Contract contract,
+		Inspection inspection,
+		Action action,
+		String reason
+	) {
+		List<String> semanticParts = List.of(
+			configuredFeatureType,
+			String.join(",", modifierTypes),
+			String.join(",", modifierConfigurations),
+			oreConfiguration.orElse(""),
+			height.map(Object::toString).orElse(""),
+			contract.name(),
+			inspection.status().name(),
+			reason
+		);
+		return new Occurrence(
+			placedFeatureId,
+			membership,
+			configuredFeatureType,
+			modifierTypes,
+			modifierConfigurations,
+			oreConfiguration,
+			height,
+			contract,
+			inspection,
+			action,
+			reason,
+			DynamicOrePlanner.fingerprint(semanticParts)
+		);
+	}
+
+	private static String featureType(ConfiguredFeature<?, ?> configured) {
+		ResourceLocation id = BuiltInRegistries.FEATURE.getKey(configured.feature());
+		return id == null ? "<unregistered:" + configured.feature().getClass().getName() + ">" : id.toString();
+	}
+
+	private static String modifierType(PlacementModifier modifier) {
+		ResourceLocation id = BuiltInRegistries.PLACEMENT_MODIFIER_TYPE.getKey(modifier.type());
+		return id == null ? "<unregistered:" + modifier.getClass().getName() + ">" : id.toString();
+	}
+
+	@SuppressWarnings("unchecked")
+	private String modifierConfiguration(PlacementModifier modifier) {
+		com.mojang.serialization.Codec<PlacementModifier> codec =
+			(com.mojang.serialization.Codec<PlacementModifier>)(com.mojang.serialization.Codec<?>)modifier.type().codec().codec();
+		return codec
+			.encodeStart(this.ops, modifier)
+			.getOrThrow(message -> new OreHeightInspector.InspectionFailure("modifier_configuration", message))
+			.toString();
+	}
+
+	private static boolean isVanillaFilter(PlacementFilter filter) {
+		PlacementModifierType<?> type = filter.type();
+		return type == PlacementModifierType.BLOCK_PREDICATE_FILTER
+			|| type == PlacementModifierType.RARITY_FILTER
+			|| type == PlacementModifierType.SURFACE_RELATIVE_THRESHOLD_FILTER
+			|| type == PlacementModifierType.SURFACE_WATER_DEPTH_FILTER
+			|| type == PlacementModifierType.BIOME_FILTER;
+	}
+
+	@FunctionalInterface
+	interface HeightInspection {
+		HeightSemantics inspect(HeightRangePlacement placement);
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreHeightInspector.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreHeightInspector.java
@@ -1,0 +1,114 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mojang.serialization.DynamicOps;
+import com.mojang.serialization.JsonOps;
+
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Anchor;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.AnchorType;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightProviderShape;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightSemantics;
+
+/** Reads height semantics through the vanilla codec instead of private fields. */
+final class OreHeightInspector {
+	private final DynamicOps<JsonElement> ops;
+
+	OreHeightInspector() {
+		this(JsonOps.INSTANCE);
+	}
+
+	OreHeightInspector(DynamicOps<JsonElement> ops) {
+		this.ops = ops;
+	}
+
+	HeightSemantics inspect(HeightRangePlacement placement) {
+		JsonElement encoded = HeightRangePlacement.CODEC.codec()
+			.encodeStart(this.ops, placement)
+			.getOrThrow(message -> new InspectionFailure("height_codec", message));
+		JsonObject root = object(encoded, "height_codec", "height placement");
+		JsonObject height = object(required(root, "height", "height_codec"), "height_codec", "height provider");
+		if (!height.has("type")) {
+			// HeightProvider.CODEC represents ConstantHeight as a bare anchor.
+			throw new UnsupportedHeightProvider("minecraft:constant");
+		}
+		String type = string(height, "type", "height_provider");
+
+		HeightProviderShape provider = switch (type) {
+			case "minecraft:uniform" -> HeightProviderShape.UNIFORM;
+			case "minecraft:trapezoid" -> HeightProviderShape.TRAPEZOID;
+			default -> throw new UnsupportedHeightProvider(type);
+		};
+		Anchor min = anchor(required(height, "min_inclusive", "height_anchor"));
+		Anchor max = anchor(required(height, "max_inclusive", "height_anchor"));
+		int plateau = provider == HeightProviderShape.TRAPEZOID && height.has("plateau")
+			? height.get("plateau").getAsInt()
+			: 0;
+		return new HeightSemantics(provider, min, max, plateau);
+	}
+
+	private static Anchor anchor(JsonElement encoded) {
+		JsonObject object = object(encoded, "height_anchor", "vertical anchor");
+		if (object.size() != 1) {
+			throw new InspectionFailure("height_anchor", "Expected exactly one vertical-anchor member: " + object);
+		}
+		if (object.has("absolute")) {
+			return new Anchor(AnchorType.ABSOLUTE, object.get("absolute").getAsInt());
+		}
+		if (object.has("above_bottom")) {
+			return new Anchor(AnchorType.ABOVE_BOTTOM, object.get("above_bottom").getAsInt());
+		}
+		if (object.has("below_top")) {
+			return new Anchor(AnchorType.BELOW_TOP, object.get("below_top").getAsInt());
+		}
+		throw new InspectionFailure("height_anchor", "Unknown vertical-anchor shape: " + object);
+	}
+
+	private static JsonElement required(JsonObject object, String member, String phase) {
+		JsonElement value = object.get(member);
+		if (value == null) {
+			throw new InspectionFailure(phase, "Missing member '" + member + "': " + object);
+		}
+		return value;
+	}
+
+	private static String string(JsonObject object, String member, String phase) {
+		return required(object, member, phase).getAsString();
+	}
+
+	private static JsonObject object(JsonElement value, String phase, String description) {
+		if (!value.isJsonObject()) {
+			throw new InspectionFailure(phase, "Expected " + description + " object: " + value);
+		}
+		return value.getAsJsonObject();
+	}
+
+	static final class UnsupportedHeightProvider extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+		private final String provider;
+
+		UnsupportedHeightProvider(String provider) {
+			super(provider);
+			this.provider = provider;
+		}
+
+		String provider() {
+			return this.provider;
+		}
+	}
+
+	static final class InspectionFailure extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+		private final String phase;
+
+		InspectionFailure(String phase, String message) {
+			super(message);
+			this.phase = phase;
+		}
+
+		String phase() {
+			return this.phase;
+		}
+	}
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreHeightInspector.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreHeightInspector.java
@@ -11,7 +11,6 @@ import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Anchor
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightProviderShape;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightSemantics;
 
-/** Reads height semantics through the vanilla codec instead of private fields. */
 final class OreHeightInspector {
 	private final DynamicOps<JsonElement> ops;
 

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -1,5 +1,5 @@
 {
-  
+
   	"required": true,
   	"plugin": "raccoonman.reterraforged.mixin.plugin.MixinPlugin",
   	"package": "raccoonman.reterraforged.mixin",
@@ -45,6 +45,9 @@
 		"BlockPredicateFilterAccessor",
 		"MixinHeightRangePlacement",
 		"MixinCountPlacement",
+		"MixinRepeatingPlacement",
+		"MixinPlacementFilter",
+		"MixinInSquarePlacement",
 		"MixinEnvironmentScanPlacement",
 		"MixinPlacedFeature",
 		"BeardifierAccessor",

--- a/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlannerTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlannerTest.java
@@ -1,0 +1,243 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+
+import net.minecraft.core.Holder;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
+import net.minecraft.world.level.levelgen.structure.templatesystem.BlockMatchTest;
+import net.minecraft.world.level.block.Blocks;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner.BiomeInput;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner.FeatureInput;
+
+class DynamicOrePlannerTest {
+	@BeforeAll
+	static void bootstrapMinecraft() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@Test
+	void preservesDuplicateMembershipOrderAndReportsInactiveEntries() {
+		PlacedFeature active = ore(5);
+		PlacedFeature inactive = ore(2);
+		BiomeInput biome = new BiomeInput("minecraft:plains", steps(
+			new FeatureInput("example:active", active),
+			new FeatureInput("example:active", active)
+		));
+
+		DynamicOrePlan plan = new DynamicOrePlanner().build(
+			List.of(biome),
+			List.of(new FeatureInput("example:inactive", inactive), new FeatureInput("example:active", active))
+		);
+
+		assertEquals(3, plan.occurrences().size());
+		assertEquals(List.of(0, 1), plan.occurrences().subList(0, 2).stream()
+			.map(occurrence -> occurrence.membership().orElseThrow().order())
+			.toList());
+		assertEquals(Contract.NO_ACTIVE_MEMBERSHIP, plan.occurrences().get(2).contract());
+		assertEquals("example:inactive", plan.occurrences().get(2).placedFeatureId());
+		assertTrue(plan.summary().contains("inspection_failed=0"));
+		assertEquals(
+			plan.occurrences().get(0).contractFingerprint(),
+			plan.occurrences().get(1).contractFingerprint()
+		);
+	}
+
+	@Test
+	void normalizesEquivalentLoaderGraphsToTheSameFingerprint() {
+		PlacedFeature first = ore(3);
+		PlacedFeature second = ore(8);
+		BiomeInput plains = new BiomeInput("minecraft:plains", steps(new FeatureInput("test:first", first)));
+		BiomeInput forest = new BiomeInput("minecraft:forest", steps(new FeatureInput("test:second", second)));
+		DynamicOrePlanner planner = new DynamicOrePlanner();
+
+		DynamicOrePlan fabric = planner.build(
+			List.of(plains, forest),
+			List.of(new FeatureInput("test:first", first), new FeatureInput("test:second", second))
+		);
+		DynamicOrePlan neoForge = planner.build(
+			List.of(forest, plains),
+			List.of(new FeatureInput("test:second", second), new FeatureInput("test:first", first))
+		);
+
+		assertEquals(fabric.graphFingerprint(), neoForge.graphFingerprint());
+		assertEquals(fabric.occurrences(), neoForge.occurrences());
+	}
+
+	@Test
+	void planIsValueOnlyImmutableAndSafeForConcurrentReads() throws Exception {
+		PlacedFeature feature = ore(4);
+		DynamicOrePlan plan = new DynamicOrePlanner().build(
+			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", feature)))),
+			List.of(new FeatureInput("test:ore", feature))
+		);
+
+		assertThrows(UnsupportedOperationException.class, () -> plan.occurrences().clear());
+		assertThrows(UnsupportedOperationException.class, () -> plan.occurrences().getFirst().placementModifierTypes().add("test:mutate"));
+		for (RecordComponent component : DynamicOrePlan.Occurrence.class.getRecordComponents()) {
+			assertTrue(!component.getType().getName().startsWith("net.minecraft"), component.getName());
+		}
+
+		try (var executor = Executors.newFixedThreadPool(4)) {
+			List<Callable<String>> readers = Collections.nCopies(64, () -> plan.graphFingerprint() + plan.summary());
+			List<String> results = executor.invokeAll(readers).stream().map(future -> {
+				try {
+					return future.get();
+				} catch (Exception exception) {
+					throw new AssertionError(exception);
+				}
+			}).toList();
+			assertEquals(1, results.stream().distinct().count());
+		}
+	}
+
+	@Test
+	void replacingARegistryEpochProducesAnIndependentPlan() {
+		DynamicOrePlanner planner = new DynamicOrePlanner();
+		PlacedFeature oldFeature = ore(1);
+		DynamicOrePlan oldPlan = planner.build(
+			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", oldFeature)))),
+			List.of(new FeatureInput("test:ore", oldFeature))
+		);
+		PlacedFeature newFeature = ore(12);
+		DynamicOrePlan newPlan = planner.build(
+			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", newFeature)))),
+			List.of(new FeatureInput("test:ore", newFeature))
+		);
+
+		assertNotEquals(oldPlan.graphFingerprint(), newPlan.graphFingerprint());
+		assertEquals(1, oldPlan.occurrences().size());
+		assertEquals(1, newPlan.occurrences().size());
+	}
+
+	@Test
+	void derivesOneDynamicTransformForRepeatedBiomeMemberships() {
+		PlacedFeature active = ore(7);
+		BiomeInput plains = new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", active)));
+		BiomeInput forest = new BiomeInput("minecraft:forest", steps(new FeatureInput("test:ore", active)));
+
+		DynamicOrePlan plan = new DynamicOrePlanner().build(
+			List.of(plains, forest),
+			List.of(new FeatureInput("test:ore", active)),
+			java.util.Optional.of(new VerticalFrame(-624, 383, 63))
+		);
+
+		assertEquals(1, plan.verticalTransforms().size());
+		assertEquals(2, plan.occurrences().size());
+		assertTrue(plan.occurrences().stream().allMatch(occurrence -> occurrence.action() == Action.DYNAMIC_VERTICAL_DENSITY));
+	}
+
+	@Test
+	void referenceFrameDelegatesWithoutPublishingATransform() {
+		PlacedFeature active = ore(7);
+		DynamicOrePlan plan = new DynamicOrePlanner().build(
+			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", active)))),
+			List.of(new FeatureInput("test:ore", active)),
+			java.util.Optional.of(new VerticalFrame(-64, 319, 63))
+		);
+
+		assertTrue(plan.verticalTransforms().isEmpty());
+		assertEquals(Action.DELEGATE_REFERENCE_IDENTITY, plan.occurrences().getFirst().action());
+	}
+
+	@Test
+	void selectsRarityFanoutBeforeHorizontalSampling() {
+		DynamicOrePlan plan = transformedPlan(oreWithPlacements(
+			RarityFilter.onAverageOnceEvery(9),
+			InSquarePlacement.spread(),
+			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64))
+		));
+
+		var transform = plan.verticalTransforms().get("test:ore");
+		assertEquals(FanoutStage.RARITY, transform.fanoutStage());
+		assertEquals(0, transform.fanoutModifierIndex());
+		assertEquals(2, transform.heightModifierIndex());
+	}
+
+	@Test
+	void selectsInSquareFanoutForImplicitMultiplicity() {
+		DynamicOrePlan plan = transformedPlan(oreWithPlacements(
+			InSquarePlacement.spread(),
+			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64))
+		));
+
+		var transform = plan.verticalTransforms().get("test:ore");
+		assertEquals(FanoutStage.IN_SQUARE, transform.fanoutStage());
+		assertEquals(0, transform.fanoutModifierIndex());
+		assertEquals(1, transform.heightModifierIndex());
+	}
+
+	@Test
+	void selectsHeightFanoutWhenHeightIsTheFirstSpatialSampler() {
+		DynamicOrePlan plan = transformedPlan(oreWithPlacements(
+			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64)),
+			InSquarePlacement.spread()
+		));
+
+		var transform = plan.verticalTransforms().get("test:ore");
+		assertEquals(FanoutStage.HEIGHT, transform.fanoutStage());
+		assertEquals(0, transform.fanoutModifierIndex());
+		assertEquals(0, transform.heightModifierIndex());
+	}
+
+	private static List<List<FeatureInput>> steps(FeatureInput... undergroundOres) {
+		List<List<FeatureInput>> steps = new ArrayList<>();
+		for (int i = 0; i < 6; i++) {
+			steps.add(List.of());
+		}
+		steps.add(List.of(undergroundOres));
+		return steps;
+	}
+
+	private static PlacedFeature ore(int attempts) {
+		return oreWithPlacements(
+			CountPlacement.of(attempts),
+			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64))
+		);
+	}
+
+	private static DynamicOrePlan transformedPlan(PlacedFeature feature) {
+		return new DynamicOrePlanner().build(
+			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", feature)))),
+			List.of(new FeatureInput("test:ore", feature)),
+			java.util.Optional.of(new VerticalFrame(-624, 383, 63))
+		);
+	}
+
+	private static PlacedFeature oreWithPlacements(PlacementModifier... placements) {
+		return new PlacedFeature(
+			Holder.direct(new ConfiguredFeature<>(Feature.ORE, new OreConfiguration(
+				new BlockMatchTest(Blocks.STONE), Blocks.IRON_ORE.defaultBlockState(), 6
+			))),
+			List.of(placements)
+		);
+	}
+}

--- a/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlannerTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOrePlannerTest.java
@@ -1,23 +1,18 @@
 package raccoonman.reterraforged.world.worldgen.feature.ore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executors;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-import net.minecraft.core.Holder;
 import net.minecraft.SharedConstants;
+import net.minecraft.core.Holder;
 import net.minecraft.server.Bootstrap;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
@@ -25,19 +20,18 @@ import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguratio
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
 import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
-import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 import net.minecraft.world.level.levelgen.placement.RarityFilter;
 import net.minecraft.world.level.levelgen.structure.templatesystem.BlockMatchTest;
-import net.minecraft.world.level.block.Blocks;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.FanoutStage;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner.BiomeInput;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner.FeatureInput;
 
 class DynamicOrePlannerTest {
+	private static final VerticalFrame DEEP_FRAME = new VerticalFrame(-624, 383, 63);
+
 	@BeforeAll
 	static void bootstrapMinecraft() {
 		SharedConstants.tryDetectVersion();
@@ -45,190 +39,92 @@ class DynamicOrePlannerTest {
 	}
 
 	@Test
-	void preservesDuplicateMembershipOrderAndReportsInactiveEntries() {
-		PlacedFeature active = ore(5);
-		PlacedFeature inactive = ore(2);
-		BiomeInput biome = new BiomeInput("minecraft:plains", steps(
-			new FeatureInput("example:active", active),
-			new FeatureInput("example:active", active)
-		));
-
-		DynamicOrePlan plan = new DynamicOrePlanner().build(
-			List.of(biome),
-			List.of(new FeatureInput("example:inactive", inactive), new FeatureInput("example:active", active))
-		);
-
-		assertEquals(3, plan.occurrences().size());
-		assertEquals(List.of(0, 1), plan.occurrences().subList(0, 2).stream()
-			.map(occurrence -> occurrence.membership().orElseThrow().order())
-			.toList());
-		assertEquals(Contract.NO_ACTIVE_MEMBERSHIP, plan.occurrences().get(2).contract());
-		assertEquals("example:inactive", plan.occurrences().get(2).placedFeatureId());
-		assertTrue(plan.summary().contains("inspection_failed=0"));
-		assertEquals(
-			plan.occurrences().get(0).contractFingerprint(),
-			plan.occurrences().get(1).contractFingerprint()
-		);
-	}
-
-	@Test
-	void normalizesEquivalentLoaderGraphsToTheSameFingerprint() {
-		PlacedFeature first = ore(3);
-		PlacedFeature second = ore(8);
-		BiomeInput plains = new BiomeInput("minecraft:plains", steps(new FeatureInput("test:first", first)));
-		BiomeInput forest = new BiomeInput("minecraft:forest", steps(new FeatureInput("test:second", second)));
-		DynamicOrePlanner planner = new DynamicOrePlanner();
-
-		DynamicOrePlan fabric = planner.build(
-			List.of(plains, forest),
-			List.of(new FeatureInput("test:first", first), new FeatureInput("test:second", second))
-		);
-		DynamicOrePlan neoForge = planner.build(
-			List.of(forest, plains),
-			List.of(new FeatureInput("test:second", second), new FeatureInput("test:first", first))
-		);
-
-		assertEquals(fabric.graphFingerprint(), neoForge.graphFingerprint());
-		assertEquals(fabric.occurrences(), neoForge.occurrences());
-	}
-
-	@Test
-	void planIsValueOnlyImmutableAndSafeForConcurrentReads() throws Exception {
-		PlacedFeature feature = ore(4);
-		DynamicOrePlan plan = new DynamicOrePlanner().build(
-			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", feature)))),
-			List.of(new FeatureInput("test:ore", feature))
-		);
-
-		assertThrows(UnsupportedOperationException.class, () -> plan.occurrences().clear());
-		assertThrows(UnsupportedOperationException.class, () -> plan.occurrences().getFirst().placementModifierTypes().add("test:mutate"));
-		for (RecordComponent component : DynamicOrePlan.Occurrence.class.getRecordComponents()) {
-			assertTrue(!component.getType().getName().startsWith("net.minecraft"), component.getName());
-		}
-
-		try (var executor = Executors.newFixedThreadPool(4)) {
-			List<Callable<String>> readers = Collections.nCopies(64, () -> plan.graphFingerprint() + plan.summary());
-			List<String> results = executor.invokeAll(readers).stream().map(future -> {
-				try {
-					return future.get();
-				} catch (Exception exception) {
-					throw new AssertionError(exception);
-				}
-			}).toList();
-			assertEquals(1, results.stream().distinct().count());
-		}
-	}
-
-	@Test
-	void replacingARegistryEpochProducesAnIndependentPlan() {
-		DynamicOrePlanner planner = new DynamicOrePlanner();
-		PlacedFeature oldFeature = ore(1);
-		DynamicOrePlan oldPlan = planner.build(
-			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", oldFeature)))),
-			List.of(new FeatureInput("test:ore", oldFeature))
-		);
-		PlacedFeature newFeature = ore(12);
-		DynamicOrePlan newPlan = planner.build(
-			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", newFeature)))),
-			List.of(new FeatureInput("test:ore", newFeature))
-		);
-
-		assertNotEquals(oldPlan.graphFingerprint(), newPlan.graphFingerprint());
-		assertEquals(1, oldPlan.occurrences().size());
-		assertEquals(1, newPlan.occurrences().size());
-	}
-
-	@Test
 	void derivesOneDynamicTransformForRepeatedBiomeMemberships() {
 		PlacedFeature active = ore(7);
-		BiomeInput plains = new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", active)));
-		BiomeInput forest = new BiomeInput("minecraft:forest", steps(new FeatureInput("test:ore", active)));
+		BiomeInput plains = biome(new FeatureInput("test:ore", active));
+		BiomeInput forest = biome(new FeatureInput("test:ore", active));
 
-		DynamicOrePlan plan = new DynamicOrePlanner().build(
-			List.of(plains, forest),
-			List.of(new FeatureInput("test:ore", active)),
-			java.util.Optional.of(new VerticalFrame(-624, 383, 63))
-		);
+		DynamicOrePlan plan = new DynamicOrePlanner().build(List.of(plains, forest), DEEP_FRAME);
 
+		assertEquals(1, plan.standardOres());
 		assertEquals(1, plan.verticalTransforms().size());
-		assertEquals(2, plan.occurrences().size());
-		assertTrue(plan.occurrences().stream().allMatch(occurrence -> occurrence.action() == Action.DYNAMIC_VERTICAL_DENSITY));
+		assertTrue(plan.skippedReasons().isEmpty());
 	}
 
 	@Test
 	void referenceFrameDelegatesWithoutPublishingATransform() {
-		PlacedFeature active = ore(7);
 		DynamicOrePlan plan = new DynamicOrePlanner().build(
-			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", active)))),
-			List.of(new FeatureInput("test:ore", active)),
-			java.util.Optional.of(new VerticalFrame(-64, 319, 63))
+			List.of(biome(new FeatureInput("test:ore", ore(7)))),
+			new VerticalFrame(-64, 319, 63)
 		);
 
 		assertTrue(plan.verticalTransforms().isEmpty());
-		assertEquals(Action.DELEGATE_REFERENCE_IDENTITY, plan.occurrences().getFirst().action());
+		assertEquals(1, plan.delegatedFeatures());
 	}
 
 	@Test
-	void selectsRarityFanoutBeforeHorizontalSampling() {
-		DynamicOrePlan plan = transformedPlan(oreWithPlacements(
+	void conflictingFeatureIdentitiesForOneIdFailClosed() {
+		DynamicOrePlan plan = new DynamicOrePlanner().build(
+			List.of(
+				biome(new FeatureInput("test:ore", ore(4))),
+				biome(new FeatureInput("test:ore", ore(9)))
+			),
+			DEEP_FRAME
+		);
+
+		assertTrue(plan.verticalTransforms().isEmpty());
+		assertEquals(1, plan.skippedReasons().get("CONFLICTING_FEATURES_FOR_ID"));
+	}
+
+	@Test
+	void selectsSafeFanoutBeforeSpatialSampling() {
+		assertFanout(oreWithPlacements(
+			CountPlacement.of(7),
+			InSquarePlacement.spread(),
+			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64))
+		), FanoutStage.COUNT, 0, 2);
+		assertFanout(oreWithPlacements(
 			RarityFilter.onAverageOnceEvery(9),
 			InSquarePlacement.spread(),
 			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64))
-		));
-
-		var transform = plan.verticalTransforms().get("test:ore");
-		assertEquals(FanoutStage.RARITY, transform.fanoutStage());
-		assertEquals(0, transform.fanoutModifierIndex());
-		assertEquals(2, transform.heightModifierIndex());
-	}
-
-	@Test
-	void selectsInSquareFanoutForImplicitMultiplicity() {
-		DynamicOrePlan plan = transformedPlan(oreWithPlacements(
+		), FanoutStage.RARITY, 0, 2);
+		assertFanout(oreWithPlacements(
 			InSquarePlacement.spread(),
 			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64))
-		));
-
-		var transform = plan.verticalTransforms().get("test:ore");
-		assertEquals(FanoutStage.IN_SQUARE, transform.fanoutStage());
-		assertEquals(0, transform.fanoutModifierIndex());
-		assertEquals(1, transform.heightModifierIndex());
-	}
-
-	@Test
-	void selectsHeightFanoutWhenHeightIsTheFirstSpatialSampler() {
-		DynamicOrePlan plan = transformedPlan(oreWithPlacements(
+		), FanoutStage.IN_SQUARE, 0, 1);
+		assertFanout(oreWithPlacements(
 			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64)),
 			InSquarePlacement.spread()
-		));
-
-		var transform = plan.verticalTransforms().get("test:ore");
-		assertEquals(FanoutStage.HEIGHT, transform.fanoutStage());
-		assertEquals(0, transform.fanoutModifierIndex());
-		assertEquals(0, transform.heightModifierIndex());
+		), FanoutStage.HEIGHT, 0, 0);
 	}
 
-	private static List<List<FeatureInput>> steps(FeatureInput... undergroundOres) {
+	private static void assertFanout(
+		PlacedFeature feature,
+		FanoutStage stage,
+		int modifierIndex,
+		int heightModifierIndex
+	) {
+		var transform = new DynamicOrePlanner().build(
+			List.of(biome(new FeatureInput("test:ore", feature))), DEEP_FRAME
+		).verticalTransforms().get("test:ore");
+		assertEquals(stage, transform.fanoutStage());
+		assertEquals(modifierIndex, transform.fanoutModifierIndex());
+		assertEquals(heightModifierIndex, transform.heightModifierIndex());
+	}
+
+	private static BiomeInput biome(FeatureInput... undergroundOres) {
 		List<List<FeatureInput>> steps = new ArrayList<>();
-		for (int i = 0; i < 6; i++) {
+		for (int index = 0; index < 6; index++) {
 			steps.add(List.of());
 		}
 		steps.add(List.of(undergroundOres));
-		return steps;
+		return new BiomeInput(steps);
 	}
 
 	private static PlacedFeature ore(int attempts) {
 		return oreWithPlacements(
 			CountPlacement.of(attempts),
 			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(0), VerticalAnchor.absolute(64))
-		);
-	}
-
-	private static DynamicOrePlan transformedPlan(PlacedFeature feature) {
-		return new DynamicOrePlanner().build(
-			List.of(new BiomeInput("minecraft:plains", steps(new FeatureInput("test:ore", feature)))),
-			List.of(new FeatureInput("test:ore", feature)),
-			java.util.Optional.of(new VerticalFrame(-624, 383, 63))
 		);
 	}
 

--- a/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransformTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransformTest.java
@@ -25,8 +25,6 @@ class DynamicOreVerticalTransformTest {
 	@Test
 	void deepDiamondMatchesTheOfflineLocalIntensityModel() {
 		VerticalTransform transform = DynamicOreVerticalTransform.derive(
-			"minecraft:ore_diamond",
-			"contract",
 			DIAMOND,
 			new VerticalFrame(-624, 383, 63)
 		).transform().orElseThrow();
@@ -50,8 +48,6 @@ class DynamicOreVerticalTransformTest {
 	@Test
 	void contractionBelowOneUsesUnbiasedStochasticThinning() {
 		VerticalTransform transform = DynamicOreVerticalTransform.derive(
-			"minecraft:ore_diamond",
-			"contract",
 			DIAMOND,
 			new VerticalFrame(-16, 383, 63)
 		).transform().orElseThrow();
@@ -67,7 +63,7 @@ class DynamicOreVerticalTransformTest {
 	}
 
 	@Test
-	void fixedGeologicalSegmentDelegatesWithoutChangingItsRandomSampling() {
+	void unchangedVerticalMappingsDelegateWithoutChangingRandomSampling() {
 		HeightSemantics fixed = new HeightSemantics(
 			HeightProviderShape.UNIFORM,
 			new Anchor(AnchorType.ABSOLUTE, 0),
@@ -75,27 +71,20 @@ class DynamicOreVerticalTransformTest {
 			0
 		);
 		var derivation = DynamicOreVerticalTransform.derive(
-			"test:fixed",
-			"contract",
 			fixed,
 			new VerticalFrame(-1024, 1023, 63)
 		);
 
 		assertTrue(derivation.transform().isEmpty());
 		assertEquals("FEATURE_VERTICAL_MAPPING_IS_IDENTITY", derivation.reasonCode());
-	}
 
-	@Test
-	void unchangedDefaultDepthDiamondDelegatesEvenWhenTheWorldTopIsHigher() {
-		var derivation = DynamicOreVerticalTransform.derive(
-			"minecraft:ore_diamond",
-			"contract",
+		var defaultDepth = DynamicOreVerticalTransform.derive(
 			DIAMOND,
 			new VerticalFrame(-64, 383, 63)
 		);
 
-		assertTrue(derivation.transform().isEmpty());
-		assertEquals("FEATURE_VERTICAL_MAPPING_IS_IDENTITY", derivation.reasonCode());
+		assertTrue(defaultDepth.transform().isEmpty());
+		assertEquals("FEATURE_VERTICAL_MAPPING_IS_IDENTITY", defaultDepth.reasonCode());
 	}
 
 	@Test
@@ -107,8 +96,6 @@ class DynamicOreVerticalTransformTest {
 			0
 		);
 		VerticalTransform transform = DynamicOreVerticalTransform.derive(
-			"minecraft:ore_iron_upper",
-			"contract",
 			upperIron,
 			new VerticalFrame(-64, 127, 63)
 		).transform().orElseThrow();
@@ -122,7 +109,7 @@ class DynamicOreVerticalTransformTest {
 	@Test
 	void malformedFramesAndEmptyAuthoredRangesFailClosed() {
 		assertFalse(DynamicOreVerticalTransform.derive(
-			"test:bad_frame", "contract", DIAMOND, new VerticalFrame(-64, 319, 7)
+			DIAMOND, new VerticalFrame(-64, 319, 7)
 		).transform().isPresent());
 		HeightSemantics empty = new HeightSemantics(
 			HeightProviderShape.UNIFORM,
@@ -133,7 +120,7 @@ class DynamicOreVerticalTransformTest {
 		assertEquals(
 			"EMPTY_REFERENCE_HEIGHT_RANGE",
 			DynamicOreVerticalTransform.derive(
-				"test:empty", "contract", empty, new VerticalFrame(-64, 383, 63)
+				empty, new VerticalFrame(-64, 383, 63)
 			).reasonCode()
 		);
 	}

--- a/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransformTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreVerticalTransformTest.java
@@ -1,0 +1,140 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.util.RandomSource;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Anchor;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.AnchorType;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightProviderShape;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightSemantics;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalTransform;
+
+class DynamicOreVerticalTransformTest {
+	private static final HeightSemantics DIAMOND = new HeightSemantics(
+		HeightProviderShape.TRAPEZOID,
+		new Anchor(AnchorType.ABOVE_BOTTOM, -80),
+		new Anchor(AnchorType.ABOVE_BOTTOM, 80),
+		0
+	);
+
+	@Test
+	void deepDiamondMatchesTheOfflineLocalIntensityModel() {
+		VerticalTransform transform = DynamicOreVerticalTransform.derive(
+			"minecraft:ore_diamond",
+			"contract",
+			DIAMOND,
+			new VerticalFrame(-624, 383, 63)
+		).transform().orElseThrow();
+
+		assertEquals(9.545953360768173, transform.expectedOutputsPerInput(), 1.0E-12);
+		assertEquals(-1404, transform.cumulativeIntensity().getFirst().y());
+		assertEquals(16, transform.cumulativeIntensity().getLast().y());
+		assertEquals(
+			transform.expectedOutputsPerInput(),
+			transform.cumulativeIntensity().getLast().cumulativeIntensity(),
+			1.0E-12
+		);
+		for (int index = 1; index < transform.cumulativeIntensity().size(); index++) {
+			assertTrue(
+				transform.cumulativeIntensity().get(index).cumulativeIntensity()
+					> transform.cumulativeIntensity().get(index - 1).cumulativeIntensity()
+			);
+		}
+	}
+
+	@Test
+	void contractionBelowOneUsesUnbiasedStochasticThinning() {
+		VerticalTransform transform = DynamicOreVerticalTransform.derive(
+			"minecraft:ore_diamond",
+			"contract",
+			DIAMOND,
+			new VerticalFrame(-16, 383, 63)
+		).transform().orElseThrow();
+		assertEquals(0.2674897119341565, transform.expectedOutputsPerInput(), 1.0E-12);
+
+		RandomSource random = RandomSource.create(9918273L);
+		int trials = 200_000;
+		long outputs = 0;
+		for (int index = 0; index < trials; index++) {
+			outputs += DynamicOrePlacement.stochasticRound(transform.expectedOutputsPerInput(), random);
+		}
+		assertEquals(transform.expectedOutputsPerInput(), outputs / (double)trials, 0.003);
+	}
+
+	@Test
+	void fixedGeologicalSegmentDelegatesWithoutChangingItsRandomSampling() {
+		HeightSemantics fixed = new HeightSemantics(
+			HeightProviderShape.UNIFORM,
+			new Anchor(AnchorType.ABSOLUTE, 0),
+			new Anchor(AnchorType.ABSOLUTE, 2),
+			0
+		);
+		var derivation = DynamicOreVerticalTransform.derive(
+			"test:fixed",
+			"contract",
+			fixed,
+			new VerticalFrame(-1024, 1023, 63)
+		);
+
+		assertTrue(derivation.transform().isEmpty());
+		assertEquals("FEATURE_VERTICAL_MAPPING_IS_IDENTITY", derivation.reasonCode());
+	}
+
+	@Test
+	void unchangedDefaultDepthDiamondDelegatesEvenWhenTheWorldTopIsHigher() {
+		var derivation = DynamicOreVerticalTransform.derive(
+			"minecraft:ore_diamond",
+			"contract",
+			DIAMOND,
+			new VerticalFrame(-64, 383, 63)
+		);
+
+		assertTrue(derivation.transform().isEmpty());
+		assertEquals("FEATURE_VERTICAL_MAPPING_IS_IDENTITY", derivation.reasonCode());
+	}
+
+	@Test
+	void shortCeilingRetainsAuthoredAboveWorldClippingTail() {
+		HeightSemantics upperIron = new HeightSemantics(
+			HeightProviderShape.TRAPEZOID,
+			new Anchor(AnchorType.ABSOLUTE, 80),
+			new Anchor(AnchorType.ABSOLUTE, 384),
+			0
+		);
+		VerticalTransform transform = DynamicOreVerticalTransform.derive(
+			"minecraft:ore_iron_upper",
+			"contract",
+			upperIron,
+			new VerticalFrame(-64, 127, 63)
+		).transform().orElseThrow();
+
+		assertEquals(0.2529182879377432, transform.expectedOutputsPerInput(), 1.0E-12);
+		assertEquals(67, transform.cumulativeIntensity().getFirst().y());
+		assertEquals(144, transform.cumulativeIntensity().getLast().y());
+		assertTrue(transform.cumulativeIntensity().stream().anyMatch(value -> value.y() > 127));
+	}
+
+	@Test
+	void malformedFramesAndEmptyAuthoredRangesFailClosed() {
+		assertFalse(DynamicOreVerticalTransform.derive(
+			"test:bad_frame", "contract", DIAMOND, new VerticalFrame(-64, 319, 7)
+		).transform().isPresent());
+		HeightSemantics empty = new HeightSemantics(
+			HeightProviderShape.UNIFORM,
+			new Anchor(AnchorType.ABSOLUTE, 20),
+			new Anchor(AnchorType.ABSOLUTE, 10),
+			0
+		);
+		assertEquals(
+			"EMPTY_REFERENCE_HEIGHT_RANGE",
+			DynamicOreVerticalTransform.derive(
+				"test:empty", "contract", empty, new VerticalFrame(-64, 383, 63)
+			).reasonCode()
+		);
+	}
+}

--- a/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifierTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifierTest.java
@@ -1,36 +1,32 @@
 package raccoonman.reterraforged.world.worldgen.feature.ore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.mojang.serialization.MapCodec;
 
+import net.minecraft.SharedConstants;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 import net.minecraft.world.level.levelgen.heightproviders.ConstantHeight;
 import net.minecraft.world.level.levelgen.heightproviders.TrapezoidHeight;
-import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
-import net.minecraft.world.level.levelgen.structure.templatesystem.BlockMatchTest;
-import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.levelgen.placement.BiomeFilter;
 import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
@@ -42,18 +38,14 @@ import net.minecraft.world.level.levelgen.placement.PlacementFilter;
 import net.minecraft.world.level.levelgen.placement.PlacementModifier;
 import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
 import net.minecraft.world.level.levelgen.placement.RarityFilter;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
+import net.minecraft.world.level.levelgen.structure.templatesystem.BlockMatchTest;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Anchor;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.AnchorType;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightProviderShape;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.InspectionStatus;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Membership;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Occurrence;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightSemantics;
+import raccoonman.reterraforged.world.worldgen.feature.ore.OreContractClassifier.Status;
 
 class OreContractClassifierTest {
-	private static final Membership MEMBERSHIP = new Membership("minecraft:plains", "underground_ores", 6, 3);
-
 	@BeforeAll
 	static void bootstrapMinecraft() {
 		SharedConstants.tryDetectVersion();
@@ -69,75 +61,69 @@ class OreContractClassifierTest {
 			BiomeFilter.biome()
 		);
 
-		Occurrence result = new OreContractClassifier().classify("minecraft:test", MEMBERSHIP, feature);
+		OreContractClassifier.Result result = new OreContractClassifier().classify(feature);
 
-		assertEquals(Contract.SUPPORTED_STANDARD, result.contract());
-		assertEquals(InspectionStatus.CLASSIFIED, result.inspection().status());
-		assertEquals(Action.REPORT_ONLY, result.action());
+		assertEquals(Status.SUPPORTED, result.status());
 		assertEquals(
-			Optional.of(new DynamicOrePlan.HeightSemantics(
+			new HeightSemantics(
 				HeightProviderShape.UNIFORM,
 				new Anchor(AnchorType.ABOVE_BOTTOM, 12),
 				new Anchor(AnchorType.ABSOLUTE, 48),
 				0
-			)),
-			result.height()
+			),
+			result.contract().orElseThrow().height()
 		);
-		assertTrue(result.oreConfiguration().orElseThrow().contains("\"size\":9"));
-		assertTrue(result.oreConfiguration().orElseThrow().contains("minecraft:stone"));
-		assertTrue(result.oreConfiguration().orElseThrow().contains("minecraft:iron_ore"));
 	}
 
 	@Test
-	void classifiesTriangularAndTrapezoidProvidersWithoutPrivateAccess() {
-		PlacedFeature triangle = ore(HeightRangePlacement.triangle(VerticalAnchor.absolute(-32), VerticalAnchor.belowTop(8)));
+	void classifiesTriangularAndTrapezoidProviders() {
+		PlacedFeature triangle = ore(HeightRangePlacement.triangle(
+			VerticalAnchor.absolute(-32), VerticalAnchor.belowTop(8)
+		));
 		PlacedFeature trapezoid = ore(HeightRangePlacement.of(
 			TrapezoidHeight.of(VerticalAnchor.absolute(-16), VerticalAnchor.absolute(80), 12)
 		));
 
-		Occurrence triangleResult = new OreContractClassifier().classify("test:triangle", MEMBERSHIP, triangle);
-		Occurrence trapezoidResult = new OreContractClassifier().classify("test:trapezoid", MEMBERSHIP, trapezoid);
+		var triangleHeight = new OreContractClassifier().classify(triangle).contract().orElseThrow().height();
+		var trapezoidHeight = new OreContractClassifier().classify(trapezoid).contract().orElseThrow().height();
 
-		assertEquals(HeightProviderShape.TRAPEZOID, triangleResult.height().orElseThrow().provider());
-		assertEquals(AnchorType.BELOW_TOP, triangleResult.height().orElseThrow().maxInclusive().type());
-		assertEquals(0, triangleResult.height().orElseThrow().plateau());
-		assertEquals(12, trapezoidResult.height().orElseThrow().plateau());
+		assertEquals(HeightProviderShape.TRAPEZOID, triangleHeight.provider());
+		assertEquals(AnchorType.BELOW_TOP, triangleHeight.maxInclusive().type());
+		assertEquals(0, triangleHeight.plateau());
+		assertEquals(12, trapezoidHeight.plateau());
 	}
 
 	@Test
-	void acceptsActualCustomPlacementFilterWithoutLinkingItsConcreteClass() {
-		PlacedFeature feature = ore(
+	void classifiesCustomModifiersByTheirActualPlacementContract() {
+		PlacedFeature downstreamFilter = ore(
 			CountPlacement.of(4),
 			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
 			TestPlacementFilter.INSTANCE
 		);
-
-		Occurrence result = new OreContractClassifier().classify("example:filtered_ore", MEMBERSHIP, feature);
-
-		assertEquals(Contract.STANDARD_WITH_CUSTOM_FILTER, result.contract());
-		assertEquals("SUPPORTED_CUSTOM_PLACEMENT_FILTER", result.reasonCode());
-		assertEquals(Action.REPORT_ONLY, result.action());
-		assertTrue(result.placementModifierTypes().getLast().contains("TestPlacementFilter"));
-	}
-
-	@Test
-	void preservesAFilterThatWouldRunBeforeTheSafeFanoutBoundary() {
-		PlacedFeature feature = ore(
+		PlacedFeature upstreamFilter = ore(
 			TestPlacementFilter.INSTANCE,
 			CountPlacement.of(4),
 			InSquarePlacement.spread(),
 			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32))
 		);
+		PlacedFeature transformer = ore(
+			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
+			FilterNamedPositionTransformer.INSTANCE
+		);
 
-		Occurrence result = new OreContractClassifier().classify("example:upstream_filter", MEMBERSHIP, feature);
-
-		assertEquals(Contract.PRESERVE_UNKNOWN, result.contract());
-		assertEquals("UPSTREAM_FILTER_BEFORE_SAFE_FANOUT", result.reasonCode());
-		assertEquals(Action.PRESERVE_UNCHANGED, result.action());
+		assertEquals(Status.SUPPORTED, new OreContractClassifier().classify(downstreamFilter).status());
+		assertEquals(
+			"UPSTREAM_FILTER_BEFORE_SAFE_FANOUT",
+			new OreContractClassifier().classify(upstreamFilter).reasonCode()
+		);
+		assertEquals(
+			"UNSUPPORTED_POSITION_MODIFIER",
+			new OreContractClassifier().classify(transformer).reasonCode()
+		);
 	}
 
 	@Test
-	void usesRegistryAwareCodecOpsForRegistryBackedModifierConfiguration() {
+	void acceptsRegistryBackedBuiltInFilters() {
 		PlacedFeature feature = ore(
 			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
 			BlockPredicateFilter.forPredicate(BlockPredicate.matchesBlocks(Blocks.STONE))
@@ -146,45 +132,23 @@ class OreContractClassifierTest {
 			RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY)
 		);
 
-		Occurrence result = classifier.classify("example:registry_codec", MEMBERSHIP, feature);
-
-		assertEquals(Contract.SUPPORTED_STANDARD, result.contract());
-		assertEquals(InspectionStatus.CLASSIFIED, result.inspection().status());
-		assertTrue(result.placementModifierConfigurations().getLast().contains("minecraft:stone"));
+		assertEquals(Status.SUPPORTED, classifier.classify(feature).status());
 	}
 
 	@Test
-	void rejectsAFilterNamedPositionTransformerThatIsNotAPlacementFilter() {
-		PlacedFeature feature = ore(
-			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
-			FilterNamedPositionTransformer.INSTANCE
-		);
-
-		Occurrence result = new OreContractClassifier().classify("example:not_a_filter", MEMBERSHIP, feature);
-
-		assertEquals(Contract.PRESERVE_UNKNOWN, result.contract());
-		assertEquals("UNSUPPORTED_POSITION_MODIFIER", result.reasonCode());
-		assertEquals(Action.PRESERVE_UNCHANGED, result.action());
-	}
-
-	@Test
-	void preservesCustomConfiguredFeaturesAndUnsupportedHeightForms() {
+	void preservesCustomFeaturesAndUnsupportedHeightForms() {
 		PlacedFeature custom = new PlacedFeature(
 			Holder.direct(new ConfiguredFeature<>(Feature.NO_OP, NoneFeatureConfiguration.INSTANCE)),
 			List.of(HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()))
 		);
 		PlacedFeature constant = ore(HeightRangePlacement.of(ConstantHeight.of(VerticalAnchor.absolute(12))));
 
-		Occurrence customResult = new OreContractClassifier().classify("example:custom", MEMBERSHIP, custom);
-		Occurrence constantResult = new OreContractClassifier().classify("example:constant", MEMBERSHIP, constant);
-
-		assertEquals(Contract.CUSTOM_DIAGNOSTIC, customResult.contract());
-		assertEquals("CUSTOM_CONFIGURED_FEATURE", customResult.reasonCode());
-		assertEquals(Action.PRESERVE_UNCHANGED, customResult.action());
-		assertEquals(Contract.PRESERVE_UNKNOWN, constantResult.contract());
-		assertEquals("UNSUPPORTED_HEIGHT_PROVIDER:minecraft:constant", constantResult.reasonCode());
-		assertEquals(InspectionStatus.UNSUPPORTED, constantResult.inspection().status());
-		assertEquals(Action.PRESERVE_UNCHANGED, constantResult.action());
+		assertEquals(Status.NOT_ORE, new OreContractClassifier().classify(custom).status());
+		assertEquals(Status.SKIPPED, new OreContractClassifier().classify(constant).status());
+		assertEquals(
+			"UNSUPPORTED_HEIGHT_PROVIDER:minecraft:constant",
+			new OreContractClassifier().classify(constant).reasonCode()
+		);
 	}
 
 	@Test
@@ -195,39 +159,12 @@ class OreContractClassifierTest {
 			HeightRangePlacement.uniform(VerticalAnchor.absolute(0), VerticalAnchor.top())
 		);
 
-		assertEquals(
-			"MISSING_HEIGHT_RANGE",
-			new OreContractClassifier().classify("test:missing", MEMBERSHIP, missing).reasonCode()
-		);
-		assertEquals(
-			"MULTIPLE_HEIGHT_RANGES",
-			new OreContractClassifier().classify("test:multiple", MEMBERSHIP, repeated).reasonCode()
-		);
+		assertEquals("MISSING_HEIGHT_RANGE", new OreContractClassifier().classify(missing).reasonCode());
+		assertEquals("MULTIPLE_HEIGHT_RANGES", new OreContractClassifier().classify(repeated).reasonCode());
 	}
 
 	@Test
-	void attributesRuntimeAndLinkageFailuresToOnlyTheInspectedOccurrence() {
-		PlacedFeature feature = ore(HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()));
-		OreContractClassifier runtimeFailure = new OreContractClassifier(height -> {
-			throw new IllegalStateException("bad codec shape");
-		});
-		OreContractClassifier linkageFailure = new OreContractClassifier(height -> {
-			throw new NoClassDefFoundError("missing optional type");
-		});
-
-		Occurrence runtime = runtimeFailure.classify("test:runtime", MEMBERSHIP, feature);
-		Occurrence linkage = linkageFailure.classify("test:linkage", MEMBERSHIP, feature);
-		Occurrence independent = new OreContractClassifier().classify("test:independent", MEMBERSHIP, feature);
-
-		assertEquals(InspectionStatus.FAILED, runtime.inspection().status());
-		assertEquals("java.lang.IllegalStateException", runtime.inspection().failureType().orElseThrow());
-		assertEquals(InspectionStatus.FAILED, linkage.inspection().status());
-		assertEquals("java.lang.NoClassDefFoundError", linkage.inspection().failureType().orElseThrow());
-		assertEquals(Contract.SUPPORTED_STANDARD, independent.contract());
-	}
-
-	@Test
-	void reportingDoesNotMutateTheConfiguredFeatureOrPlacementChain() {
+	void classifyingScatteredOreDoesNotMutateItsPlacementChain() {
 		ConfiguredFeature<?, ?> configured = new ConfiguredFeature<>(Feature.SCATTERED_ORE, configuration());
 		List<PlacementModifier> modifiers = List.of(
 			RarityFilter.onAverageOnceEvery(3),
@@ -237,13 +174,10 @@ class OreContractClassifierTest {
 		);
 		PlacedFeature feature = new PlacedFeature(Holder.direct(configured), modifiers);
 
-		Occurrence result = new OreContractClassifier().classify("test:identity", MEMBERSHIP, feature);
-
-		assertEquals(Contract.SUPPORTED_STANDARD, result.contract());
+		assertEquals(Status.SUPPORTED, new OreContractClassifier().classify(feature).status());
 		assertSame(configured, feature.feature().value());
 		assertSame(modifiers, feature.placement());
 		assertSame(configured.config(), feature.feature().value().config());
-		assertFalse(result.oreConfiguration().isEmpty());
 	}
 
 	private static PlacedFeature ore(PlacementModifier... modifiers) {

--- a/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifierTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/world/worldgen/feature/ore/OreContractClassifierTest.java
@@ -1,0 +1,289 @@
+package raccoonman.reterraforged.world.worldgen.feature.ore;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeAll;
+
+import com.mojang.serialization.MapCodec;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
+import net.minecraft.world.level.levelgen.heightproviders.ConstantHeight;
+import net.minecraft.world.level.levelgen.heightproviders.TrapezoidHeight;
+import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
+import net.minecraft.world.level.levelgen.structure.templatesystem.BlockMatchTest;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.levelgen.placement.BiomeFilter;
+import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementContext;
+import net.minecraft.world.level.levelgen.placement.PlacementFilter;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.PlacementModifierType;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Action;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Anchor;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.AnchorType;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Contract;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.HeightProviderShape;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.InspectionStatus;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Membership;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.Occurrence;
+
+class OreContractClassifierTest {
+	private static final Membership MEMBERSHIP = new Membership("minecraft:plains", "underground_ores", 6, 3);
+
+	@BeforeAll
+	static void bootstrapMinecraft() {
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+	}
+
+	@Test
+	void classifiesUniformOreAndPreservesMixedAnchorSemantics() {
+		PlacedFeature feature = ore(
+			CountPlacement.of(7),
+			InSquarePlacement.spread(),
+			HeightRangePlacement.uniform(VerticalAnchor.aboveBottom(12), VerticalAnchor.absolute(48)),
+			BiomeFilter.biome()
+		);
+
+		Occurrence result = new OreContractClassifier().classify("minecraft:test", MEMBERSHIP, feature);
+
+		assertEquals(Contract.SUPPORTED_STANDARD, result.contract());
+		assertEquals(InspectionStatus.CLASSIFIED, result.inspection().status());
+		assertEquals(Action.REPORT_ONLY, result.action());
+		assertEquals(
+			Optional.of(new DynamicOrePlan.HeightSemantics(
+				HeightProviderShape.UNIFORM,
+				new Anchor(AnchorType.ABOVE_BOTTOM, 12),
+				new Anchor(AnchorType.ABSOLUTE, 48),
+				0
+			)),
+			result.height()
+		);
+		assertTrue(result.oreConfiguration().orElseThrow().contains("\"size\":9"));
+		assertTrue(result.oreConfiguration().orElseThrow().contains("minecraft:stone"));
+		assertTrue(result.oreConfiguration().orElseThrow().contains("minecraft:iron_ore"));
+	}
+
+	@Test
+	void classifiesTriangularAndTrapezoidProvidersWithoutPrivateAccess() {
+		PlacedFeature triangle = ore(HeightRangePlacement.triangle(VerticalAnchor.absolute(-32), VerticalAnchor.belowTop(8)));
+		PlacedFeature trapezoid = ore(HeightRangePlacement.of(
+			TrapezoidHeight.of(VerticalAnchor.absolute(-16), VerticalAnchor.absolute(80), 12)
+		));
+
+		Occurrence triangleResult = new OreContractClassifier().classify("test:triangle", MEMBERSHIP, triangle);
+		Occurrence trapezoidResult = new OreContractClassifier().classify("test:trapezoid", MEMBERSHIP, trapezoid);
+
+		assertEquals(HeightProviderShape.TRAPEZOID, triangleResult.height().orElseThrow().provider());
+		assertEquals(AnchorType.BELOW_TOP, triangleResult.height().orElseThrow().maxInclusive().type());
+		assertEquals(0, triangleResult.height().orElseThrow().plateau());
+		assertEquals(12, trapezoidResult.height().orElseThrow().plateau());
+	}
+
+	@Test
+	void acceptsActualCustomPlacementFilterWithoutLinkingItsConcreteClass() {
+		PlacedFeature feature = ore(
+			CountPlacement.of(4),
+			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
+			TestPlacementFilter.INSTANCE
+		);
+
+		Occurrence result = new OreContractClassifier().classify("example:filtered_ore", MEMBERSHIP, feature);
+
+		assertEquals(Contract.STANDARD_WITH_CUSTOM_FILTER, result.contract());
+		assertEquals("SUPPORTED_CUSTOM_PLACEMENT_FILTER", result.reasonCode());
+		assertEquals(Action.REPORT_ONLY, result.action());
+		assertTrue(result.placementModifierTypes().getLast().contains("TestPlacementFilter"));
+	}
+
+	@Test
+	void preservesAFilterThatWouldRunBeforeTheSafeFanoutBoundary() {
+		PlacedFeature feature = ore(
+			TestPlacementFilter.INSTANCE,
+			CountPlacement.of(4),
+			InSquarePlacement.spread(),
+			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32))
+		);
+
+		Occurrence result = new OreContractClassifier().classify("example:upstream_filter", MEMBERSHIP, feature);
+
+		assertEquals(Contract.PRESERVE_UNKNOWN, result.contract());
+		assertEquals("UPSTREAM_FILTER_BEFORE_SAFE_FANOUT", result.reasonCode());
+		assertEquals(Action.PRESERVE_UNCHANGED, result.action());
+	}
+
+	@Test
+	void usesRegistryAwareCodecOpsForRegistryBackedModifierConfiguration() {
+		PlacedFeature feature = ore(
+			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
+			BlockPredicateFilter.forPredicate(BlockPredicate.matchesBlocks(Blocks.STONE))
+		);
+		OreContractClassifier classifier = new OreContractClassifier(
+			RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY)
+		);
+
+		Occurrence result = classifier.classify("example:registry_codec", MEMBERSHIP, feature);
+
+		assertEquals(Contract.SUPPORTED_STANDARD, result.contract());
+		assertEquals(InspectionStatus.CLASSIFIED, result.inspection().status());
+		assertTrue(result.placementModifierConfigurations().getLast().contains("minecraft:stone"));
+	}
+
+	@Test
+	void rejectsAFilterNamedPositionTransformerThatIsNotAPlacementFilter() {
+		PlacedFeature feature = ore(
+			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
+			FilterNamedPositionTransformer.INSTANCE
+		);
+
+		Occurrence result = new OreContractClassifier().classify("example:not_a_filter", MEMBERSHIP, feature);
+
+		assertEquals(Contract.PRESERVE_UNKNOWN, result.contract());
+		assertEquals("UNSUPPORTED_POSITION_MODIFIER", result.reasonCode());
+		assertEquals(Action.PRESERVE_UNCHANGED, result.action());
+	}
+
+	@Test
+	void preservesCustomConfiguredFeaturesAndUnsupportedHeightForms() {
+		PlacedFeature custom = new PlacedFeature(
+			Holder.direct(new ConfiguredFeature<>(Feature.NO_OP, NoneFeatureConfiguration.INSTANCE)),
+			List.of(HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()))
+		);
+		PlacedFeature constant = ore(HeightRangePlacement.of(ConstantHeight.of(VerticalAnchor.absolute(12))));
+
+		Occurrence customResult = new OreContractClassifier().classify("example:custom", MEMBERSHIP, custom);
+		Occurrence constantResult = new OreContractClassifier().classify("example:constant", MEMBERSHIP, constant);
+
+		assertEquals(Contract.CUSTOM_DIAGNOSTIC, customResult.contract());
+		assertEquals("CUSTOM_CONFIGURED_FEATURE", customResult.reasonCode());
+		assertEquals(Action.PRESERVE_UNCHANGED, customResult.action());
+		assertEquals(Contract.PRESERVE_UNKNOWN, constantResult.contract());
+		assertEquals("UNSUPPORTED_HEIGHT_PROVIDER:minecraft:constant", constantResult.reasonCode());
+		assertEquals(InspectionStatus.UNSUPPORTED, constantResult.inspection().status());
+		assertEquals(Action.PRESERVE_UNCHANGED, constantResult.action());
+	}
+
+	@Test
+	void requiresExactlyOneHeightRange() {
+		PlacedFeature missing = ore(CountPlacement.of(1));
+		PlacedFeature repeated = ore(
+			HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.absolute(32)),
+			HeightRangePlacement.uniform(VerticalAnchor.absolute(0), VerticalAnchor.top())
+		);
+
+		assertEquals(
+			"MISSING_HEIGHT_RANGE",
+			new OreContractClassifier().classify("test:missing", MEMBERSHIP, missing).reasonCode()
+		);
+		assertEquals(
+			"MULTIPLE_HEIGHT_RANGES",
+			new OreContractClassifier().classify("test:multiple", MEMBERSHIP, repeated).reasonCode()
+		);
+	}
+
+	@Test
+	void attributesRuntimeAndLinkageFailuresToOnlyTheInspectedOccurrence() {
+		PlacedFeature feature = ore(HeightRangePlacement.uniform(VerticalAnchor.bottom(), VerticalAnchor.top()));
+		OreContractClassifier runtimeFailure = new OreContractClassifier(height -> {
+			throw new IllegalStateException("bad codec shape");
+		});
+		OreContractClassifier linkageFailure = new OreContractClassifier(height -> {
+			throw new NoClassDefFoundError("missing optional type");
+		});
+
+		Occurrence runtime = runtimeFailure.classify("test:runtime", MEMBERSHIP, feature);
+		Occurrence linkage = linkageFailure.classify("test:linkage", MEMBERSHIP, feature);
+		Occurrence independent = new OreContractClassifier().classify("test:independent", MEMBERSHIP, feature);
+
+		assertEquals(InspectionStatus.FAILED, runtime.inspection().status());
+		assertEquals("java.lang.IllegalStateException", runtime.inspection().failureType().orElseThrow());
+		assertEquals(InspectionStatus.FAILED, linkage.inspection().status());
+		assertEquals("java.lang.NoClassDefFoundError", linkage.inspection().failureType().orElseThrow());
+		assertEquals(Contract.SUPPORTED_STANDARD, independent.contract());
+	}
+
+	@Test
+	void reportingDoesNotMutateTheConfiguredFeatureOrPlacementChain() {
+		ConfiguredFeature<?, ?> configured = new ConfiguredFeature<>(Feature.SCATTERED_ORE, configuration());
+		List<PlacementModifier> modifiers = List.of(
+			RarityFilter.onAverageOnceEvery(3),
+			InSquarePlacement.spread(),
+			HeightRangePlacement.uniform(VerticalAnchor.absolute(-20), VerticalAnchor.belowTop(4)),
+			BiomeFilter.biome()
+		);
+		PlacedFeature feature = new PlacedFeature(Holder.direct(configured), modifiers);
+
+		Occurrence result = new OreContractClassifier().classify("test:identity", MEMBERSHIP, feature);
+
+		assertEquals(Contract.SUPPORTED_STANDARD, result.contract());
+		assertSame(configured, feature.feature().value());
+		assertSame(modifiers, feature.placement());
+		assertSame(configured.config(), feature.feature().value().config());
+		assertFalse(result.oreConfiguration().isEmpty());
+	}
+
+	private static PlacedFeature ore(PlacementModifier... modifiers) {
+		return new PlacedFeature(
+			Holder.direct(new ConfiguredFeature<>(Feature.ORE, configuration())),
+			List.of(modifiers)
+		);
+	}
+
+	private static OreConfiguration configuration() {
+		return new OreConfiguration(new BlockMatchTest(Blocks.STONE), Blocks.IRON_ORE.defaultBlockState(), 9, 0.35F);
+	}
+
+	private static final class TestPlacementFilter extends PlacementFilter {
+		private static final TestPlacementFilter INSTANCE = new TestPlacementFilter();
+		private static final PlacementModifierType<TestPlacementFilter> TYPE = () -> MapCodec.unit(() -> INSTANCE);
+
+		@Override
+		protected boolean shouldPlace(PlacementContext context, RandomSource random, BlockPos position) {
+			return true;
+		}
+
+		@Override
+		public PlacementModifierType<?> type() {
+			return TYPE;
+		}
+	}
+
+	private static final class FilterNamedPositionTransformer extends PlacementModifier {
+		private static final FilterNamedPositionTransformer INSTANCE = new FilterNamedPositionTransformer();
+		private static final PlacementModifierType<FilterNamedPositionTransformer> TYPE = () -> MapCodec.unit(() -> INSTANCE);
+
+		@Override
+		public Stream<BlockPos> getPositions(PlacementContext context, RandomSource random, BlockPos position) {
+			return Stream.of(position.above());
+		}
+
+		@Override
+		public PlacementModifierType<?> type() {
+			return TYPE;
+		}
+	}
+}

--- a/fabric/src/main/java/raccoonman/reterraforged/fabric/mixin/MixinMinecraftServer.java
+++ b/fabric/src/main/java/raccoonman/reterraforged/fabric/mixin/MixinMinecraftServer.java
@@ -11,12 +11,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.packs.resources.ResourceManager;
 import raccoonman.reterraforged.server.RTFMinecraftServer;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner;
 import raccoonman.reterraforged.world.worldgen.feature.template.template.FeatureTemplateManager;
 
 @Implements(@Interface(iface = RTFMinecraftServer.class, prefix = "reterraforged$RTFMinecraftServer$"))
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 	private FeatureTemplateManager templateManager;
+	private volatile DynamicOrePlan dynamicOrePlan = DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint());
 
 	@Inject(
 		method = "<init>",
@@ -25,11 +28,19 @@ public class MixinMinecraftServer {
 	public void MinecraftServer(CallbackInfo callback) {
 		this.templateManager = new FeatureTemplateManager(this.getResourceManager());
 	}
-	
+
 	public FeatureTemplateManager reterraforged$RTFMinecraftServer$getFeatureTemplateManager() {
 		return this.templateManager;
 	}
-	
+
+	public DynamicOrePlan reterraforged$RTFMinecraftServer$getDynamicOrePlan() {
+		return this.dynamicOrePlan;
+	}
+
+	public void reterraforged$RTFMinecraftServer$publishDynamicOrePlan(DynamicOrePlan plan) {
+		this.dynamicOrePlan = plan;
+	}
+
 	@Inject(
 		method = { "method_29440" },
 		require = 0,

--- a/fabric/src/main/java/raccoonman/reterraforged/fabric/mixin/MixinMinecraftServer.java
+++ b/fabric/src/main/java/raccoonman/reterraforged/fabric/mixin/MixinMinecraftServer.java
@@ -12,14 +12,13 @@ import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.packs.resources.ResourceManager;
 import raccoonman.reterraforged.server.RTFMinecraftServer;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner;
 import raccoonman.reterraforged.world.worldgen.feature.template.template.FeatureTemplateManager;
 
 @Implements(@Interface(iface = RTFMinecraftServer.class, prefix = "reterraforged$RTFMinecraftServer$"))
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 	private FeatureTemplateManager templateManager;
-	private volatile DynamicOrePlan dynamicOrePlan = DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint());
+	private volatile DynamicOrePlan dynamicOrePlan = DynamicOrePlan.empty();
 
 	@Inject(
 		method = "<init>",

--- a/neoforge/src/main/java/raccoonman/reterraforged/neoforge/mixin/MixinMinecraftServer.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/neoforge/mixin/MixinMinecraftServer.java
@@ -22,12 +22,15 @@ import net.minecraft.server.packs.repository.PackRepository;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import raccoonman.reterraforged.server.RTFMinecraftServer;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner;
 import raccoonman.reterraforged.world.worldgen.feature.template.template.FeatureTemplateManager;
 
 @Implements(@Interface(iface = RTFMinecraftServer.class, prefix = "reterraforged$RTFMinecraftServer$"))
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 	private FeatureTemplateManager templateManager;
+	private volatile DynamicOrePlan dynamicOrePlan = DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint());
 
 	@Inject(
 		method = "<init>(Ljava/lang/Thread;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/server/packs/repository/PackRepository;Lnet/minecraft/server/WorldStem;Ljava/net/Proxy;Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/server/Services;Lnet/minecraft/server/level/progress/ChunkProgressListenerFactory;)V",
@@ -36,9 +39,17 @@ public class MixinMinecraftServer {
 	public void MinecraftServer(Thread thread, LevelStorageSource.LevelStorageAccess arg2, PackRepository arg22, WorldStem arg3, Proxy proxy, DataFixer dataFixer, Services arg4, ChunkProgressListenerFactory arg5, CallbackInfo callback) {
 		this.templateManager = new FeatureTemplateManager(this.getResourceManager());
 	}
-	
+
 	public FeatureTemplateManager reterraforged$RTFMinecraftServer$getFeatureTemplateManager() {
 		return this.templateManager;
+	}
+
+	public DynamicOrePlan reterraforged$RTFMinecraftServer$getDynamicOrePlan() {
+		return this.dynamicOrePlan;
+	}
+
+	public void reterraforged$RTFMinecraftServer$publishDynamicOrePlan(DynamicOrePlan plan) {
+		this.dynamicOrePlan = plan;
 	}
 
 	@Inject(

--- a/neoforge/src/main/java/raccoonman/reterraforged/neoforge/mixin/MixinMinecraftServer.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/neoforge/mixin/MixinMinecraftServer.java
@@ -23,14 +23,13 @@ import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import raccoonman.reterraforged.server.RTFMinecraftServer;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan;
-import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlanner;
 import raccoonman.reterraforged.world.worldgen.feature.template.template.FeatureTemplateManager;
 
 @Implements(@Interface(iface = RTFMinecraftServer.class, prefix = "reterraforged$RTFMinecraftServer$"))
 @Mixin(MinecraftServer.class)
 public class MixinMinecraftServer {
 	private FeatureTemplateManager templateManager;
-	private volatile DynamicOrePlan dynamicOrePlan = DynamicOrePlan.empty(DynamicOrePlanner.schemaFingerprint());
+	private volatile DynamicOrePlan dynamicOrePlan = DynamicOrePlan.empty();
 
 	@Inject(
 		method = "<init>(Ljava/lang/Thread;Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/server/packs/repository/PackRepository;Lnet/minecraft/server/WorldStem;Ljava/net/Proxy;Lcom/mojang/datafixers/DataFixer;Lnet/minecraft/server/Services;Lnet/minecraft/server/level/progress/ChunkProgressListenerFactory;)V",


### PR DESCRIPTION
# TL;DR

### Problem

Minecraft's ore distribution is restricted to a fixed y-range of `-64..319` Overworld. Because FTF can make worlds taller/deeper or shorter/shallower, that restriction makes short worlds over-saturated and tall worlds under-saturated.

### Solution

This PR makes ordinary ore placement dynamic to the FTF world's actual height and depth. More vertical space = more ore opportunities. Less vertical space = less opportunities. 

### What this *doesn't* do

This PR doesn't change anything except placement opportunities along the y axis. The original vein size, horizontal spread, target blocks, air-exposure behavior, biome membership, and mod-specific behaviors are all preserved.

----

# More Details

More information on how it works, what it looks like, and what its compatible with in the sections below. Starting off with screenshots:

## Screenshots

> [!NOTE]
> All screenshots taken:
> - at seed 08211998
> - with [this preset
](https://github.com/user-attachments/files/31270571/Tall.World.Test.json)
> - at same coords for before and after shots
> - with various biome mods to show ores being placed in non-vanilla biomes, as expected.

### Deep World: Before

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/e00dcc20-c601-4aad-b88d-e0d898613a8f" width="95%"></kbd></p>

### Deep World: After

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/4f3012e8-e030-4c72-99da-26dd7873966d" width="95%"></kbd></p>

### Tall World: Before

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/4d523001-2ef5-4e4a-99e5-2da748a027aa" width="95%"></kbd></p>

### Tall World: After

<p align="center"><kbd><img src="https://github.com/user-attachments/assets/c7aea1a3-012a-4063-835b-0bff380cad7e" width="95%"></kbd></p>

## Mod Compatibility

> [!IMPORTANT]
> **TL;DR:** Solution is agnostic to modded ores, modded biomes, etc.Just like the cave feature placement fix in #154 

This is mechanism-based, not namespace- or mod-based. It applies to final active placed features backed by Minecraft's standard `ore` or `scattered_ore` configured features when their placement pipeline has a safe point to add independent attempts.

FTF does not need to know an ore's name or which mod owns it. Standard modded ores automatically qualify through the same contract as vanilla ores, and their downstream custom filters remain active. Unknown/custom systems fail closed and continue through their original path.

Some examples of what is and isn't affected:

| Feature system | Result |
| --- | --- |
| Vanilla ordinary ores | Dynamically distributed |
| Vanilla `scattered_ore` such as raw gold | Dynamically distributed |
| Create Mod: zinc | Dynamically distributed; Create's config filter remains active |
| Create Mod: striated ores | Unchanged; this is a custom feature system |
| Immersive Ores: vibranium | Dynamically distributed through its standard ore path |
| Immersive Ores: geodes | Unchanged; this is a custom/conditional path |
| Minecraft noise-router `largeOreVeins` | Unchanged; this is a separate worldgen system |

## How it Works

Treat vanilla's ore distribution as a "vertical intensity profile", then remap that profile onto the equivalent regions in the current FTF world:

| Vanilla reference region | FTF world region |
| --- | --- |
| World bottom through `Y=-1` | Configured world bottom through `Y=-1` |
| Vanilla geology transition `Y=0..8` | The same inherited transition |
| `Y=9` through sea level | `Y=9` through the configured sea level |
| Sea level through world top | Configured sea level through the actual world top |

Expanded regions receive proportionally more independent attempts. Contracted regions receive proportionally fewer. Fractional expansion is handled probabilistically, so an extra half-slice averages half of an additional opportunity across many chunks instead of being rounded away.

### Placement Flow

```mermaid
%%{init: {"theme": "base", "themeVariables": {"background": "#282a36", "primaryColor": "#44475a", "primaryTextColor": "#f8f8f2", "primaryBorderColor": "#bd93f9", "lineColor": "#8be9fd", "secondaryColor": "#6272a4", "tertiaryColor": "#21222c"}}}%%
flowchart LR
    A["Final active Overworld placed feature"] --> B{"Ordinary ore or scattered ore?"}
    B -->|"No"| C["Keep the original feature unchanged"]
    B -->|"Yes"| D{"Supported placement shape?"}
    D -->|"No"| C
    D -->|"Yes"| E["Map its authored Y intensity into the FTF vertical frame"]
    E --> F["Create the proportional number of independent X/Z/Y candidates"]
    F --> G["Continue the original filters and configured ore feature"]
    classDef normal fill:#44475a,stroke:#8be9fd,color:#f8f8f2
    classDef decision fill:#44475a,stroke:#ffb86c,color:#f8f8f2
    classDef success fill:#28513e,stroke:#50fa7b,color:#f8f8f2
    class A,E,F normal
    class B,D decision
    class C,G success
```