### PR TITLE
fix: Preserve mouse scroll preview snap back

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -482,11 +482,16 @@ public class Preview2D extends Button {
             if (this.page.zoom2D != null) {
                 double currentVal = this.page.zoom2D.getValue();
                 double step = 0.05;
+                double newVal = currentVal;
+
                 if (scrollY > 0) {
-                    this.page.zoom2D.setValue(Math.min(1.0, currentVal + step));
+                    newVal = Math.min(1.0, currentVal + step);
                 } else if (scrollY < 0) {
-                    this.page.zoom2D.setValue(Math.max(0.0, currentVal - step));
+                    newVal = Math.max(0.0, currentVal - step);
                 }
+
+                this.page.zoom2D.setValue(newVal);
+                this.page.zoom2D.applyValue();
                 this.regenerate();
             }
             return true;

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -586,11 +586,16 @@ public class Preview3D extends Button {
             if (this.page.zoom3D != null) {
                 double currentVal = this.page.zoom3D.getValue();
                 double step = 0.05;
+                double newVal = currentVal;
+
                 if (scrollY > 0) {
-                    this.page.zoom3D.setValue(Math.min(1.0, currentVal + step));
+                    newVal = Math.min(1.0, currentVal + step);
                 } else if (scrollY < 0) {
-                    this.page.zoom3D.setValue(Math.max(0.0, currentVal - step));
+                    newVal = Math.max(0.0, currentVal - step);
                 }
+
+                this.page.zoom3D.setValue(newVal);
+                this.page.zoom3D.applyValue();
                 this.regenerate();
             }
             return true;


### PR DESCRIPTION
When changing zoom level via mouse scrolling the preview zoom level wasn't preserved when the previewlistpage was cycled.

This change fixes that by correctly updating the backend data correctly to preserve mouse scroll zoom adjustments.