### PR TITLE
chore: Split shared preivew functionality to common interface

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/IPreviewHandler.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/IPreviewHandler.java
@@ -1,0 +1,662 @@
+package raccoonman.reterraforged.client.gui.screen.presetconfig;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.chat.Component;
+import raccoonman.reterraforged.RTFCommon;
+import raccoonman.reterraforged.config.PerformanceConfig;
+import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
+import raccoonman.reterraforged.data.worldgen.preset.settings.SpawnType;
+import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
+import raccoonman.reterraforged.registries.RTFRegistries;
+import raccoonman.reterraforged.world.worldgen.GeneratorContext;
+import raccoonman.reterraforged.world.worldgen.cell.Cell;
+import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
+import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
+import raccoonman.reterraforged.world.worldgen.noise.module.Noise;
+import raccoonman.reterraforged.world.worldgen.util.PosUtil;
+
+/**
+ * Everything Preview2D and Preview3D share:
+ * the async regeneration pipeline (prepare context ->
+ * generate/fetch tile -> rasterize -> upload), on-demand re-rasterization when only the render
+ * mode changes, legend rendering, and click/scroll handling.
+ *
+ * Both implementations still extend Button, so this isn't an abstract base class -
+ * instead the pieces of per-instance state live in PreviewState, which each implementer
+ * owns and exposes via state().
+ *
+ * The methods below that have no default body are exactly
+ * the places where 2D and 3D genuinely differ (how a tile becomes pixels, the zoom formula,
+ * legend text layout, etc.) - everything else is implemented once, here.
+ */
+public interface IPreviewHandler {
+    int FACTOR = 4;
+    int SIZE = (1 << 4) << FACTOR;
+    float[] LEGEND_SCALES = { 1, 0.9F, 0.75F, 0.6F };
+    long REFRESH_DEBOUNCE_MILLIS = 75L;
+
+    // ------------------------------------------------------------------
+    // Contract implementers must supply - either genuinely different logic,
+    // or state accessors satisfied automatically by an inherited Button method.
+    // ------------------------------------------------------------------
+
+    PreviewState state();
+
+    PresetEditorPage page();
+
+    int getX();
+
+    int getY();
+
+    int getWidth();
+
+    int getHeight();
+
+    boolean isMouseOver(double mouseX, double mouseY);
+
+    /** Plays the widget's click sound. Implemented per-class since {@code playDownSound} is protected on Button. */
+    void playClickSound();
+
+    /** "2D" / "3D" - used to label log messages for the two failure paths. */
+    String getFailureLabel();
+
+    RenderMode getRenderMode();
+
+    int getZoom();
+
+    boolean hasZoomControl();
+
+    double getZoomValue();
+
+    void setZoomValue(double value);
+
+    void applyZoomValue();
+
+    /** Snapshot of whatever extra sizing info rasterization needs, captured on the render thread. */
+    RasterParams captureRasterParams();
+
+    /** Turns a generated tile into pixels. For 2D this is a flat top-down buffer; for 3D an isometric projection. */
+    int[] createRasterData(Tile tile, BiomePreview.Sidecar biomes, RenderMode mode, Levels levels, WorldSettings.Properties properties, RasterParams params);
+
+    /** Applies a freshly generated frame's raster data (only called when the frame has no failure). */
+    void applyGeneratedFrame(FrameResult result);
+
+    /** Applies pixels produced by an on-demand {@link #requestRasterization()} call. */
+    void applyRasterizedPixels(int[] pixels, RasterParams params);
+
+    /** True if rasterization can't currently produce anything useful (e.g. zero widget size). */
+    boolean rasterizationBlocked();
+
+    boolean updateLegend(int mx, int my);
+
+    String buildLegendLine(String labelStr, String value);
+
+    int legendLineX(Font font, String line, float maxWidth);
+
+    /** Releases mode-specific GPU resources (textures). Called from {@link #close()}. */
+    default void closeResources() {
+    }
+
+    /** Hook for state that must track the render mode outside of {@code page()} (3D's fallback mode). */
+    default void onRenderModeChanged(RenderMode mode) {
+    }
+
+    /** Hook for per-mode bookkeeping once a generated frame has been adopted (3D clears its hover cache). */
+    default void onFrameApplied() {
+    }
+
+    // ------------------------------------------------------------------
+    // Shared behavior
+    // ------------------------------------------------------------------
+
+    default void regenerate() {
+        PreviewState state = state();
+        PreviewCancellation previous = state.generationCancellation;
+        if (previous != null) {
+            previous.cancel();
+        }
+        state.generationCancellation = new PreviewCancellation();
+        state.isDirty = true;
+        state.refreshRequestNanos = System.nanoTime();
+        scheduleRegeneration();
+    }
+
+    default void scheduleRegeneration() {
+        PreviewState state = state();
+        long requestNanos = state.refreshRequestNanos;
+        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestNanos);
+        long delayMillis = Math.max(0L, REFRESH_DEBOUNCE_MILLIS - elapsedMillis);
+        CompletableFuture.delayedExecutor(delayMillis, TimeUnit.MILLISECONDS).execute(() ->
+                Minecraft.getInstance().execute(() -> {
+                    if (!state.closed && requestNanos == state.refreshRequestNanos && !state.isRunning) {
+                        executeRegenerate();
+                    }
+                })
+        );
+    }
+
+    default void refreshRenderMode(RenderMode mode) {
+        onRenderModeChanged(mode);
+        PreviewState state = state();
+        boolean biomePipeline = mode == RenderMode.BIOME;
+        if (state.tile == null
+                || (mode == RenderMode.BIOME && state.biomes == null)
+                || state.generatedWithBiomePipeline != biomePipeline) {
+            regenerate();
+            return;
+        }
+        requestRasterization();
+    }
+
+    default void executeRegenerate() {
+        PreviewState state = state();
+        if (state.closed) {
+            return;
+        }
+
+        PreviewCancellation request = state.generationCancellation;
+        if (request == null) {
+            request = new PreviewCancellation();
+            state.generationCancellation = request;
+        }
+        final PreviewCancellation cancellation = request;
+
+        state.isRunning = true;
+        state.isDirty = false;
+
+        PresetEditorPage page = page();
+        WorldCreationContext settings;
+        Preset requestedPreset;
+        BiomePreview.CacheKey requestedKey;
+        RenderMode mode;
+        boolean biomePipeline;
+        PreparedContext reusable;
+        HolderLookup.Provider provider;
+        HolderGetter<Noise> noises;
+        Preset presetObj;
+        try {
+            settings = page.getScreen().getSettings();
+            requestedPreset = page.preset.getPreset();
+            requestedKey = BiomePreview.cacheKey(settings, requestedPreset);
+            mode = getRenderMode();
+            biomePipeline = mode == RenderMode.BIOME;
+            reusable = state.preparedContext;
+            provider = null;
+            noises = null;
+            presetObj = requestedPreset;
+            if (reusable == null
+                    || !Objects.equals(reusable.cacheKey, requestedKey)
+                    || reusable.biomePipeline != biomePipeline) {
+                RegistryAccess.Frozen registries = settings.worldgenLoadContext();
+                provider = biomePipeline
+                        ? requestedPreset.buildFullPatch(registries)
+                        : requestedPreset.buildPatch(registries);
+                HolderGetter<Preset> presets = provider.lookupOrThrow(RTFRegistries.PRESET);
+                noises = provider.lookupOrThrow(RTFRegistries.NOISE);
+                presetObj = presets.getOrThrow(Preset.KEY).value();
+            }
+        } catch (RuntimeException | LinkageError error) {
+            state.isRunning = false;
+            state.previewFailure = PreviewFailure.log("Failed to prepare " + getFailureLabel() + " preview provider", error);
+            if (state.isDirty) {
+                scheduleRegeneration();
+            }
+            return;
+        }
+        HolderLookup.Provider preparedProvider = provider;
+        HolderGetter<Noise> preparedNoises = noises;
+        Preset preparedPreset = presetObj;
+        if (!Objects.equals(state.cacheKey, requestedKey)) {
+            state.cacheKey = requestedKey;
+        }
+        WorldSettings.Properties properties = presetObj.world().properties;
+        Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
+
+        int seed = (int) settings.options().seed();
+        int zoomLevel = getZoom();
+        int localOffsetX = page.previewNavigationX();
+        int localOffsetZ = page.previewNavigationZ();
+        boolean localNavigated = page.previewNavigated();
+        RasterParams params = captureRasterParams();
+
+        // Stage 1: prepare context, run config loading and structure lookups off the main thread
+        CompletableFuture<PreGenContext> setupStage = CompletableFuture.supplyAsync(() -> {
+            PreparedContext prepared = reusable;
+            if (prepared == null
+                    || !Objects.equals(prepared.cacheKey, requestedKey)
+                    || prepared.biomePipeline != biomePipeline) {
+                PerformanceConfig config = PerformanceConfig.read(PerformanceConfig.DEFAULT_FILE_PATH)
+                        .resultOrPartial(RTFCommon.LOGGER::error)
+                        .orElseGet(PerformanceConfig::makeDefault);
+                GeneratorContext generatorContext = GeneratorContext.makeUncached(
+                        preparedPreset, preparedNoises, seed, FACTOR, 0, config.batchCount()
+                );
+                prepared = new PreparedContext(requestedKey, generatorContext, preparedProvider, preparedPreset, biomePipeline);
+                state.preparedContext = prepared;
+            }
+            BiomePreview biomePreview = null;
+            PreviewFailure biomeFailure = null;
+            if (biomePipeline) {
+                try {
+                    prepared.ensureBiomePreview(settings);
+                    biomePreview = prepared.biomePreview();
+                } catch (RuntimeException | LinkageError error) {
+                    biomeFailure = PreviewFailure.log("Failed to prepare " + getFailureLabel() + " biome preview", error);
+                }
+            }
+            GeneratorContext generatorContext = prepared.context;
+            if (properties.spawnType == SpawnType.CONTINENT_CENTER) {
+                long baseContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(0, 0);
+                properties.spawnX = PosUtil.unpackLeft(baseContinentCenter);
+                properties.spawnZ = PosUtil.unpackRight(baseContinentCenter);
+            }
+
+            int cx;
+            int cz;
+            if (preparedPreset.world().properties.spawnType == SpawnType.CONTINENT_CENTER) {
+                long nearestContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(
+                        localNavigated ? localOffsetX : 0,
+                        localNavigated ? localOffsetZ : 0
+                );
+                cx = PosUtil.unpackLeft(nearestContinentCenter);
+                cz = PosUtil.unpackRight(nearestContinentCenter);
+            } else {
+                cx = localNavigated ? localOffsetX : (preparedPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? preparedPreset.world().properties.spawnX : 0);
+                cz = localNavigated ? localOffsetZ : (preparedPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? preparedPreset.world().properties.spawnZ : 0);
+            }
+
+            PreviewComputationCache.TileKey tileKey = new PreviewComputationCache.TileKey(
+                    requestedKey, cx, cz, zoomLevel, SIZE, biomePipeline
+            );
+            return new PreGenContext(generatorContext, biomePreview, cx, cz, zoomLevel, tileKey, biomeFailure);
+        }, net.minecraft.Util.backgroundExecutor());
+
+        // Stage 2: fetch/generate the tile and rasterize it, entirely on the worker pool
+        state.pendingGeneration = setupStage.thenCompose(preGen -> {
+            cancellation.check();
+            PreviewComputationCache.TileLease cached = page.previewCache().acquire(preGen.tileKey);
+            CompletableFuture<PreviewComputationCache.TileLease> tileFuture;
+            if (cached != null) {
+                tileFuture = CompletableFuture.completedFuture(cached);
+            } else {
+                tileFuture = preGen.context.generator.generateZoomed(
+                        preGen.cx, preGen.cz, preGen.zoomLevel, biomePipeline, cancellation::isCancelled
+                ).thenApply(newTile -> {
+                    PreviewComputationCache.TileLease stored = page.previewCache().store(preGen.tileKey, newTile);
+                    if (stored == null) {
+                        throw new java.util.concurrent.CancellationException("Preview cache closed");
+                    }
+                    return stored;
+                });
+            }
+            return tileFuture.thenApply(lease -> {
+                cancellation.check();
+                Tile generatedTile = lease.tile();
+                try {
+                    BiomePreview.Sidecar biomes = null;
+                    PreviewFailure failure = preGen.biomeFailure;
+                    if (failure == null && biomePipeline) {
+                        biomes = preGen.biomePreview.resolveCached(
+                                page.previewCache(), generatedTile, preGen.cx, preGen.cz, preGen.zoomLevel, levels, cancellation
+                        );
+                    }
+                    int[] rasterData = failure == null
+                            ? createRasterData(generatedTile, biomes, mode, levels, properties, params)
+                            : null;
+                    return new FrameResult(lease, biomes, preGen.cx, preGen.cz, rasterData, params.width, params.height, failure);
+                } catch (Throwable throwable) {
+                    lease.close();
+                    throw throwable;
+                }
+            });
+        });
+
+        // Stage 3: return to the main render thread and adopt the result
+        state.pendingGeneration.whenCompleteAsync((result, throwable) -> {
+            state.isRunning = false;
+
+            if (state.closed) {
+                if (result != null) result.lease.close();
+                return;
+            }
+
+            if (throwable != null) {
+                if (!PreviewCancellation.isCancellation(throwable)) {
+                    state.previewFailure = PreviewFailure.log("Failed handling " + getFailureLabel() + " preview generation pipeline", throwable);
+                }
+            } else if (!state.isDirty && result != null && result.tile != null
+                    && !cancellation.isCancelled()
+                    && Objects.equals(requestedKey, state.cacheKey)
+                    && mode == getRenderMode()) {
+                PreviewComputationCache.TileLease previousLease = state.tileLease;
+                state.tileLease = result.lease;
+                state.tile = result.lease.tile();
+                state.biomes = result.biomes;
+                state.generatedWithBiomePipeline = biomePipeline;
+                state.centerX = result.centerX;
+                state.centerZ = result.centerZ;
+                state.previewFailure = result.failure;
+                state.legendValues[3] = getSpawnCoords();
+
+                if (result.failure == null) {
+                    applyGeneratedFrame(result);
+                }
+                onFrameApplied();
+                if (previousLease != null) previousLease.close();
+            } else if (result != null && result.tile != null) {
+                result.lease.close();
+            }
+
+            if (state.isDirty) {
+                scheduleRegeneration();
+            }
+        }, Minecraft.getInstance());
+    }
+
+    /** Re-rasterizes the current tile without a full regenerate - used when only the render mode changes. */
+    default void requestRasterization() {
+        PreviewState state = state();
+        PreviewComputationCache.TileLease current = state.tileLease;
+        if (current == null || state.closed || rasterizationBlocked()) {
+            return;
+        }
+        PreviewCancellation previous = state.rasterCancellation;
+        if (previous != null) previous.cancel();
+        PreviewCancellation cancellation = new PreviewCancellation();
+        state.rasterCancellation = cancellation;
+        long version = state.rasterRequestVersion.incrementAndGet();
+        PreviewComputationCache.TileLease retained = current.retain();
+        RenderMode mode = getRenderMode();
+        WorldSettings.Properties properties = page().preset.getPreset().world().properties;
+        Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
+        RasterParams params = captureRasterParams();
+        BiomePreview.Sidecar sidecar = state.biomes;
+        state.pendingRasterization = CompletableFuture.supplyAsync(() -> {
+            cancellation.check();
+            return createRasterData(retained.tile(), sidecar, mode, levels, properties, params);
+        }, net.minecraft.Util.backgroundExecutor()).whenCompleteAsync((pixels, throwable) -> {
+            try {
+                if (!state.closed && throwable != null && !PreviewCancellation.isCancellation(throwable)
+                        && version == state.rasterRequestVersion.get() && mode == getRenderMode()) {
+                    state.previewFailure = PreviewFailure.log("Failed rasterizing " + getFailureLabel() + " preview", throwable);
+                } else if (!state.closed && throwable == null && !cancellation.isCancelled()
+                        && version == state.rasterRequestVersion.get() && mode == getRenderMode()) {
+                    state.previewFailure = null;
+                    applyRasterizedPixels(pixels, params);
+                }
+            } finally {
+                retained.close();
+            }
+        }, Minecraft.getInstance());
+    }
+
+    default void close() throws Exception {
+        PreviewState state = state();
+        state.closed = true;
+        PreviewCancellation generation = state.generationCancellation;
+        if (generation != null) generation.cancel();
+        PreviewCancellation raster = state.rasterCancellation;
+        if (raster != null) raster.cancel();
+        closeResources();
+        if (state.tileLease != null) {
+            state.tileLease.close();
+            state.tileLease = null;
+        }
+        state.tile = null;
+        state.previewFailure = null;
+        state.generatedWithBiomePipeline = false;
+        state.preparedContext = null;
+    }
+
+    default float getLegendScale() {
+        int index = page().getScreen().minecraft.options.guiScale().get() - 1;
+        if (index < 0 || index >= LEGEND_SCALES.length) {
+            index = LEGEND_SCALES.length - 1;
+        }
+        return LEGEND_SCALES[index];
+    }
+
+    default void renderLegend(GuiGraphics guiGraphics, int mx, int my, Component[] labels, String[] values, int left, int top, int lineHeight, int color) {
+        float scale = getLegendScale();
+        PoseStack pose = guiGraphics.pose();
+
+        pose.pushPose();
+        pose.translate(left + 3.75F * scale, top - lineHeight * (3.2F * scale), 0);
+        pose.scale(scale, scale, 1);
+
+        Font renderer = Minecraft.getInstance().font;
+        float maxWidth = (getWidth() - 4) / scale;
+
+        for (int i = 0; i < labels.length && i < values.length; i++) {
+            Component label = labels[i];
+            String value = values[i];
+
+            String labelStr = label.getString();
+            if (labelStr.endsWith(": ")) {
+                labelStr = labelStr.substring(0, labelStr.length() - 2);
+            } else if (labelStr.endsWith(":")) {
+                labelStr = labelStr.substring(0, labelStr.length() - 1);
+            }
+
+            String line = buildLegendLine(labelStr, value);
+            while (line.length() > 0 && renderer.width(line) > maxWidth) {
+                line = line.substring(0, line.length() - 1);
+            }
+
+            int x = legendLineX(renderer, line, maxWidth);
+            guiGraphics.drawString(renderer, line, x, i * lineHeight, color);
+        }
+
+        pose.popPose();
+
+        String hoveredCoords = state().hoveredCoords;
+        if (!hoveredCoords.isEmpty()) {
+            guiGraphics.drawCenteredString(renderer, hoveredCoords, mx, my - 10, 0xFFFFFF);
+        }
+    }
+
+    default String getSpawnCoords() {
+        PreviewState state = state();
+        return getSpawnCoords(state.centerX, state.centerZ);
+    }
+
+    default String getSpawnCoords(int cx, int cz) {
+        WorldSettings.Properties props = page().preset.getPreset().world().properties;
+        if (props.spawnType == SpawnType.USER_SELECTED) {
+            return "x" + props.spawnX + " z" + props.spawnZ;
+        }
+        if (props.spawnType == SpawnType.CONTINENT_CENTER || props.spawnType == SpawnType.ISLANDS) {
+            return "~x" + cx + " ~z" + cz;
+        }
+        return "x0 z0";
+    }
+
+    static String getTerrainName(Cell cell) {
+        if (cell.terrain.isRiver()) {
+            return "river";
+        }
+        return cell.terrain.getName().toLowerCase();
+    }
+
+    /** Shared right/middle-click handling. Returns true if the click was handled (caller should not fall through to super). */
+    default boolean handleClick(double mouseX, double mouseY, int button) {
+        if (!isMouseOver(mouseX, mouseY)) {
+            return false;
+        }
+        PreviewState state = state();
+        // Right click: navigate to specific coordinates
+        if (button == 1) {
+            if (updateLegend((int) mouseX, (int) mouseY) && !state.hoveredCoords.isEmpty()) {
+                playClickSound();
+                WorldSettings.Properties props = page().preset.getPreset().world().properties;
+                if (props.spawnType == SpawnType.CONTINENT_CENTER) {
+                    props.spawnType = SpawnType.USER_SELECTED;
+                    if (page() instanceof WorldSettingsPage worldPage) {
+                        worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
+                    }
+                }
+                page().setPreviewNavigation(state.hoveredCoordX, state.hoveredCoordZ);
+                regenerate();
+                return true;
+            }
+        }
+        // Middle click: reset to current spawn coordinates
+        else if (button == 2) {
+            playClickSound();
+            page().resetPreviewNavigation();
+            regenerate();
+            return true;
+        }
+        return false;
+    }
+
+    /** Shared scroll-to-zoom handling. Returns true if the scroll was consumed. */
+    default boolean handleScroll(double mouseX, double mouseY, double scrollY) {
+        if (!isMouseOver(mouseX, mouseY)) {
+            return false;
+        }
+        if (hasZoomControl()) {
+            double currentVal = getZoomValue();
+            double step = 0.05;
+            double newVal = currentVal;
+
+            if (scrollY > 0) {
+                newVal = Math.min(1.0, currentVal + step);
+            } else if (scrollY < 0) {
+                newVal = Math.max(0.0, currentVal - step);
+            }
+
+            setZoomValue(newVal);
+            applyZoomValue();
+            regenerate();
+        }
+        return true;
+    }
+
+    /** Shared onPress handler for the underlying Button - left click sets spawn to the hovered cell. */
+    static Button.OnPress onPress() {
+        return (b) -> {
+            if (b instanceof IPreviewHandler self) {
+                Minecraft mc = Minecraft.getInstance();
+                double guiX = mc.mouseHandler.xpos() * (double) mc.getWindow().getGuiScaledWidth() / (double) mc.getWindow().getWidth();
+                double guiY = mc.mouseHandler.ypos() * (double) mc.getWindow().getGuiScaledHeight() / (double) mc.getWindow().getHeight();
+
+                PreviewState state = self.state();
+                if (self.updateLegend((int) guiX, (int) guiY) && !state.hoveredCoords.isEmpty()) {
+                    self.playClickSound();
+                    WorldSettings.Properties props = self.page().preset.getPreset().world().properties;
+                    props.spawnType = SpawnType.USER_SELECTED;
+                    props.spawnX = state.hoveredCoordX;
+                    props.spawnZ = state.hoveredCoordZ;
+
+                    if (self.page() instanceof WorldSettingsPage worldPage) {
+                        worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
+                    }
+
+                    self.page().resetPreviewNavigation();
+                    self.page().regenerate();
+                }
+            }
+        };
+    }
+
+    // ------------------------------------------------------------------
+    // Shared value types
+    // ------------------------------------------------------------------
+
+    final class RasterParams {
+        final int width;
+        final int height;
+        final double zoom;
+
+        RasterParams(int width, int height, double zoom) {
+            this.width = width;
+            this.height = height;
+            this.zoom = zoom;
+        }
+    }
+
+    final class PreGenContext {
+        final GeneratorContext context;
+        final BiomePreview biomePreview;
+        final int cx;
+        final int cz;
+        final int zoomLevel;
+        final PreviewComputationCache.TileKey tileKey;
+        final PreviewFailure biomeFailure;
+
+        PreGenContext(GeneratorContext context, BiomePreview biomePreview, int cx, int cz, int zoomLevel, PreviewComputationCache.TileKey tileKey, PreviewFailure biomeFailure) {
+            this.context = context;
+            this.biomePreview = biomePreview;
+            this.cx = cx;
+            this.cz = cz;
+            this.zoomLevel = zoomLevel;
+            this.tileKey = tileKey;
+            this.biomeFailure = biomeFailure;
+        }
+    }
+
+    final class PreparedContext {
+        final BiomePreview.CacheKey cacheKey;
+        final GeneratorContext context;
+        final HolderLookup.Provider provider;
+        final Preset preset;
+        final boolean biomePipeline;
+        private BiomePreview biomePreview;
+
+        PreparedContext(BiomePreview.CacheKey cacheKey, GeneratorContext context, HolderLookup.Provider provider, Preset preset, boolean biomePipeline) {
+            this.cacheKey = cacheKey;
+            this.context = context;
+            this.provider = provider;
+            this.preset = preset;
+            this.biomePipeline = biomePipeline;
+        }
+
+        synchronized void ensureBiomePreview(WorldCreationContext settings) {
+            if (this.biomePreview == null) {
+                this.biomePreview = BiomePreview.create(settings, this.provider, this.preset, this.context);
+            }
+        }
+
+        BiomePreview biomePreview() {
+            return this.biomePreview;
+        }
+    }
+
+    final class FrameResult {
+        final PreviewComputationCache.TileLease lease;
+        final Tile tile;
+        final BiomePreview.Sidecar biomes;
+        final int centerX;
+        final int centerZ;
+        final int[] rasterPayload;
+        final int rasterWidth;
+        final int rasterHeight;
+        final PreviewFailure failure;
+
+        FrameResult(PreviewComputationCache.TileLease lease, BiomePreview.Sidecar biomes, int centerX, int centerZ, int[] rasterPayload, int rasterWidth, int rasterHeight, PreviewFailure failure) {
+            this.lease = lease;
+            this.tile = lease.tile();
+            this.biomes = biomes;
+            this.centerX = centerX;
+            this.centerZ = centerZ;
+            this.rasterPayload = rasterPayload;
+            this.rasterWidth = rasterWidth;
+            this.rasterHeight = rasterHeight;
+            this.failure = failure;
+        }
+    }
+}

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -1,108 +1,40 @@
 package raccoonman.reterraforged.client.gui.screen.presetconfig;
 
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.mojang.blaze3d.platform.NativeImage;
 import com.mojang.blaze3d.systems.RenderSystem;
