### PR TITLE
fix: Preview flicker

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetListPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PresetListPage.java
@@ -287,6 +287,10 @@ class PresetListPage extends BisectedPage<PresetConfigScreen, AbstractWidget, Ab
 	}
 
 	private void selectPreset(@Nullable PresetEntry entry) {
+		// Clear 2D and 3D preview buffers to black on selection change
+		Preview2D.resetToBlack();
+		Preview3D.resetToBlack();
+
 		// Sync list widget selection first so input callbacks recognize the selected entry
 		if (this.left != null) {
 			if (entry != null) {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -22,25 +22,37 @@ import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
 public class Preview2D extends Button implements IPreviewHandler {
     public static final int SIZE = IPreviewHandler.SIZE;
 
+    // Statically cached backing texture shared across widget instances
+    private static DynamicTexture STATIC_TEXTURE;
+    private static ResourceLocation STATIC_TEXTURE_ID;
+
     private final PresetEditorPage page;
     private final PreviewState state = new PreviewState();
-
-    private final DynamicTexture texture;
-    private final ResourceLocation textureId;
 
     public Preview2D(PresetEditorPage parent, int x, int y, int width, int height) {
         super(x, y, width, height, CommonComponents.EMPTY, IPreviewHandler.onPress(), DEFAULT_NARRATION);
         this.page = parent;
         this.state.cacheKey = BiomePreview.cacheKey(parent.getScreen().getSettings(), parent.preset.getPreset());
 
-        this.texture = new DynamicTexture(new NativeImage(SIZE, SIZE, false));
-        this.textureId = Minecraft.getInstance().getTextureManager().register(RTFCommon.MOD_ID + "-preview-framebuffer", this.texture);
+        // Ensure static texture is initialized
+        getOrCreateTexture();
+    }
 
-        NativeImage pixels = this.texture.getPixels();
-        if (pixels != null) {
-            pixels.fillRect(0, 0, SIZE, SIZE, 0xFF000000);
-            this.texture.upload();
+    private static ResourceLocation getOrCreateTexture() {
+        if (STATIC_TEXTURE == null) {
+            STATIC_TEXTURE = new DynamicTexture(new NativeImage(SIZE, SIZE, false));
+            STATIC_TEXTURE_ID = Minecraft.getInstance().getTextureManager().register(
+                    RTFCommon.MOD_ID + "-preview-framebuffer",
+                    STATIC_TEXTURE
+            );
+
+            NativeImage pixels = STATIC_TEXTURE.getPixels();
+            if (pixels != null) {
+                pixels.fillRect(0, 0, SIZE, SIZE, 0xFF000000);
+                STATIC_TEXTURE.upload();
+            }
         }
+        return STATIC_TEXTURE_ID;
     }
 
     @Override
@@ -134,7 +146,10 @@ public class Preview2D extends Button implements IPreviewHandler {
     }
 
     private void uploadPixelData(int[] pixelData) {
-        NativeImage pixels = this.texture.getPixels();
+        if (STATIC_TEXTURE == null) {
+            getOrCreateTexture();
+        }
+        NativeImage pixels = STATIC_TEXTURE.getPixels();
         if (pixels == null || pixelData == null) return;
 
         int tileWidth = (int) Math.sqrt(pixelData.length);
@@ -143,7 +158,7 @@ public class Preview2D extends Button implements IPreviewHandler {
                 pixels.setPixelRGBA(bx, bz, pixelData[bz * tileWidth + bx]);
             }
         }
-        this.texture.upload();
+        STATIC_TEXTURE.upload();
     }
 
     @Override
@@ -158,7 +173,7 @@ public class Preview2D extends Button implements IPreviewHandler {
 
     @Override
     public void closeResources() {
-        this.texture.close();
+        // Keep STATIC_TEXTURE alive across page rebuilds.
     }
 
     @Override
@@ -187,14 +202,12 @@ public class Preview2D extends Button implements IPreviewHandler {
             return;
         }
 
-        if (this.state.tile == null) {
-            guiGraphics.fill(xPos, yPos, xPos + this.width, yPos + this.height, 0xFF000000);
-        } else {
-            RenderSystem.enableBlend();
-            RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
-            RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
-            guiGraphics.blit(this.textureId, xPos, yPos, 0, 0, this.width, this.height, this.width, this.height);
-        }
+        // Always blit the static texture (preserves the previous page's rendered frame
+        // while the new page tile generates in the background)
+        RenderSystem.enableBlend();
+        RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ZERO);
+        RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        guiGraphics.blit(getOrCreateTexture(), xPos, yPos, 0, 0, this.width, this.height, this.width, this.height);
 
         renderSpawnMarker(guiGraphics);
         if (this.state.biomes != null && this.state.biomes.warning() != null) {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -294,4 +294,14 @@ public class Preview2D extends Button implements IPreviewHandler {
         }
         return false;
     }
+
+    public static void resetToBlack() {
+        if (STATIC_TEXTURE != null) {
+            NativeImage pixels = STATIC_TEXTURE.getPixels();
+            if (pixels != null) {
+                pixels.fillRect(0, 0, SIZE, SIZE, 0xFF000000);
+                STATIC_TEXTURE.upload();
+            }
+        }
+    }
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -463,4 +463,14 @@ public class Preview3D extends Button implements IPreviewHandler {
         }
         return false;
     }
+
+    public static void resetToBlack() {
+        if (STATIC_TEXTURE_CACHE != null) {
+            NativeImage pixels = STATIC_TEXTURE_CACHE.getPixels();
+            if (pixels != null) {
+                pixels.fillRect(0, 0, pixels.getWidth(), pixels.getHeight(), 0xFF000000);
+                STATIC_TEXTURE_CACHE.upload();
+            }
+        }
+    }
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -21,13 +21,15 @@ import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
 public class Preview3D extends Button implements IPreviewHandler {
     public static final int SIZE = IPreviewHandler.SIZE;
 
+    // Statically cached backing texture shared across widget instances
+    private static DynamicTexture STATIC_TEXTURE_CACHE;
+    private static ResourceLocation STATIC_CACHE_LOCATION;
+
     private final PresetEditorPage page;
     private final PreviewState state = new PreviewState();
 
     private RenderMode currentMode = RenderMode.BIOME;
 
-    private DynamicTexture textureCache;
-    private ResourceLocation cacheLocation;
     private boolean needsTextureRefresh = false;
     private volatile int[] pendingTexturePixels;
     private volatile int pendingTextureWidth;
@@ -210,22 +212,26 @@ public class Preview3D extends Button implements IPreviewHandler {
     private void uploadPendingTexture() {
         int[] pixels = this.pendingTexturePixels;
         if (pixels == null || this.pendingTextureWidth <= 0 || this.pendingTextureHeight <= 0) return;
-        if (this.textureCache == null || this.textureCache.getPixels().getWidth() != this.pendingTextureWidth
-                || this.textureCache.getPixels().getHeight() != this.pendingTextureHeight) {
-            if (this.textureCache != null) {
-                this.textureCache.close();
-                Minecraft.getInstance().getTextureManager().release(this.cacheLocation);
+
+        if (STATIC_TEXTURE_CACHE == null
+                || STATIC_TEXTURE_CACHE.getPixels().getWidth() != this.pendingTextureWidth
+                || STATIC_TEXTURE_CACHE.getPixels().getHeight() != this.pendingTextureHeight) {
+
+            if (STATIC_TEXTURE_CACHE != null) {
+                STATIC_TEXTURE_CACHE.close();
+                Minecraft.getInstance().getTextureManager().release(STATIC_CACHE_LOCATION);
             }
-            this.textureCache = new DynamicTexture(new NativeImage(this.pendingTextureWidth, this.pendingTextureHeight, true));
-            this.cacheLocation = Minecraft.getInstance().getTextureManager().register("rtf_preview_cache_" + this.hashCode(), this.textureCache);
+            STATIC_TEXTURE_CACHE = new DynamicTexture(new NativeImage(this.pendingTextureWidth, this.pendingTextureHeight, true));
+            STATIC_CACHE_LOCATION = Minecraft.getInstance().getTextureManager().register("rtf_preview_cache_3d", STATIC_TEXTURE_CACHE);
         }
-        NativeImage image = this.textureCache.getPixels();
+
+        NativeImage image = STATIC_TEXTURE_CACHE.getPixels();
         for (int y = 0; y < this.pendingTextureHeight; y++) {
             for (int x = 0; x < this.pendingTextureWidth; x++) {
                 image.setPixelRGBA(x, y, pixels[y * this.pendingTextureWidth + x]);
             }
         }
-        this.textureCache.upload();
+        STATIC_TEXTURE_CACHE.upload();
         this.pendingTexturePixels = null;
         this.needsTextureRefresh = false;
     }
@@ -240,12 +246,7 @@ public class Preview3D extends Button implements IPreviewHandler {
 
     @Override
     public void closeResources() {
-        if (this.textureCache != null) {
-            this.textureCache.close();
-            Minecraft.getInstance().getTextureManager().release(this.cacheLocation);
-            this.textureCache = null;
-            this.cacheLocation = null;
-        }
+        // Keep STATIC_TEXTURE_CACHE alive across page rebuilds.
     }
 
     @Override
@@ -288,8 +289,8 @@ public class Preview3D extends Button implements IPreviewHandler {
             this.uploadPendingTexture();
         }
 
-        if (this.cacheLocation != null) {
-            guiGraphics.blit(this.cacheLocation, x, y, 0.0F, 0.0F, this.width, this.height, this.width, this.height);
+        if (STATIC_CACHE_LOCATION != null) {
+            guiGraphics.blit(STATIC_CACHE_LOCATION, x, y, 0.0F, 0.0F, this.width, this.height, this.width, this.height);
         } else {
             guiGraphics.fill(x, y, x + this.width, y + this.height, 0xFF000000);
         }


### PR DESCRIPTION
When changing settings pages the previews flicker to black.

This is caused by the widget instance being destroyed and recreated. The previews are only ever intended to be singletons, we never expect two side by side preview2d instances so a cheap and straightforward fix for this is to cache the backing texture statically during page transitions.

This PR does that and now the previews no longer flicker to black.