-import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
 import net.minecraft.client.renderer.texture.DynamicTexture;
-import net.minecraft.core.HolderGetter;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.CommonComponents;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import raccoonman.reterraforged.RTFCommon;
-import raccoonman.reterraforged.client.data.RTFTranslationKeys;
-import raccoonman.reterraforged.config.PerformanceConfig;
-import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.data.worldgen.preset.settings.SpawnType;
 import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
-import raccoonman.reterraforged.registries.RTFRegistries;
-import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
-import raccoonman.reterraforged.world.worldgen.noise.module.Noise;
-import raccoonman.reterraforged.world.worldgen.util.PosUtil;
 
-public class Preview2D extends Button {
-    private static final int FACTOR = 4;
-    public static final int SIZE = (1 << 4) << FACTOR;
-    private static final float[] LEGEND_SCALES = { 1, 0.9F, 0.75F, 0.6F };
-    private static final long REFRESH_DEBOUNCE_MILLIS = 75L;
+public class Preview2D extends Button implements IPreviewHandler {
+    public static final int SIZE = IPreviewHandler.SIZE;
 
     private final PresetEditorPage page;
-    private final DynamicTexture texture = new DynamicTexture(new NativeImage(SIZE, SIZE, false));
-    private final ResourceLocation textureId = Minecraft.getInstance().getTextureManager().register(RTFCommon.MOD_ID + "-preview-framebuffer", this.texture);
+    private final PreviewState state = new PreviewState();
 
-    private Tile tile;
-    private PreviewComputationCache.TileLease tileLease;
-    private BiomePreview.Sidecar biomes;
-    private boolean generatedWithBiomePipeline;
-    private BiomePreview.CacheKey cacheKey;
-    private int centerX, centerZ;
-    private int hoveredCoordX = 0;
-    private int hoveredCoordZ = 0;
-    private String hoveredCoords = "";
-    private final String[] legendValues = {"", "", "", ""};
-    private final Component[] legendLabels = {
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_AREA),
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_TERRAIN),
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_BIOME),
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_SPAWN)
-    };
-
-    private CompletableFuture<FrameResult> pendingGeneration = null;
-    private volatile PreparedContext preparedContext;
-    private volatile PreviewCancellation generationCancellation;
-    private volatile PreviewFailure previewFailure;
-    private final AtomicLong pixelRequestVersion = new AtomicLong();
-    private volatile PreviewCancellation pixelCancellation;
-    private CompletableFuture<?> pendingPixelRasterization;
-
-    // State Gates
-    private boolean isRunning = false;
-    private boolean isDirty = false;
-    private boolean closed = false;
-    private long refreshRequestNanos = 0L;
+    private final DynamicTexture texture;
+    private final ResourceLocation textureId;
 
     public Preview2D(PresetEditorPage parent, int x, int y, int width, int height) {
-        super(x, y, width, height, CommonComponents.EMPTY, (b) -> {
-            if (b instanceof Preview2D self) {
-                Minecraft mc = Minecraft.getInstance();
-                double guiX = mc.mouseHandler.xpos() * (double) mc.getWindow().getGuiScaledWidth() / (double) mc.getWindow().getWidth();
-                double guiY = mc.mouseHandler.ypos() * (double) mc.getWindow().getGuiScaledHeight() / (double) mc.getWindow().getHeight();
-
-                if (self.updateLegend((int) guiX, (int) guiY) && !self.hoveredCoords.isEmpty()) {
-                    self.playDownSound(Minecraft.getInstance().getSoundManager());
-                    WorldSettings.Properties props = self.page.preset.getPreset().world().properties;
-                    props.spawnType = SpawnType.USER_SELECTED;
-                    props.spawnX = self.hoveredCoordX;
-                    props.spawnZ = self.hoveredCoordZ;
-
-                    if (self.page instanceof WorldSettingsPage worldPage) {
-                        worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
-                    }
-
-                    self.page.resetPreviewNavigation();
-                    self.page.regenerate();
-                }
-            }
-        }, DEFAULT_NARRATION);
+        super(x, y, width, height, CommonComponents.EMPTY, IPreviewHandler.onPress(), DEFAULT_NARRATION);
         this.page = parent;
+        this.state.cacheKey = BiomePreview.cacheKey(parent.getScreen().getSettings(), parent.preset.getPreset());
 
-        this.cacheKey = BiomePreview.cacheKey(parent.getScreen().getSettings(), parent.preset.getPreset());
+        this.texture = new DynamicTexture(new NativeImage(SIZE, SIZE, false));
+        this.textureId = Minecraft.getInstance().getTextureManager().register(RTFCommon.MOD_ID + "-preview-framebuffer", this.texture);
 
         NativeImage pixels = this.texture.getPixels();
         if (pixels != null) {
@@ -111,255 +43,68 @@ public class Preview2D extends Button {
         }
     }
 
-    public void regenerate() {
-        PreviewCancellation previous = this.generationCancellation;
-        if (previous != null) {
-            previous.cancel();
-        }
-        this.generationCancellation = new PreviewCancellation();
-        this.isDirty = true;
-        this.refreshRequestNanos = System.nanoTime();
-        this.scheduleRegeneration();
+    @Override
+    public PreviewState state() {
+        return this.state;
     }
 
-    private void scheduleRegeneration() {
-        long requestNanos = this.refreshRequestNanos;
-        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestNanos);
-        long delayMillis = Math.max(0L, REFRESH_DEBOUNCE_MILLIS - elapsedMillis);
-        CompletableFuture.delayedExecutor(delayMillis, TimeUnit.MILLISECONDS).execute(() ->
-            Minecraft.getInstance().execute(() -> {
-                if (!this.closed && requestNanos == this.refreshRequestNanos && !this.isRunning) {
-                    this.executeRegenerate();
-                }
-            })
-        );
+    @Override
+    public PresetEditorPage page() {
+        return this.page;
     }
 
-    public void refreshRenderMode(RenderMode mode) {
-        boolean biomePipeline = mode == RenderMode.BIOME;
-        if (this.tile == null
-                || (mode == RenderMode.BIOME && this.biomes == null)
-                || this.generatedWithBiomePipeline != biomePipeline) {
-            this.regenerate();
-            return;
-        }
-        WorldSettings.Properties properties = this.page.preset.getPreset().world().properties;
-        Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
-        this.requestPixelRasterization(mode, levels, properties);
+    @Override
+    public void playClickSound() {
+        this.playDownSound(Minecraft.getInstance().getSoundManager());
     }
 
-    private void executeRegenerate() {
-        if (this.closed) return;
-
-        PreviewCancellation request = this.generationCancellation;
-        if (request == null) {
-            request = new PreviewCancellation();
-            this.generationCancellation = request;
-        }
-        final PreviewCancellation cancellation = request;
-
-        this.isRunning = true;
-        this.isDirty = false;
-
-        WorldCreationContext settings;
-        Preset requestedPreset;
-        BiomePreview.CacheKey requestedKey;
-        RenderMode mode;
-        boolean biomePipeline;
-        PreparedContext reusable;
-        HolderLookup.Provider provider;
-        HolderGetter<Noise> noises;
-        Preset presetObj;
-        try {
-            settings = this.page.getScreen().getSettings();
-            requestedPreset = this.page.preset.getPreset();
-            requestedKey = BiomePreview.cacheKey(settings, requestedPreset);
-            mode = this.page.renderMode2D.getValue();
-            biomePipeline = mode == RenderMode.BIOME;
-            reusable = this.preparedContext;
-            provider = null;
-            noises = null;
-            presetObj = requestedPreset;
-            if (reusable == null
-                    || !Objects.equals(reusable.cacheKey, requestedKey)
-                    || reusable.biomePipeline != biomePipeline) {
-                RegistryAccess.Frozen registries = settings.worldgenLoadContext();
-                provider = biomePipeline
-                        ? requestedPreset.buildFullPatch(registries)
-                        : requestedPreset.buildPatch(registries);
-                HolderGetter<Preset> presets = provider.lookupOrThrow(RTFRegistries.PRESET);
-                noises = provider.lookupOrThrow(RTFRegistries.NOISE);
-                presetObj = presets.getOrThrow(Preset.KEY).value();
-            }
-        } catch (RuntimeException | LinkageError error) {
-            this.isRunning = false;
-            this.previewFailure = PreviewFailure.log("Failed to prepare 2D preview provider", error);
-            if (this.isDirty) {
-                this.scheduleRegeneration();
-            }
-            return;
-        }
-        HolderLookup.Provider preparedProvider = provider;
-        HolderGetter<Noise> preparedNoises = noises;
-        Preset preparedPreset = presetObj;
-        if (!Objects.equals(this.cacheKey, requestedKey)) {
-            this.cacheKey = requestedKey;
-        }
-        WorldSettings.Properties properties = presetObj.world().properties;
-
-        int seed = (int) settings.options().seed();
-        int zoomLevel = this.getZoom();
-        int localOffsetX = this.page.previewNavigationX();
-        int localOffsetZ = this.page.previewNavigationZ();
-        boolean localNavigated = this.page.previewNavigated();
-        Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
-
-        // Stage 1: Run clear, config loading, and structure lookups off the main thread
-        CompletableFuture<PreGenContext> setupStage = CompletableFuture.supplyAsync(() -> {
-            PreparedContext prepared = reusable;
-            if (prepared == null
-                    || !Objects.equals(prepared.cacheKey, requestedKey)
-                    || prepared.biomePipeline != biomePipeline) {
-                PerformanceConfig config = PerformanceConfig.read(PerformanceConfig.DEFAULT_FILE_PATH)
-                        .resultOrPartial(RTFCommon.LOGGER::error)
-                        .orElseGet(PerformanceConfig::makeDefault);
-                GeneratorContext generatorContext = GeneratorContext.makeUncached(
-                    preparedPreset, preparedNoises, seed, FACTOR, 0, config.batchCount()
-                );
-                prepared = new PreparedContext(requestedKey, generatorContext, preparedProvider, preparedPreset, biomePipeline);
-                this.preparedContext = prepared;
-            }
-            BiomePreview biomePreview = null;
-            PreviewFailure biomeFailure = null;
-            if (biomePipeline) {
-                try {
-                    prepared.ensureBiomePreview(settings);
-                    biomePreview = prepared.biomePreview;
-                } catch (RuntimeException | LinkageError error) {
-                    biomeFailure = PreviewFailure.log("Failed to prepare 2D biome preview", error);
-                }
-            }
-            GeneratorContext generatorContext = prepared.context;
-            if (properties.spawnType == SpawnType.CONTINENT_CENTER) {
-                long baseContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(0, 0);
-                properties.spawnX = PosUtil.unpackLeft(baseContinentCenter);
-                properties.spawnZ = PosUtil.unpackRight(baseContinentCenter);
-            }
-
-            int cx = 0;
-            int cz = 0;
-
-            // Generalize coordinate selection for all spawn types
-            if (preparedPreset.world().properties.spawnType == SpawnType.CONTINENT_CENTER) {
-                long nearestContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(
-                        localNavigated ? localOffsetX : 0,
-                        localNavigated ? localOffsetZ : 0
-                );
-                cx = PosUtil.unpackLeft(nearestContinentCenter);
-                cz = PosUtil.unpackRight(nearestContinentCenter);
-            } else {
-                // If navigated, center on the clicked spot; otherwise fallback to spawn values or origin depending on type
-                cx = localNavigated ? localOffsetX : (preparedPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? preparedPreset.world().properties.spawnX : 0);
-                cz = localNavigated ? localOffsetZ : (preparedPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? preparedPreset.world().properties.spawnZ : 0);
-            }
-
-            PreviewComputationCache.TileKey tileKey = new PreviewComputationCache.TileKey(
-                requestedKey, cx, cz, zoomLevel, Preview2D.SIZE, biomePipeline
-            );
-            return new PreGenContext(generatorContext, biomePreview, cx, cz, zoomLevel, tileKey, biomeFailure);
-        }, net.minecraft.Util.backgroundExecutor());
-
-        // Stage 2: Handle calculation maps and evaluate visual color tables entirely on worker pool
-        this.pendingGeneration = setupStage.thenCompose(preGen -> {
-            cancellation.check();
-            PreviewComputationCache.TileLease cached = this.page.previewCache().acquire(preGen.tileKey);
-            CompletableFuture<PreviewComputationCache.TileLease> tileFuture;
-            if (cached != null) {
-                tileFuture = CompletableFuture.completedFuture(cached);
-            } else {
-                tileFuture = preGen.context.generator.generateZoomed(
-					preGen.cx, preGen.cz, preGen.zoomLevel, biomePipeline, cancellation::isCancelled
-                ).thenApply(newTile -> {
-                    PreviewComputationCache.TileLease stored = this.page.previewCache().store(preGen.tileKey, newTile);
-                    if (stored == null) {
-                        throw new java.util.concurrent.CancellationException("Preview cache closed");
-                    }
-                    return stored;
-                });
-            }
-            return tileFuture.thenApply(lease -> {
-                cancellation.check();
-                Tile generatedTile = lease.tile();
-                try {
-                    BiomePreview.Sidecar biomes = null;
-                    PreviewFailure failure = preGen.biomeFailure;
-                    if (failure == null && biomePipeline) {
-                        biomes = preGen.biomePreview.resolveCached(
-                            this.page.previewCache(), generatedTile, preGen.cx, preGen.cz, preGen.zoomLevel, levels, cancellation
-                        );
-                    }
-
-                    int[] bufferedPixels = failure == null
-                        ? this.createPixelData(generatedTile, biomes, mode, levels, properties)
-                        : null;
-                    return new FrameResult(lease, biomes, preGen.cx, preGen.cz, bufferedPixels, failure);
-                } catch (Throwable throwable) {
-                    lease.close();
-                    throw throwable;
-                }
-            });
-        });
-
-        // Stage 3: Return safely back onto the primary Minecraft render thread for GL transfers
-        this.pendingGeneration.whenCompleteAsync((result, throwable) -> {
-            this.isRunning = false;
-
-            if (this.closed) {
-                if (result != null) result.lease.close();
-                return;
-            }
-
-            if (throwable != null) {
-                if (!PreviewCancellation.isCancellation(throwable)) {
-                    this.previewFailure = PreviewFailure.log("Failed handling 2D preview generation pipeline", throwable);
-                }
-            } else if (!this.isDirty && result != null && result.tile != null
-                    && !cancellation.isCancelled()
-                    && Objects.equals(requestedKey, this.cacheKey)
-                    && mode == this.page.renderMode2D.getValue()) {
-                PreviewComputationCache.TileLease previousLease = this.tileLease;
-                this.tileLease = result.lease;
-                this.tile = result.lease.tile();
-                this.biomes = result.biomes;
-                this.generatedWithBiomePipeline = biomePipeline;
-                this.centerX = result.centerX;
-                this.centerZ = result.centerZ;
-                this.previewFailure = result.failure;
-                this.legendValues[3] = getSpawnCoords();
-
-                // Safe structural upload across to GPU
-                if (result.failure == null) {
-                    this.uploadPixelData(result.pixelData);
-                }
-                if (previousLease != null) previousLease.close();
-            } else if (result != null && result.tile != null) {
-                result.lease.close();
-            }
-
-            // Consume trailing-edge loop calls if input shifted during calculations
-            if (this.isDirty) {
-                this.scheduleRegeneration();
-            }
-        }, Minecraft.getInstance());
+    @Override
+    public String getFailureLabel() {
+        return "2D";
     }
 
-    private int[] createPixelData(
-        Tile tile,
-        BiomePreview.Sidecar biomes,
-        RenderMode mode,
-        Levels levels,
-        WorldSettings.Properties properties
-    ) {
+    @Override
+    public RenderMode getRenderMode() {
+        return this.page.renderMode2D.getValue();
+    }
+
+    @Override
+    public int getZoom() {
+        return NoiseUtil.round(1.5F * (101 - (float) this.page.zoom2D.getLerpedValue()));
+    }
+
+    @Override
+    public boolean hasZoomControl() {
+        return this.page.zoom2D != null;
+    }
+
+    @Override
+    public double getZoomValue() {
+        return this.page.zoom2D.getValue();
+    }
+
+    @Override
+    public void setZoomValue(double value) {
+        this.page.zoom2D.setValue(value);
+    }
+
+    @Override
+    public void applyZoomValue() {
+        this.page.zoom2D.applyValue();
+    }
+
+    @Override
+    public RasterParams captureRasterParams() {
+        return new RasterParams(SIZE, SIZE, 0);
+    }
+
+    @Override
+    public boolean rasterizationBlocked() {
+        return false;
+    }
+
+    @Override
+    public int[] createRasterData(Tile tile, BiomePreview.Sidecar biomes, RenderMode mode, Levels levels, WorldSettings.Properties properties, RasterParams params) {
         int stroke = 2;
         int tileWidth = tile.getBlockSize().size();
         int[] pixels = new int[tileWidth * tileWidth];
@@ -378,6 +123,16 @@ public class Preview2D extends Button {
         return pixels;
     }
 
+    @Override
+    public void applyGeneratedFrame(FrameResult result) {
+        uploadPixelData(result.rasterPayload);
+    }
+
+    @Override
+    public void applyRasterizedPixels(int[] pixels, RasterParams params) {
+        uploadPixelData(pixels);
+    }
+
     private void uploadPixelData(int[] pixelData) {
         NativeImage pixels = this.texture.getPixels();
         if (pixels == null || pixelData == null) return;
@@ -391,109 +146,32 @@ public class Preview2D extends Button {
         this.texture.upload();
     }
 
-    private void requestPixelRasterization(RenderMode mode, Levels levels, WorldSettings.Properties properties) {
-        PreviewComputationCache.TileLease current = this.tileLease;
-        if (current == null || this.closed) return;
-        PreviewCancellation previous = this.pixelCancellation;
-        if (previous != null) previous.cancel();
-        PreviewCancellation cancellation = new PreviewCancellation();
-        this.pixelCancellation = cancellation;
-        long version = this.pixelRequestVersion.incrementAndGet();
-        PreviewComputationCache.TileLease retained = current.retain();
-        BiomePreview.Sidecar sidecar = this.biomes;
-        this.pendingPixelRasterization = CompletableFuture.supplyAsync(() -> {
-            cancellation.check();
-            return this.createPixelData(retained.tile(), sidecar, mode, levels, properties);
-        }, net.minecraft.Util.backgroundExecutor()).whenCompleteAsync((pixels, throwable) -> {
-            try {
-                if (!this.closed && throwable != null && !PreviewCancellation.isCancellation(throwable)
-                        && version == this.pixelRequestVersion.get()
-                        && mode == this.page.renderMode2D.getValue()) {
-                    this.previewFailure = PreviewFailure.log("Failed rasterizing 2D preview", throwable);
-                } else if (!this.closed && throwable == null && !cancellation.isCancelled()
-                        && version == this.pixelRequestVersion.get()
-                        && mode == this.page.renderMode2D.getValue()) {
-                    this.previewFailure = null;
-                    this.uploadPixelData(pixels);
-                }
-            } finally {
-                retained.close();
-            }
-        }, Minecraft.getInstance());
+    @Override
+    public String buildLegendLine(String labelStr, String value) {
+        return "\u00a77(" + labelStr + ")\u00a7r " + value;
     }
 
-    public void close() throws Exception {
-        this.closed = true;
-        PreviewCancellation generation = this.generationCancellation;
-        if (generation != null) generation.cancel();
-        PreviewCancellation pixels = this.pixelCancellation;
-        if (pixels != null) pixels.cancel();
+    @Override
+    public int legendLineX(Font font, String line, float maxWidth) {
+        return 0;
+    }
+
+    @Override
+    public void closeResources() {
         this.texture.close();
-        if (this.tileLease != null) {
-            this.tileLease.close();
-            this.tileLease = null;
-        }
-        this.tile = null;
-        this.previewFailure = null;
-        this.generatedWithBiomePipeline = false;
-        this.preparedContext = null;
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (this.isMouseOver(mouseX, mouseY)) {
-            // Right Click: Navigate to specific coordinates
-            if (button == 1) {
-                if (this.updateLegend((int) mouseX, (int) mouseY) && !this.hoveredCoords.isEmpty()) {
-                    this.playDownSound(Minecraft.getInstance().getSoundManager());
-
-                    WorldSettings.Properties props = this.page.preset.getPreset().world().properties;
-                    if (props.spawnType == SpawnType.CONTINENT_CENTER) {
-                        props.spawnType = SpawnType.USER_SELECTED;
-                        if (this.page instanceof WorldSettingsPage worldPage) {
-                            worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
-                        }
-                    }
-
-                    this.page.setPreviewNavigation(this.hoveredCoordX, this.hoveredCoordZ);
-                    this.regenerate();
-                    return true;
-                }
-            }
-            // Middle Click: Reset to current spawn coordinates
-            else if (button == 2) {
-                this.playDownSound(Minecraft.getInstance().getSoundManager());
-                this.page.resetPreviewNavigation();
-                this.regenerate();
-                return true;
-            }
+        if (handleClick(mouseX, mouseY, button)) {
+            return true;
         }
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
     @Override
-    public boolean isMouseOver(double mouseX, double mouseY) {
-        return super.isMouseOver(mouseX, mouseY);
-    }
-
-    @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
-        if (this.isMouseOver(mouseX, mouseY)) {
-            if (this.page.zoom2D != null) {
-                double currentVal = this.page.zoom2D.getValue();
-                double step = 0.05;
-                double newVal = currentVal;
-
-                if (scrollY > 0) {
-                    newVal = Math.min(1.0, currentVal + step);
-                } else if (scrollY < 0) {
-                    newVal = Math.max(0.0, currentVal - step);
-                }
-
-                this.page.zoom2D.setValue(newVal);
-                this.page.zoom2D.applyValue();
-                this.regenerate();
-            }
+        if (handleScroll(mouseX, mouseY, scrollY)) {
             return true;
         }
         return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
@@ -504,12 +182,12 @@ public class Preview2D extends Button {
         int xPos = this.getX();
         int yPos = this.getY();
 
-        if (this.previewFailure != null) {
+        if (this.state.previewFailure != null) {
             PreviewFailure.renderUnavailable(guiGraphics, xPos, yPos, this.width, this.height);
             return;
         }
 
-        if (this.tile == null) {
+        if (this.state.tile == null) {
             guiGraphics.fill(xPos, yPos, xPos + this.width, yPos + this.height, 0xFF000000);
         } else {
             RenderSystem.enableBlend();
@@ -519,17 +197,17 @@ public class Preview2D extends Button {
         }
 
         renderSpawnMarker(guiGraphics);
-        if (this.biomes != null && this.biomes.warning() != null) {
+        if (this.state.biomes != null && this.state.biomes.warning() != null) {
             guiGraphics.drawCenteredString(
-                Minecraft.getInstance().font,
-                this.biomes.warning(),
-                xPos + this.width / 2,
-                yPos + 4,
-                0xFFFF5555
+                    Minecraft.getInstance().font,
+                    this.state.biomes.warning(),
+                    xPos + this.width / 2,
+                    yPos + 4,
+                    0xFFFF5555
             );
         }
-        this.updateLegend(mx, my);
-        this.renderLegend(guiGraphics, mx, my, this.legendLabels, this.legendValues, xPos, yPos + this.width + 30, 10, 0xFFFFFF);
+        updateLegend(mx, my);
+        renderLegend(guiGraphics, mx, my, this.state.legendLabels, this.state.legendValues, xPos, yPos + this.width + 30, 10, 0xFFFFFF);
     }
 
     private void renderSpawnMarker(GuiGraphics guiGraphics) {
@@ -538,9 +216,9 @@ public class Preview2D extends Button {
         if (props.spawnType == SpawnType.USER_SELECTED || props.spawnType == SpawnType.CONTINENT_CENTER) {
             int currentZoom = this.getZoom();
 
-            if (this.tile != null) {
-                float relX = (float) (props.spawnX - this.centerX) / (this.tile.getBlockSize().size() * currentZoom);
-                float relZ = (float) (props.spawnZ - this.centerZ) / (this.tile.getBlockSize().size() * currentZoom);
+            if (this.state.tile != null) {
+                float relX = (float) (props.spawnX - this.state.centerX) / (this.state.tile.getBlockSize().size() * currentZoom);
+                float relZ = (float) (props.spawnZ - this.state.centerZ) / (this.state.tile.getBlockSize().size() * currentZoom);
 
                 int markerX = this.getX() + (this.width / 2) + (int) (relX * this.width);
                 int markerY = this.getY() + (this.height / 2) + (int) (relZ * this.height);
@@ -562,188 +240,45 @@ public class Preview2D extends Button {
         }
     }
 
-    private boolean updateLegend(int mx, int my) {
-        if (this.tile != null) {
+    @Override
+    public boolean updateLegend(int mx, int my) {
+        if (this.state.tile != null) {
             int left = this.getX();
             int top = this.getY();
             float size = this.width;
 
             int currentZoom = this.getZoom();
-            int width = Math.max(1, this.tile.getBlockSize().size() * currentZoom);
-            int height = Math.max(1, this.tile.getBlockSize().size() * currentZoom);
-            this.legendValues[0] = width + "x" + height;
+            int width = Math.max(1, this.state.tile.getBlockSize().size() * currentZoom);
+            int height = Math.max(1, this.state.tile.getBlockSize().size() * currentZoom);
+            this.state.legendValues[0] = width + "x" + height;
             if (mx >= left && mx <= left + size && my >= top && my <= top + size) {
                 float fx = (mx - left) / size;
                 float fz = (my - top) / size;
-                int maxIndex = this.tile.getBlockSize().size() - 1;
+                int maxIndex = this.state.tile.getBlockSize().size() - 1;
                 int ix = Math.max(0, Math.min(maxIndex, NoiseUtil.round(fx * maxIndex)));
                 int iz = Math.max(0, Math.min(maxIndex, NoiseUtil.round(fz * maxIndex)));
-                Cell cell = this.tile.lookup(ix, iz);
-                this.legendValues[1] = getTerrainName(cell);
-                String biomeId = this.biomes == null ? null : this.biomes.id(ix, iz);
+                Cell cell = this.state.tile.lookup(ix, iz);
+                this.state.legendValues[1] = IPreviewHandler.getTerrainName(cell);
+                String biomeId = this.state.biomes == null ? null : this.state.biomes.id(ix, iz);
+                WorldSettings.Properties properties = this.page.preset.getPreset().world().properties;
                 PreviewDetails.Detail detail = PreviewDetails.forCell(
-                    this.page.renderMode2D.getValue(), cell, new Levels(
-                        this.page.preset.getPreset().world().properties.terrainScaler(),
-                        this.page.preset.getPreset().world().properties.worldDepth,
-                        this.page.preset.getPreset().world().properties.seaLevel
-                    ), biomeId
+                        getRenderMode(), cell, new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel), biomeId
                 );
-                this.legendLabels[2] = detail.label();
-                this.legendValues[2] = detail.value();
-                this.legendValues[3] = getSpawnCoords();
+                this.state.legendLabels[2] = detail.label();
+                this.state.legendValues[2] = detail.value();
+                this.state.legendValues[3] = getSpawnCoords();
 
-                int dx = (ix - (this.tile.getBlockSize().size() / 2)) * currentZoom;
-                int dz = (iz - (this.tile.getBlockSize().size() / 2)) * currentZoom;
+                int dx = (ix - (this.state.tile.getBlockSize().size() / 2)) * currentZoom;
+                int dz = (iz - (this.state.tile.getBlockSize().size() / 2)) * currentZoom;
 
-                this.hoveredCoords = (this.centerX + dx) + ":" + (this.centerZ + dz);
-                this.hoveredCoordX = this.centerX + dx;
-                this.hoveredCoordZ = this.centerZ + dz;
+                this.state.hoveredCoords = (this.state.centerX + dx) + ":" + (this.state.centerZ + dz);
+                this.state.hoveredCoordX = this.state.centerX + dx;
+                this.state.hoveredCoordZ = this.state.centerZ + dz;
                 return true;
             } else {
-                this.hoveredCoords = "";
+                this.state.hoveredCoords = "";
             }
         }
         return false;
-    }
-
-    private float getLegendScale() {
-        int index = this.page.getScreen().minecraft.options.guiScale().get() - 1;
-        if (index < 0 || index >= LEGEND_SCALES.length) {
-            index = LEGEND_SCALES.length - 1;
-        }
-        return LEGEND_SCALES[index];
-    }
-
-    private void renderLegend(GuiGraphics guiGraphics, int mx, int my, Component[] labels, String[] values, int left, int top, int lineHeight, int color) {
-        float scale = this.getLegendScale();
-        PoseStack pose = guiGraphics.pose();
-
-        pose.pushPose();
-        pose.translate(left + 3.75F * scale, top - lineHeight * (3.2F * scale), 0);
-        pose.scale(scale, scale, 1);
-
-        Minecraft mc = Minecraft.getInstance();
-        Font renderer = mc.font;
-
-        float maxWidth = (this.width - 4) / scale;
-
-        for (int i = 0; i < labels.length && i < values.length; i++) {
-            Component label = labels[i];
-            String value = values[i];
-
-            String labelStr = label.getString();
-            if (labelStr.endsWith(": ")) {
-                labelStr = labelStr.substring(0, labelStr.length() - 2);
-            } else if (labelStr.endsWith(":")) {
-                labelStr = labelStr.substring(0, labelStr.length() - 1);
-            }
-
-            String line = "\u00a77(" + labelStr + ")\u00a7r " + value;
-
-            while (line.length() > 0 && renderer.width(line) > maxWidth) {
-                line = line.substring(0, line.length() - 1);
-            }
-
-            int x = 0;
-            guiGraphics.drawString(renderer, line, x, i * lineHeight, color);
-        }
-
-        pose.popPose();
-
-        if (!this.hoveredCoords.isEmpty()) {
-            guiGraphics.drawCenteredString(renderer, this.hoveredCoords, mx, my - 10, 0xFFFFFF);
-        }
-    }
-
-    private int getZoom() {
-        return NoiseUtil.round(1.5F * (101 - (float) this.page.zoom2D.getLerpedValue()));
-    }
-
-    private static String getTerrainName(Cell cell) {
-        if (cell.terrain.isRiver()) {
-            return "river";
-        }
-        return cell.terrain.getName().toLowerCase();
-    }
-
-    private String getSpawnCoords() {
-        WorldSettings.Properties props = this.page.preset.getPreset().world().properties;
-
-        if (props.spawnType == SpawnType.USER_SELECTED) {
-            return "x" + props.spawnX + " z" + props.spawnZ;
-        }
-        if (props.spawnType == SpawnType.CONTINENT_CENTER || props.spawnType == SpawnType.ISLANDS) {
-            return "~x" + this.centerX + " ~z" + this.centerZ;
-        }
-        return "x0 z0";
-    }
-
-    private static class PreGenContext {
-        final GeneratorContext context;
-        final BiomePreview biomePreview;
-        final int cx;
-        final int cz;
-        final int zoomLevel;
-        final PreviewComputationCache.TileKey tileKey;
-
-        final PreviewFailure biomeFailure;
-
-        PreGenContext(GeneratorContext context, BiomePreview biomePreview, int cx, int cz, int zoomLevel, PreviewComputationCache.TileKey tileKey, PreviewFailure biomeFailure) {
-            this.context = context;
-            this.biomePreview = biomePreview;
-            this.cx = cx;
-            this.cz = cz;
-            this.zoomLevel = zoomLevel;
-            this.tileKey = tileKey;
-            this.biomeFailure = biomeFailure;
-        }
-    }
-
-    private static class PreparedContext {
-        final BiomePreview.CacheKey cacheKey;
-        final GeneratorContext context;
-        final HolderLookup.Provider provider;
-        final Preset preset;
-        private BiomePreview biomePreview;
-
-        final boolean biomePipeline;
-
-        PreparedContext(BiomePreview.CacheKey cacheKey, GeneratorContext context, HolderLookup.Provider provider, Preset preset, boolean biomePipeline) {
-            this.cacheKey = cacheKey;
-            this.context = context;
-            this.provider = provider;
-            this.preset = preset;
-            this.biomePipeline = biomePipeline;
-        }
-
-        synchronized void ensureBiomePreview(WorldCreationContext settings) {
-            if (this.biomePreview == null) {
-                this.biomePreview = BiomePreview.create(settings, this.provider, this.preset, this.context);
-            }
-        }
-
-        BiomePreview biomePreview() {
-            return this.biomePreview;
-        }
-    }
-
-    private static class FrameResult {
-        final PreviewComputationCache.TileLease lease;
-        final Tile tile;
-        final BiomePreview.Sidecar biomes;
-        final int centerX;
-        final int centerZ;
-        final int[] pixelData;
-        final PreviewFailure failure;
-
-        FrameResult(PreviewComputationCache.TileLease lease, BiomePreview.Sidecar biomes, int centerX, int centerZ, int[] pixelData, PreviewFailure failure) {
-            this.lease = lease;
-            this.tile = lease.tile();
-            this.biomes = biomes;
-            this.centerX = centerX;
-            this.centerZ = centerZ;
-            this.pixelData = pixelData;
-            this.failure = failure;
-        }
     }
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -1,66 +1,30 @@
 package raccoonman.reterraforged.client.gui.screen.presetconfig;
 
 import java.awt.Color;
-import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+
+import com.mojang.blaze3d.platform.NativeImage;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
-import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
 import net.minecraft.client.renderer.texture.DynamicTexture;
-import net.minecraft.core.HolderGetter;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.chat.CommonComponents;
-import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
-import com.mojang.blaze3d.vertex.PoseStack;
-import com.mojang.blaze3d.platform.NativeImage;
-
-import raccoonman.reterraforged.RTFCommon;
-import raccoonman.reterraforged.client.data.RTFTranslationKeys;
-import raccoonman.reterraforged.config.PerformanceConfig;
-import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.data.worldgen.preset.settings.SpawnType;
 import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
-import raccoonman.reterraforged.registries.RTFRegistries;
-import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
-import raccoonman.reterraforged.world.worldgen.noise.module.Noise;
-import raccoonman.reterraforged.world.worldgen.util.PosUtil;
 
-public class Preview3D extends Button {
-    private static final int FACTOR = 4;
-    public static final int SIZE = (1 << 4) << FACTOR;
-    private static final float[] LEGEND_SCALES = { 1, 0.9F, 0.75F, 0.6F };
-    private static final long REFRESH_DEBOUNCE_MILLIS = 75L;
+public class Preview3D extends Button implements IPreviewHandler {
+    public static final int SIZE = IPreviewHandler.SIZE;
 
-	private RenderMode currentMode = RenderMode.BIOME;
+    private final PresetEditorPage page;
+    private final PreviewState state = new PreviewState();
 
-    private PresetEditorPage page;
-    private Tile tile;
-    private PreviewComputationCache.TileLease tileLease;
-    private BiomePreview.Sidecar biomes;
-    private boolean generatedWithBiomePipeline;
-    private BiomePreview.CacheKey cacheKey;
-    private int centerX, centerZ;
-
-    private int hoveredCoordX = 0;
-    private int hoveredCoordZ = 0;
-    private String hoveredCoords = "";
-    private String[] legendValues = {"", "", "", ""};
-    private final Component[] legendLabels = {
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_AREA),
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_TERRAIN),
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_BIOME),
-            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_SPAWN)
-    };
+    private RenderMode currentMode = RenderMode.BIOME;
 
     private DynamicTexture textureCache;
     private ResourceLocation cacheLocation;
@@ -68,315 +32,86 @@ public class Preview3D extends Button {
     private volatile int[] pendingTexturePixels;
     private volatile int pendingTextureWidth;
     private volatile int pendingTextureHeight;
-    private final AtomicLong textureRequestVersion = new AtomicLong();
-    private volatile PreviewCancellation textureCancellation;
-    private CompletableFuture<?> pendingTextureRasterization;
 
     private int lastHoveredIx = -1;
     private int lastHoveredIz = -1;
 
-    private CompletableFuture<FrameResult> pendingGeneration = null;
-    private volatile PreparedContext preparedContext;
-    private volatile PreviewCancellation generationCancellation;
-    private volatile PreviewFailure previewFailure;
-
-    // Concurrency Gates
-    private boolean isRunning = false;
-    private boolean isDirty = false;
-    private boolean closed = false;
-    private long refreshRequestNanos = 0L;
-
     public Preview3D(PresetEditorPage page, int x, int y, int width, int height) {
-        super(x, y, width, height, CommonComponents.EMPTY, (b) -> {
-            if (b instanceof Preview3D self) {
-                Minecraft mc = Minecraft.getInstance();
-                double guiX = mc.mouseHandler.xpos() * (double) mc.getWindow().getGuiScaledWidth() / (double) mc.getWindow().getWidth();
-                double guiY = mc.mouseHandler.ypos() * (double) mc.getWindow().getGuiScaledHeight() / (double) mc.getWindow().getHeight();
-
-                if (self.updateLegend((int) guiX, (int) guiY) && !self.hoveredCoords.isEmpty()) {
-                    self.playDownSound(Minecraft.getInstance().getSoundManager());
-                    WorldSettings.Properties props = self.page.preset.getPreset().world().properties;
-                    props.spawnType = SpawnType.USER_SELECTED;
-                    props.spawnX = self.hoveredCoordX;
-                    props.spawnZ = self.hoveredCoordZ;
-
-                    if (self.page instanceof WorldSettingsPage worldPage) {
-                        worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
-                    }
-
-                    self.page.resetPreviewNavigation();
-                    self.page.regenerate();
-                }
-            }
-        }, DEFAULT_NARRATION);
-
+        super(x, y, width, height, CommonComponents.EMPTY, IPreviewHandler.onPress(), DEFAULT_NARRATION);
         this.page = page;
-        this.cacheKey = BiomePreview.cacheKey(page.getScreen().getSettings(), page.preset.getPreset());
+        this.state.cacheKey = BiomePreview.cacheKey(page.getScreen().getSettings(), page.preset.getPreset());
     }
 
-    public void regenerate() {
-        PreviewCancellation previous = this.generationCancellation;
-        if (previous != null) previous.cancel();
-        this.generationCancellation = new PreviewCancellation();
-        this.isDirty = true;
-        this.refreshRequestNanos = System.nanoTime();
-        this.scheduleRegeneration();
+    @Override
+    public PreviewState state() {
+        return this.state;
     }
 
-    private void scheduleRegeneration() {
-        long requestNanos = this.refreshRequestNanos;
-        long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - requestNanos);
-        long delayMillis = Math.max(0L, REFRESH_DEBOUNCE_MILLIS - elapsedMillis);
-        CompletableFuture.delayedExecutor(delayMillis, TimeUnit.MILLISECONDS).execute(() ->
-            Minecraft.getInstance().execute(() -> {
-                if (!this.closed && requestNanos == this.refreshRequestNanos && !this.isRunning) {
-                    this.executeRegenerate();
-                }
-            })
-        );
+    @Override
+    public PresetEditorPage page() {
+        return this.page;
     }
 
-    public void refreshRenderMode(RenderMode mode) {
-        currentMode = mode;
-        boolean biomePipeline = mode == RenderMode.BIOME;
-        Tile activeTile = this.tile;
-        BiomePreview.Sidecar activeBiomes = this.biomes;
-        if (activeTile == null
-                || (mode == RenderMode.BIOME && activeBiomes == null)
-                || this.generatedWithBiomePipeline != biomePipeline) {
-            this.regenerate();
-            return;
-        }
-        this.requestTextureRasterization();
+    @Override
+    public void playClickSound() {
+        this.playDownSound(Minecraft.getInstance().getSoundManager());
     }
 
-    private void executeRegenerate() {
-        if (this.closed) return;
-
-        PreviewCancellation request = this.generationCancellation;
-        if (request == null) {
-            request = new PreviewCancellation();
-            this.generationCancellation = request;
-        }
-        final PreviewCancellation cancellation = request;
-
-        this.isRunning = true;
-        this.isDirty = false;
-
-        WorldCreationContext settings;
-        Preset requestedPreset;
-        BiomePreview.CacheKey requestedKey;
-        RenderMode requestedMode;
-        boolean biomePipeline;
-        PreparedContext reusable;
-        HolderLookup.Provider provider;
-        HolderGetter<Noise> noises;
-        Preset currentPreset;
-        try {
-            settings = this.page.getScreen().getSettings();
-            requestedPreset = this.page.preset.getPreset();
-            requestedKey = BiomePreview.cacheKey(settings, requestedPreset);
-            requestedMode = this.page.renderMode3D == null ? currentMode : this.page.renderMode3D.getValue();
-            biomePipeline = requestedMode == RenderMode.BIOME;
-            reusable = this.preparedContext;
-            provider = null;
-            noises = null;
-            currentPreset = requestedPreset;
-            if (reusable == null
-                    || !Objects.equals(reusable.cacheKey, requestedKey)
-                    || reusable.biomePipeline != biomePipeline) {
-                RegistryAccess.Frozen registries = settings.worldgenLoadContext();
-                provider = biomePipeline
-                        ? requestedPreset.buildFullPatch(registries)
-                        : requestedPreset.buildPatch(registries);
-                HolderGetter<Preset> presets = provider.lookupOrThrow(RTFRegistries.PRESET);
-                noises = provider.lookupOrThrow(RTFRegistries.NOISE);
-                currentPreset = presets.getOrThrow(Preset.KEY).value();
-            }
-        } catch (RuntimeException | LinkageError error) {
-            this.isRunning = false;
-            this.previewFailure = PreviewFailure.log("Failed to prepare 3D preview provider", error);
-            if (this.isDirty) {
-                this.scheduleRegeneration();
-            }
-            return;
-        }
-        HolderLookup.Provider preparedProvider = provider;
-        HolderGetter<Noise> preparedNoises = noises;
-        Preset preparedPreset = currentPreset;
-        if (!Objects.equals(this.cacheKey, requestedKey)) {
-            this.cacheKey = requestedKey;
-        }
-
-        int seed = (int) settings.options().seed();
-        int zoomLevel = this.getZoom();
-        int localOffsetX = this.page.previewNavigationX();
-        int localOffsetZ = this.page.previewNavigationZ();
-        boolean localNavigated = this.page.previewNavigated();
-        int renderWidth = this.width;
-        int renderHeight = this.height;
-        double renderZoom = this.page.zoom3D == null ? 95.0D : this.page.zoom3D.getLerpedValue();
-
-        // Step 1: Offload disk IO and heavy context calculations to background executor
-        CompletableFuture<PreGenContext> setupStage = CompletableFuture.supplyAsync(() -> {
-            PreparedContext prepared = reusable;
-            if (prepared == null
-                    || !Objects.equals(prepared.cacheKey, requestedKey)
-                    || prepared.biomePipeline != biomePipeline) {
-                PerformanceConfig config = PerformanceConfig.read(PerformanceConfig.DEFAULT_FILE_PATH)
-                        .resultOrPartial(RTFCommon.LOGGER::error)
-                        .orElseGet(PerformanceConfig::makeDefault);
-                GeneratorContext generatorContext = GeneratorContext.makeUncached(
-                    preparedPreset, preparedNoises, seed, FACTOR, 0, config.batchCount()
-                );
-                prepared = new PreparedContext(requestedKey, generatorContext, preparedProvider, preparedPreset, biomePipeline);
-                this.preparedContext = prepared;
-            }
-            BiomePreview biomePreview = null;
-            PreviewFailure biomeFailure = null;
-            if (biomePipeline) {
-                try {
-                    prepared.ensureBiomePreview(settings);
-                    biomePreview = prepared.biomePreview();
-                } catch (RuntimeException | LinkageError error) {
-                    biomeFailure = PreviewFailure.log("Failed to prepare 3D biome preview", error);
-                }
-            }
-            GeneratorContext generatorContext = prepared.context;
-            WorldSettings.Properties properties = preparedPreset.world().properties;
-            if (properties.spawnType == SpawnType.CONTINENT_CENTER) {
-                long baseContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(0, 0);
-                properties.spawnX = PosUtil.unpackLeft(baseContinentCenter);
-                properties.spawnZ = PosUtil.unpackRight(baseContinentCenter);
-            }
-
-            int cx = 0;
-            int cz = 0;
-
-            // Generalize coordinate selection for all spawn types
-            if (preparedPreset.world().properties.spawnType == SpawnType.CONTINENT_CENTER) {
-                long nearestContinentCenter = generatorContext.lookup.getHeightmap().continent().getNearestCenter(
-                        localNavigated ? localOffsetX : 0,
-                        localNavigated ? localOffsetZ : 0
-                );
-                cx = PosUtil.unpackLeft(nearestContinentCenter);
-                cz = PosUtil.unpackRight(nearestContinentCenter);
-            } else {
-                // If navigated, center on the clicked spot; otherwise fallback to spawn values or origin depending on type
-                cx = localNavigated ? localOffsetX : (preparedPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? preparedPreset.world().properties.spawnX : 0);
-                cz = localNavigated ? localOffsetZ : (preparedPreset.world().properties.spawnType == SpawnType.USER_SELECTED ? preparedPreset.world().properties.spawnZ : 0);
-            }
-
-            PreviewComputationCache.TileKey tileKey = new PreviewComputationCache.TileKey(
-                requestedKey, cx, cz, zoomLevel, Preview3D.SIZE, biomePipeline
-            );
-            return new PreGenContext(generatorContext, biomePreview, cx, cz, zoomLevel, tileKey, biomeFailure);
-        }, net.minecraft.Util.backgroundExecutor());
-
-        // Step 2: Compose into the chunk generator's pipeline
-        this.pendingGeneration = setupStage.thenCompose(preGen -> {
-            cancellation.check();
-            PreviewComputationCache.TileLease cached = this.page.previewCache().acquire(preGen.tileKey);
-            CompletableFuture<PreviewComputationCache.TileLease> tileFuture;
-            if (cached != null) {
-                tileFuture = CompletableFuture.completedFuture(cached);
-            } else {
-                tileFuture = preGen.context.generator.generateZoomed(
-					preGen.cx, preGen.cz, preGen.zoomLevel, biomePipeline, cancellation::isCancelled
-                ).thenApply(newTile -> {
-                    PreviewComputationCache.TileLease stored = this.page.previewCache().store(preGen.tileKey, newTile);
-                    if (stored == null) {
-                        throw new java.util.concurrent.CancellationException("Preview cache closed");
-                    }
-                    return stored;
-                });
-            }
-            return tileFuture.thenApply(lease -> {
-                cancellation.check();
-                Tile generatedTile = lease.tile();
-                try {
-                    WorldSettings.Properties properties = preparedPreset.world().properties;
-                    Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
-                    BiomePreview.Sidecar biomes = null;
-                    PreviewFailure failure = preGen.biomeFailure;
-                    if (failure == null && biomePipeline) {
-                        biomes = preGen.biomePreview.resolveCached(
-                            this.page.previewCache(), generatedTile, preGen.cx, preGen.cz, preGen.zoomLevel, levels, cancellation
-                        );
-                    }
-                    int[] texturePixels = failure == null
-                        ? createTexturePixels(
-                            generatedTile, biomes, requestedMode, levels, properties, renderWidth, renderHeight, renderZoom
-                        )
-                        : null;
-                    return new FrameResult(lease, biomes, preGen.cx, preGen.cz, texturePixels, renderWidth, renderHeight, failure);
-                } catch (Throwable throwable) {
-                    lease.close();
-                    throw throwable;
-                }
-            });
-        });
-
-        // Step 3: Handle execution complete back on the client main render thread
-        this.pendingGeneration.whenCompleteAsync((result, throwable) -> {
-            this.isRunning = false;
-
-            if (this.closed) {
-                if (result != null) result.lease.close();
-                return;
-            }
-
-            if (throwable != null) {
-                if (!PreviewCancellation.isCancellation(throwable)) {
-                    this.previewFailure = PreviewFailure.log("Failed handling 3D preview generation pipeline", throwable);
-                }
-            } else if (!this.isDirty && result != null && result.tile != null
-                    && !cancellation.isCancelled()
-                    && Objects.equals(requestedKey, this.cacheKey)
-                    && requestedMode == this.page.renderMode3D.getValue()) {
-                PreviewComputationCache.TileLease previousLease = this.tileLease;
-                this.tileLease = result.lease;
-                this.tile = result.lease.tile();
-                this.biomes = result.biomes;
-                this.generatedWithBiomePipeline = biomePipeline;
-                this.centerX = result.centerX;
-                this.centerZ = result.centerZ;
-                this.previewFailure = result.failure;
-
-                this.legendValues[3] = getSpawnCoords();
-                if (result.failure == null && result.textureWidth == this.width && result.textureHeight == this.height) {
-                    this.pendingTexturePixels = result.texturePixels;
-                    this.pendingTextureWidth = result.textureWidth;
-                    this.pendingTextureHeight = result.textureHeight;
-                    this.needsTextureRefresh = true;
-                } else if (result.failure == null) {
-                    this.requestTextureRasterization();
-                }
-
-                this.lastHoveredIx = -1;
-                this.lastHoveredIz = -1;
-                if (previousLease != null) previousLease.close();
-            } else if (result != null && result.tile != null) {
-                result.lease.close();
-            }
-
-            // If the user modified values while this task was running, consume the change state immediately
-            if (this.isDirty) {
-                this.scheduleRegeneration();
-            }
-        }, Minecraft.getInstance());
+    @Override
+    public String getFailureLabel() {
+        return "3D";
     }
 
-    private int[] createTexturePixels(
-        Tile activeTile,
-        BiomePreview.Sidecar activeBiomes,
-        RenderMode mode,
-        Levels levels,
-        WorldSettings.Properties properties,
-        int width,
-        int height,
-        double zoomValue
-    ) {
+    @Override
+    public void onRenderModeChanged(RenderMode mode) {
+        this.currentMode = mode;
+    }
+
+    @Override
+    public RenderMode getRenderMode() {
+        return this.page.renderMode3D == null ? this.currentMode : this.page.renderMode3D.getValue();
+    }
+
+    @Override
+    public int getZoom() {
+        return NoiseUtil.round(1.5F * (101 - (float) this.page.zoom3D.getLerpedValue()));
+    }
+
+    @Override
+    public boolean hasZoomControl() {
+        return this.page.zoom3D != null;
+    }
+
+    @Override
+    public double getZoomValue() {
+        return this.page.zoom3D.getValue();
+    }
+
+    @Override
+    public void setZoomValue(double value) {
+        this.page.zoom3D.setValue(value);
+    }
+
+    @Override
+    public void applyZoomValue() {
+        this.page.zoom3D.applyValue();
+    }
+
+    @Override
+    public RasterParams captureRasterParams() {
+        double zoomValue = this.page.zoom3D == null ? 95.0D : this.page.zoom3D.getLerpedValue();
+        return new RasterParams(this.width, this.height, zoomValue);
+    }
+
+    @Override
+    public boolean rasterizationBlocked() {
+        return this.width <= 0 || this.height <= 0;
+    }
+
+    @Override
+    public int[] createRasterData(Tile activeTile, BiomePreview.Sidecar activeBiomes, RenderMode mode, Levels levels, WorldSettings.Properties properties, RasterParams params) {
+        int width = params.width;
+        int height = params.height;
         if (activeTile == null || width <= 0 || height <= 0) return new int[0];
         int[] pixels = new int[width * height];
         java.util.Arrays.fill(pixels, 0xFF000000);
@@ -389,7 +124,7 @@ public class Preview3D extends Button {
         int blockH = halfH * 2;
         int centerVisualX = width / 2;
         int centerVisualY = height / 2;
-        float heightScale = getHeightScale((float) blockW, zoomValue);
+        float heightScale = getHeightScale((float) blockW, params.zoom);
         int halfTile = tileSize / 2;
         float maxCellHeight = properties.worldHeight * levels.unit;
         float[] hsb = new float[3];
@@ -414,9 +149,9 @@ public class Preview3D extends Button {
                 hsb[2] = Math.max(0.0f, Math.min(1.0f, hsb[2] + jitter));
                 int jitteredRgb = Color.HSBtoRGB(hsb[0], hsb[1], hsb[2]);
                 int jitteredColor = (color & 0xFF000000)
-                    | (jitteredRgb >> 16 & 0xFF)
-                    | (jitteredRgb >> 8 & 0xFF) << 8
-                    | (jitteredRgb & 0xFF) << 16;
+                        | (jitteredRgb >> 16 & 0xFF)
+                        | (jitteredRgb >> 8 & 0xFF) << 8
+                        | (jitteredRgb & 0xFF) << 16;
                 int dx = ix - halfTile;
                 int dz = iz - halfTile;
                 int isoX = centerVisualX + (dx - dz) * halfW;
@@ -433,6 +168,32 @@ public class Preview3D extends Button {
         return pixels;
     }
 
+    @Override
+    public void applyGeneratedFrame(FrameResult result) {
+        if (result.rasterWidth == this.width && result.rasterHeight == this.height) {
+            this.pendingTexturePixels = result.rasterPayload;
+            this.pendingTextureWidth = result.rasterWidth;
+            this.pendingTextureHeight = result.rasterHeight;
+            this.needsTextureRefresh = true;
+        } else {
+            requestRasterization();
+        }
+    }
+
+    @Override
+    public void applyRasterizedPixels(int[] pixels, RasterParams params) {
+        this.pendingTexturePixels = pixels;
+        this.pendingTextureWidth = params.width;
+        this.pendingTextureHeight = params.height;
+        this.needsTextureRefresh = true;
+    }
+
+    @Override
+    public void onFrameApplied() {
+        this.lastHoveredIx = -1;
+        this.lastHoveredIz = -1;
+    }
+
     private static void fillPixelRect(int[] pixels, int width, int xStart, int yStart, int xEnd, int yEnd, int nativeColor) {
         int startX = Math.max(0, xStart);
         int endX = Math.min(width, xEnd);
@@ -444,46 +205,6 @@ public class Preview3D extends Button {
                 pixels[y * width + x] = nativeColor;
             }
         }
-    }
-
-    private void requestTextureRasterization() {
-        PreviewComputationCache.TileLease current = this.tileLease;
-        if (current == null || this.closed || this.width <= 0 || this.height <= 0) return;
-        PreviewCancellation previous = this.textureCancellation;
-        if (previous != null) previous.cancel();
-        PreviewCancellation cancellation = new PreviewCancellation();
-        this.textureCancellation = cancellation;
-        long version = this.textureRequestVersion.incrementAndGet();
-        PreviewComputationCache.TileLease retained = current.retain();
-        RenderMode mode = this.page.renderMode3D == null ? currentMode : this.page.renderMode3D.getValue();
-        WorldSettings.Properties properties = this.page.preset.getPreset().world().properties;
-        Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
-        int width = this.width;
-        int height = this.height;
-        double zoomValue = this.page.zoom3D == null ? 95.0D : this.page.zoom3D.getLerpedValue();
-        BiomePreview.Sidecar sidecar = this.biomes;
-        this.pendingTextureRasterization = CompletableFuture.supplyAsync(() -> {
-            cancellation.check();
-            return this.createTexturePixels(retained.tile(), sidecar, mode, levels, properties, width, height, zoomValue);
-        }, net.minecraft.Util.backgroundExecutor()).whenCompleteAsync((pixels, throwable) -> {
-            try {
-                if (!this.closed && throwable != null && !PreviewCancellation.isCancellation(throwable)
-                        && version == this.textureRequestVersion.get()
-                        && mode == (this.page.renderMode3D == null ? currentMode : this.page.renderMode3D.getValue())) {
-                    this.previewFailure = PreviewFailure.log("Failed rasterizing 3D preview", throwable);
-                } else if (!this.closed && throwable == null && !cancellation.isCancelled()
-                        && version == this.textureRequestVersion.get()
-                        && mode == (this.page.renderMode3D == null ? currentMode : this.page.renderMode3D.getValue())) {
-                    this.previewFailure = null;
-                    this.pendingTexturePixels = pixels;
-                    this.pendingTextureWidth = width;
-                    this.pendingTextureHeight = height;
-                    this.needsTextureRefresh = true;
-                }
-            } finally {
-                retained.close();
-            }
-        }, Minecraft.getInstance());
     }
 
     private void uploadPendingTexture() {
@@ -517,87 +238,37 @@ public class Preview3D extends Button {
         return (a << 24) | (r << 16) | (g << 8) | b;
     }
 
-    public void close() throws Exception {
-        this.closed = true;
-        PreviewCancellation generation = this.generationCancellation;
-        if (generation != null) generation.cancel();
-        PreviewCancellation texture = this.textureCancellation;
-        if (texture != null) texture.cancel();
+    @Override
+    public void closeResources() {
         if (this.textureCache != null) {
             this.textureCache.close();
             Minecraft.getInstance().getTextureManager().release(this.cacheLocation);
             this.textureCache = null;
             this.cacheLocation = null;
         }
-        if (this.tileLease != null) {
-            this.tileLease.close();
-            this.tileLease = null;
-        }
-        this.tile = null;
-        this.previewFailure = null;
-        this.generatedWithBiomePipeline = false;
-        this.preparedContext = null;
+    }
+
+    @Override
+    public String buildLegendLine(String labelStr, String value) {
+        return value + " \u00a77(" + labelStr + ")";
+    }
+
+    @Override
+    public int legendLineX(Font font, String line, float maxWidth) {
+        return (int) (maxWidth - font.width(line));
     }
 
     @Override
     public boolean mouseClicked(double mouseX, double mouseY, int button) {
-        if (this.isMouseOver(mouseX, mouseY)) {
-
-            // Right Click: Navigate to specific coordinates
-            if (button == 1) {
-                if (this.updateLegend((int) mouseX, (int) mouseY) && !this.hoveredCoords.isEmpty()) {
-                    this.playDownSound(Minecraft.getInstance().getSoundManager());
-
-                    WorldSettings.Properties props = this.page.preset.getPreset().world().properties;
-                    if (props.spawnType == SpawnType.CONTINENT_CENTER) {
-                        props.spawnType = SpawnType.USER_SELECTED;
-                        if (this.page instanceof WorldSettingsPage worldPage) {
-                            worldPage.spawnType.setValue(SpawnType.USER_SELECTED);
-                        }
-                    }
-
-                    this.page.setPreviewNavigation(this.hoveredCoordX, this.hoveredCoordZ);
-                    this.regenerate();
-                    return true;
-                }
-            }
-
-            // Middle Click: Reset to current spawn coordinates
-            else if (button == 2) {
-                this.playDownSound(Minecraft.getInstance().getSoundManager());
-                this.page.resetPreviewNavigation();
-                this.regenerate();
-                return true;
-            }
+        if (handleClick(mouseX, mouseY, button)) {
+            return true;
         }
-
-        // Left click set spawn coords
         return super.mouseClicked(mouseX, mouseY, button);
     }
 
     @Override
-    public boolean isMouseOver(double mouseX, double mouseY) {
-        return super.isMouseOver(mouseX, mouseY);
-    }
-
-    @Override
     public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
-        if (this.isMouseOver(mouseX, mouseY)) {
-            if (this.page.zoom3D != null) {
-                double currentVal = this.page.zoom3D.getValue();
-                double step = 0.05;
-                double newVal = currentVal;
-
-                if (scrollY > 0) {
-                    newVal = Math.min(1.0, currentVal + step);
-                } else if (scrollY < 0) {
-                    newVal = Math.max(0.0, currentVal - step);
-                }
-
-                this.page.zoom3D.setValue(newVal);
-                this.page.zoom3D.applyValue();
-                this.regenerate();
-            }
+        if (handleScroll(mouseX, mouseY, scrollY)) {
             return true;
         }
         return super.mouseScrolled(mouseX, mouseY, scrollX, scrollY);
@@ -608,12 +279,12 @@ public class Preview3D extends Button {
         int x = this.getX();
         int y = this.getY();
 
-        if (this.previewFailure != null) {
+        if (this.state.previewFailure != null) {
             PreviewFailure.renderUnavailable(guiGraphics, x, y, this.width, this.height);
             return;
         }
 
-        if (this.tile != null && this.needsTextureRefresh) {
+        if (this.state.tile != null && this.needsTextureRefresh) {
             this.uploadPendingTexture();
         }
 
@@ -624,18 +295,18 @@ public class Preview3D extends Button {
         }
 
         renderSpawnMarker(guiGraphics);
-        BiomePreview.Sidecar activeBiomes = this.biomes;
+        BiomePreview.Sidecar activeBiomes = this.state.biomes;
         if (activeBiomes != null && activeBiomes.warning() != null) {
             guiGraphics.drawCenteredString(
-                Minecraft.getInstance().font,
-                activeBiomes.warning(),
-                x + this.width / 2,
-                y + 4,
-                0xFFFF5555
+                    Minecraft.getInstance().font,
+                    activeBiomes.warning(),
+                    x + this.width / 2,
+                    y + 4,
+                    0xFFFF5555
             );
         }
-        this.updateLegend(mx, my);
-        this.renderLegend(guiGraphics, mx, my, this.legendLabels, this.legendValues, x, y + this.width + 30, 10, 0xFFFFFF);
+        updateLegend(mx, my);
+        renderLegend(guiGraphics, mx, my, this.state.legendLabels, this.state.legendValues, x, y + this.width + 30, 10, 0xFFFFFF);
     }
 
     private static float getHeightScale(float blockW, double zoomValue) {
@@ -659,15 +330,15 @@ public class Preview3D extends Button {
 
         if (props.spawnType == SpawnType.USER_SELECTED || props.spawnType == SpawnType.CONTINENT_CENTER) {
             int zoomValue = this.getZoom();
-            Tile activeTile = this.tile;
+            Tile activeTile = this.state.tile;
             int tileSize = activeTile != null ? activeTile.getBlockSize().size() : 0;
 
             if (tileSize > 0) {
-                int activeCX = this.centerX;
-                int activeCZ = this.centerZ;
+                int activeCX = this.state.centerX;
+                int activeCZ = this.state.centerZ;
 
-                int ix = NoiseUtil.round(((float)(props.spawnX - activeCX) / zoomValue) + (tileSize / 2.0f));
-                int iz = NoiseUtil.round(((float)(props.spawnZ - activeCZ) / zoomValue) + (tileSize / 2.0f));
+                int ix = NoiseUtil.round(((float) (props.spawnX - activeCX) / zoomValue) + (tileSize / 2.0f));
+                int iz = NoiseUtil.round(((float) (props.spawnZ - activeCZ) / zoomValue) + (tileSize / 2.0f));
 
                 if (ix >= 0 && ix < tileSize && iz >= 0 && iz < tileSize) {
                     Cell cell = activeTile.lookup(ix, iz);
@@ -712,13 +383,14 @@ public class Preview3D extends Button {
         if (this.width != width || this.height != height) {
             this.width = width;
             this.height = height;
-            this.requestTextureRasterization();
+            requestRasterization();
         }
     }
 
-    private boolean updateLegend(int mx, int my) {
-        Tile activeTile = this.tile;
-        BiomePreview.Sidecar activeBiomes = this.biomes;
+    @Override
+    public boolean updateLegend(int mx, int my) {
+        Tile activeTile = this.state.tile;
+        BiomePreview.Sidecar activeBiomes = this.state.biomes;
         if (activeTile != null) {
             int left = this.getX();
             int top = this.getY();
@@ -728,10 +400,10 @@ public class Preview3D extends Button {
 
             int totalWidth = Math.max(1, tileSize * zoomValue);
             int totalHeight = Math.max(1, tileSize * zoomValue);
-            this.legendValues[0] = totalWidth + "x" + totalHeight;
+            this.state.legendValues[0] = totalWidth + "x" + totalHeight;
 
             if (mx < left || mx >= left + this.width || my < top || my >= top + this.height) {
-                this.hoveredCoords = "";
+                this.state.hoveredCoords = "";
                 this.lastHoveredIx = -1;
                 this.lastHoveredIz = -1;
                 return false;
@@ -759,185 +431,35 @@ public class Preview3D extends Button {
                     this.lastHoveredIz = iz;
 
                     Cell cell = activeTile.lookup(ix, iz);
-                    this.legendValues[1] = getTerrainName(cell);
+                    this.state.legendValues[1] = IPreviewHandler.getTerrainName(cell);
                     String biomeId = activeBiomes == null ? null : activeBiomes.id(ix, iz);
                     WorldSettings.Properties properties = this.page.preset.getPreset().world().properties;
                     PreviewDetails.Detail detail = PreviewDetails.forCell(
-                        this.page.renderMode3D.getValue(), cell,
-                        new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel),
-                        biomeId
+                            getRenderMode(), cell,
+                            new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel),
+                            biomeId
                     );
-                    this.legendLabels[2] = detail.label();
-                    this.legendValues[2] = detail.value();
+                    this.state.legendLabels[2] = detail.label();
+                    this.state.legendValues[2] = detail.value();
 
-                    int activeCX = this.centerX;
-                    int activeCZ = this.centerZ;
-                    this.legendValues[3] = getSpawnCoords(activeCX, activeCZ);
+                    int activeCX = this.state.centerX;
+                    int activeCZ = this.state.centerZ;
+                    this.state.legendValues[3] = getSpawnCoords(activeCX, activeCZ);
 
                     int worldOffsetX = (ix - (tileSize / 2)) * zoomValue;
                     int worldOffsetZ = (iz - (tileSize / 2)) * zoomValue;
 
-                    this.hoveredCoords = (activeCX + worldOffsetX) + ":" + (activeCZ + worldOffsetZ);
-                    this.hoveredCoordX = activeCX + worldOffsetX;
-                    this.hoveredCoordZ = activeCZ + worldOffsetZ;
+                    this.state.hoveredCoords = (activeCX + worldOffsetX) + ":" + (activeCZ + worldOffsetZ);
+                    this.state.hoveredCoordX = activeCX + worldOffsetX;
+                    this.state.hoveredCoordZ = activeCZ + worldOffsetZ;
                 }
                 return true;
             } else {
-                this.hoveredCoords = "";
+                this.state.hoveredCoords = "";
                 this.lastHoveredIx = -1;
                 this.lastHoveredIz = -1;
             }
         }
         return false;
-    }
-
-    private float getLegendScale() {
-        int index = this.page.getScreen().minecraft.options.guiScale().get() - 1;
-        if (index < 0 || index >= LEGEND_SCALES.length) {
-            index = LEGEND_SCALES.length - 1;
-        }
-        return LEGEND_SCALES[index];
-    }
-
-    private void renderLegend(GuiGraphics guiGraphics, int mx, int my, Component[] labels, String[] values, int left, int top, int lineHeight, int color) {
-        float scale = this.getLegendScale();
-        PoseStack pose = guiGraphics.pose();
-
-        pose.pushPose();
-        pose.translate(left + 3.75F * scale, top - lineHeight * (3.2F * scale), 0);
-        pose.scale(scale, scale, 1);
-
-        Minecraft mc = Minecraft.getInstance();
-        Font renderer = mc.font;
-
-        float maxWidth = (this.width - 4) / scale;
-
-        for (int i = 0; i < labels.length && i < values.length; i++) {
-            Component label = labels[i];
-            String value = values[i];
-
-            String labelStr = label.getString();
-            if (labelStr.endsWith(": ")) {
-                labelStr = labelStr.substring(0, labelStr.length() - 2);
-            } else if (labelStr.endsWith(":")) {
-                labelStr = labelStr.substring(0, labelStr.length() - 1);
-            }
-
-            String line = value + " \u00a77(" + labelStr + ")";
-
-            while (line.length() > 0 && renderer.width(line) > maxWidth) {
-                line = line.substring(0, line.length() - 1);
-            }
-
-            int x = (int) (maxWidth - renderer.width(line));
-            guiGraphics.drawString(renderer, line, x, i * lineHeight, color);
-        }
-
-        pose.popPose();
-
-        if (!this.hoveredCoords.isEmpty()) {
-            guiGraphics.drawCenteredString(renderer, this.hoveredCoords, mx, my - 10, 0xFFFFFF);
-        }
-    }
-
-    private int getZoom() {
-        return NoiseUtil.round(1.5F * (101 - (float) this.page.zoom3D.getLerpedValue()));
-    }
-
-    private static String getTerrainName(Cell cell) {
-        if (cell.terrain.isRiver()) {
-            return "river";
-        }
-        return cell.terrain.getName().toLowerCase();
-    }
-
-    private String getSpawnCoords() {
-        int activeCX = this.centerX;
-        int activeCZ = this.centerZ;
-        return getSpawnCoords(activeCX, activeCZ);
-    }
-
-    private String getSpawnCoords(int cx, int cz) {
-        WorldSettings.Properties props = this.page.preset.getPreset().world().properties;
-        if (props.spawnType == SpawnType.USER_SELECTED) {
-            return "x" + props.spawnX + " z" + props.spawnZ;
-        }
-        if (props.spawnType == SpawnType.CONTINENT_CENTER || props.spawnType == SpawnType.ISLANDS) {
-            return "~x" + cx + " ~z" + cz;
-        }
-        return "x0 z0";
-    }
-
-    private static class PreGenContext {
-        final GeneratorContext context;
-        final BiomePreview biomePreview;
-        final int cx;
-        final int cz;
-        final int zoomLevel;
-        final PreviewComputationCache.TileKey tileKey;
-
-        final PreviewFailure biomeFailure;
-
-        PreGenContext(GeneratorContext context, BiomePreview biomePreview, int cx, int cz, int zoomLevel, PreviewComputationCache.TileKey tileKey, PreviewFailure biomeFailure) {
-            this.context = context;
-            this.biomePreview = biomePreview;
-            this.cx = cx;
-            this.cz = cz;
-            this.zoomLevel = zoomLevel;
-            this.tileKey = tileKey;
-            this.biomeFailure = biomeFailure;
-        }
-    }
-
-    private static class PreparedContext {
-        final BiomePreview.CacheKey cacheKey;
-        final GeneratorContext context;
-        final HolderLookup.Provider provider;
-        final Preset preset;
-        private BiomePreview biomePreview;
-
-        final boolean biomePipeline;
-
-        PreparedContext(BiomePreview.CacheKey cacheKey, GeneratorContext context, HolderLookup.Provider provider, Preset preset, boolean biomePipeline) {
-            this.cacheKey = cacheKey;
-            this.context = context;
-            this.provider = provider;
-            this.preset = preset;
-            this.biomePipeline = biomePipeline;
-        }
-
-        synchronized void ensureBiomePreview(WorldCreationContext settings) {
-            if (this.biomePreview == null) {
-                this.biomePreview = BiomePreview.create(settings, this.provider, this.preset, this.context);
-            }
-        }
-
-        BiomePreview biomePreview() {
-            return this.biomePreview;
-        }
-    }
-
-    private static class FrameResult {
-        final PreviewComputationCache.TileLease lease;
-        final Tile tile;
-        final BiomePreview.Sidecar biomes;
-        final int centerX;
-        final int centerZ;
-        final int[] texturePixels;
-        final int textureWidth;
-        final int textureHeight;
-        final PreviewFailure failure;
-
-        FrameResult(PreviewComputationCache.TileLease lease, BiomePreview.Sidecar biomes, int centerX, int centerZ, int[] texturePixels, int textureWidth, int textureHeight, PreviewFailure failure) {
-            this.lease = lease;
-            this.tile = lease.tile();
-            this.biomes = biomes;
-            this.centerX = centerX;
-            this.centerZ = centerZ;
-            this.texturePixels = texturePixels;
-            this.textureWidth = textureWidth;
-            this.textureHeight = textureHeight;
-            this.failure = failure;
-        }
     }
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewState.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewState.java
@@ -1,0 +1,47 @@
+package raccoonman.reterraforged.client.gui.screen.presetconfig;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+
+import net.minecraft.network.chat.Component;
+import raccoonman.reterraforged.client.data.RTFTranslationKeys;
+import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
+
+/**
+ * Mutable state shared by every IPreviewHandler. Preview2D and Preview3D each own a
+ * single instance of this class instead of duplicating the same fields, so all the shared
+ * default logic on the interface has somewhere to read and write.
+ */
+final class PreviewState {
+    final Component[] legendLabels = {
+            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_AREA),
+            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_TERRAIN),
+            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_BIOME),
+            Component.translatable(RTFTranslationKeys.GUI_LABEL_PREVIEW_SPAWN)
+    };
+    final String[] legendValues = {"", "", "", ""};
+
+    Tile tile;
+    PreviewComputationCache.TileLease tileLease;
+    BiomePreview.Sidecar biomes;
+    boolean generatedWithBiomePipeline;
+    BiomePreview.CacheKey cacheKey;
+    int centerX, centerZ;
+    int hoveredCoordX, hoveredCoordZ;
+    String hoveredCoords = "";
+
+    CompletableFuture<IPreviewHandler.FrameResult> pendingGeneration;
+    volatile IPreviewHandler.PreparedContext preparedContext;
+    volatile PreviewCancellation generationCancellation;
+    volatile PreviewFailure previewFailure;
+
+    // On-demand rasterization (re-render current tile without a full regenerate)
+    volatile PreviewCancellation rasterCancellation;
+    final AtomicLong rasterRequestVersion = new AtomicLong();
+    CompletableFuture<?> pendingRasterization;
+
+    boolean isRunning;
+    boolean isDirty;
+    boolean closed;
+    long refreshRequestNanos;
+}


### PR DESCRIPTION
The Preview2D and Preview3d class split I originally did was more experimental meant as a personal debugging tool rather than originally intended for mass consumption. The job I did was known dirty and a little hacky. Since then it has demonstrated significant value (leading to its full incorporation) which means I now want need to revisit it to ensure it's a bit cleaner and tidier to maintain moving forwards. Some of the recent changes have significantly increased the surrounding codes complexity motivating the further change.

The 2D and 3D previews share a lot of common code, particularly around backing state and controls. Really, they should only be varying by how the display the same underlying data, and it should be easier to generate additional previews that display the same data differently.

This PR splits all the shared functionality out to an interface, dropping the size and complexity of the preview classes significantly.

---

I have retested all known preview functionality
- [x] Validated each mode displays data correctly
- [x] Validated existing performance optimisations were carried over to the common implementation
- [x] Validated legends update correctly
- [x] Validated mouse interactions behave correctly
- [x] Validated no crashes hangs or weirdness across multiple extreme presets
- [x] Validate navigating to extreme coordinates behaves sensibly
- [x] No user facing visible symptoms of the change