### PR TITLE
fix: Make preview modes more worldheight aware

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -134,7 +134,7 @@ final class BiomePreview {
 
     private static int surfaceY(Cell cell, Levels levels) {
         int minY = -levels.worldDepth;
-        int maxY = Math.max(minY, levels.worldHeight - 1);
+        int maxY = Math.max(minY, levels.terrainScaleFactor - 1);
         return Math.max(minY, Math.min(maxY, levels.scale(cell.height)));
     }
 

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/IPreviewHandler.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/IPreviewHandler.java
@@ -223,7 +223,7 @@ public interface IPreviewHandler {
             state.cacheKey = requestedKey;
         }
         WorldSettings.Properties properties = presetObj.world().properties;
-        Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
+        Levels levels = new Levels(properties.terrainScaler(), properties.worldHeight, properties.worldDepth, properties.seaLevel);
 
         int seed = (int) settings.options().seed();
         int zoomLevel = getZoom();
@@ -381,7 +381,7 @@ public interface IPreviewHandler {
         PreviewComputationCache.TileLease retained = current.retain();
         RenderMode mode = getRenderMode();
         WorldSettings.Properties properties = page().preset.getPreset().world().properties;
-        Levels levels = new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel);
+        Levels levels = new Levels(properties.terrainScaler(), properties.worldHeight, properties.worldDepth, properties.seaLevel);
         RasterParams params = captureRasterParams();
         BiomePreview.Sidecar sidecar = state.biomes;
         state.pendingRasterization = CompletableFuture.supplyAsync(() -> {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -275,7 +275,7 @@ public class Preview2D extends Button implements IPreviewHandler {
                 String biomeId = this.state.biomes == null ? null : this.state.biomes.id(ix, iz);
                 WorldSettings.Properties properties = this.page.preset.getPreset().world().properties;
                 PreviewDetails.Detail detail = PreviewDetails.forCell(
-                        getRenderMode(), cell, new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel), biomeId
+                        getRenderMode(), cell, new Levels(properties.terrainScaler(), properties.worldHeight, properties.worldDepth, properties.seaLevel), biomeId
                 );
                 this.state.legendLabels[2] = detail.label();
                 this.state.legendValues[2] = detail.value();

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -437,7 +437,7 @@ public class Preview3D extends Button implements IPreviewHandler {
                     WorldSettings.Properties properties = this.page.preset.getPreset().world().properties;
                     PreviewDetails.Detail detail = PreviewDetails.forCell(
                             getRenderMode(), cell,
-                            new Levels(properties.terrainScaler(), properties.worldDepth, properties.seaLevel),
+                            new Levels(properties.terrainScaler(), properties.worldHeight, properties.worldDepth, properties.seaLevel),
                             biomeId
                     );
                     this.state.legendLabels[2] = detail.label();

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/RenderMode.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/RenderMode.java
@@ -23,6 +23,7 @@ public enum RenderMode {
 				shade = 1.0F - depth * 0.4F;
 			} else {
 				float elevation = levels.getNormalizedInlandElevation(cell.height);
+                elevation = (float) cubicHermite(0.0, 1.0, 3.0, 0.0, elevation);
 				shade = 0.88F + elevation * 0.12F;
 			}
 			return this.getColor(cell, levels, shade, 0.0F, biomeColor);
@@ -139,18 +140,19 @@ public enum RenderMode {
             }
 
             // Normalize height relative to sea level
-            // 'h' will now be 0.0 at the shoreline and 1.0 at the highest peak
-            float h = levels.getNormalizedInlandElevation(cell.height);
+            // 'elevation' will now be 0.0 at the shoreline and 1.0 at the highest peak
+            float elevation = levels.getNormalizedInlandElevation(cell.height);
+            elevation = (float) cubicHermite(0.0, 1.0, 3.0, 0.0, elevation);
 
             // Map Normalized Height to Hue
             // We start the hue at 0.35F (Green/Spring) for lowlands
             // and transition to 0.0F (Red) for mountain peaks.
-            float hue = 0.35F * (1.0F - h);
+            float hue = 0.35F * (1.0F - elevation);
 
             // Adjust Saturation and Brightness for depth
             // Lowlands (near coast) are softer; peaks are more intense.
-            float saturation = 0.4F + (h * 0.4F);
-            float brightness = 0.6F + (h * 0.3F);
+            float saturation = 0.4F + (elevation * 0.4F);
+            float brightness = 0.6F + (elevation * 0.3F);
 
             return rgba(hue, saturation, brightness);
         }
@@ -189,8 +191,9 @@ public enum RenderMode {
             }
 
             // Normalize land height (0.0 at water level, 1.0 at peak)
-            float landHeight = levels.getNormalizedInlandElevation(cell.height);
-            float landStep = step(landHeight, contourSteps);
+            float elevation = levels.getNormalizedInlandElevation(cell.height);
+            elevation = (float) cubicHermite(0.0, 1.0, 3.0, 0.0, elevation);
+            float landStep = step(elevation, contourSteps);
 
             float hue = 0.05F;
             float saturation = 0.5F;
@@ -324,5 +327,28 @@ public enum RenderMode {
 
     private static int rgba(int r, int g, int b) {
         return r + (g << 8) + (b << 16) + (255 << 24);
+    }
+
+    /**
+     * General Cubic Hermite Interpolation.
+     *
+     * @param p0 Start point (value at t = 0)
+     * @param p1 End point (value at t = 1)
+     * @param m0 Start tangent (slope at t = 0)
+     * @param m1 End tangent (slope at t = 1)
+     * @param t  Normalized linear input in [0, 1]
+     */
+    public static double cubicHermite(double p0, double p1, double m0, double m1, double t) {
+        t = Math.max(0.0, Math.min(1.0, t));
+        double t2 = t * t;
+        double t3 = t2 * t;
+
+        // Hermite Basis Functions
+        double h00 =  2 * t3 - 3 * t2 + 1; // Basis for start value p0
+        double h10 =      t3 - 2 * t2 + t; // Basis for start tangent m0
+        double h01 = -2 * t3 + 3 * t2;     // Basis for end value p1
+        double h11 =      t3 -     t2;     // Basis for end tangent m1
+
+        return h00 * p0 + h10 * m0 + h01 * p1 + h11 * m1;
     }
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/RenderMode.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/RenderMode.java
@@ -4,7 +4,6 @@ import java.awt.Color;
 
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
-import raccoonman.reterraforged.world.worldgen.cell.terrain.TerrainType;
 import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
 
 public enum RenderMode {
@@ -23,7 +22,7 @@ public enum RenderMode {
 				float depth = NoiseUtil.clamp((levels.water - cell.height) / depthRange, 0.0F, 1.0F);
 				shade = 1.0F - depth * 0.4F;
 			} else {
-				float elevation = NoiseUtil.clamp(levels.elevation(cell.height), 0.0F, 1.0F);
+				float elevation = levels.getNormalizedInlandElevation(cell.height);
 				shade = 0.88F + elevation * 0.12F;
 			}
 			return this.getColor(cell, levels, shade, 0.0F, biomeColor);
@@ -141,8 +140,7 @@ public enum RenderMode {
 
             // Normalize height relative to sea level
             // 'h' will now be 0.0 at the shoreline and 1.0 at the highest peak
-            float h = (cell.height - levels.water) / (1.0F - levels.water);
-            h = NoiseUtil.clamp(h, 0.0F, 1.0F);
+            float h = levels.getNormalizedInlandElevation(cell.height);
 
             // Map Normalized Height to Hue
             // We start the hue at 0.35F (Green/Spring) for lowlands
@@ -191,8 +189,7 @@ public enum RenderMode {
             }
 
             // Normalize land height (0.0 at water level, 1.0 at peak)
-            float landRange = 1.0F - levels.water;
-            float landHeight = (cell.height - levels.water) / landRange;
+            float landHeight = levels.getNormalizedInlandElevation(cell.height);
             float landStep = step(landHeight, contourSteps);
 
             float hue = 0.05F;

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/RenderMode.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/RenderMode.java
@@ -23,7 +23,7 @@ public enum RenderMode {
 				shade = 1.0F - depth * 0.4F;
 			} else {
 				float elevation = levels.getNormalizedInlandElevation(cell.height);
-                elevation = (float) cubicHermite(0.0, 1.0, 3.0, 0.0, elevation);
+                elevation = (float) cubicHermite(0.0, 1.0, 2.0, 0.0, elevation);
 				shade = 0.88F + elevation * 0.12F;
 			}
 			return this.getColor(cell, levels, shade, 0.0F, biomeColor);
@@ -142,17 +142,16 @@ public enum RenderMode {
             // Normalize height relative to sea level
             // 'elevation' will now be 0.0 at the shoreline and 1.0 at the highest peak
             float elevation = levels.getNormalizedInlandElevation(cell.height);
-            elevation = (float) cubicHermite(0.0, 1.0, 3.0, 0.0, elevation);
+            elevation = (float) cubicHermite(0.0, 1.0, 2.0, 0.0, elevation);
 
             // Map Normalized Height to Hue
-            // We start the hue at 0.35F (Green/Spring) for lowlands
-            // and transition to 0.0F (Red) for mountain peaks.
+            // Strictly transitions from 0.35F (Green) down to 0.0F (Red) for mountain peaks
             float hue = 0.35F * (1.0F - elevation);
 
-            // Adjust Saturation and Brightness for depth
-            // Lowlands (near coast) are softer; peaks are more intense.
-            float saturation = 0.4F + (elevation * 0.4F);
-            float brightness = 0.6F + (elevation * 0.3F);
+            // Adjust Saturation and Brightness
+            // Boosted lowlands base saturation (0.60F) scaling up to full saturation (1.0F) at high peaks
+            float saturation = 0.60F + (elevation * 0.40F);
+            float brightness = 0.60F + (elevation * 0.35F);
 
             return rgba(hue, saturation, brightness);
         }
@@ -192,7 +191,7 @@ public enum RenderMode {
 
             // Normalize land height (0.0 at water level, 1.0 at peak)
             float elevation = levels.getNormalizedInlandElevation(cell.height);
-            elevation = (float) cubicHermite(0.0, 1.0, 3.0, 0.0, elevation);
+            elevation = (float) cubicHermite(0.0, 1.0, 2.0, 0.0, elevation);
             float landStep = step(elevation, contourSteps);
 
             float hue = 0.05F;
@@ -331,6 +330,7 @@ public enum RenderMode {
 
     /**
      * General Cubic Hermite Interpolation.
+     * We use it here in rendermode to shift the normalized elevations more into the midrange rather than the extremes
      *
      * @param p0 Start point (value at t = 0)
      * @param p1 End point (value at t = 1)

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/GeneratorContext.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/GeneratorContext.java
@@ -26,7 +26,7 @@ public class GeneratorContext {
         this.preset = preset;
         this.noiseLookup = noiseLookup;
         this.seed = new Seed(seed);
-        this.levels = new Levels(preset.world().properties.terrainScaler(), preset.world().properties.worldDepth, preset.world().properties.seaLevel);
+        this.levels = new Levels(preset.world().properties.terrainScaler(), preset.world().properties.worldHeight, preset.world().properties.worldDepth, preset.world().properties.seaLevel);
         this.generator = new TileGenerator(Heightmap.make(this), new WorldFilters(this), tileSize, tileBorder, batchCount);
         this.cache = cache;
         this.lookup = new WorldLookup(this);

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/Cell.java
@@ -20,6 +20,10 @@ public class Cell {
     public static final ThreadLocal<Resource<Cell>> LOCAL = ThreadLocal.withInitial(() -> {
         return new SimpleResource<>(new Cell(), Cell::reset);
     });
+
+    /**
+     * THIS IS NOT A NORMALIZED 0-1 RANGED VALUE - MAX IS PRESET WORLD HEIGHT / 256
+     */
     public float height;
     public float heightErosion;
     public float sediment;

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/heightmap/Levels.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/cell/heightmap/Levels.java
@@ -3,10 +3,12 @@ package raccoonman.reterraforged.world.worldgen.cell.heightmap;
 import raccoonman.reterraforged.world.worldgen.noise.NoiseUtil;
 
 public class Levels {
+    public int terrainScaleFactor;
     public int worldHeight;
     public int worldDepth;
     public float unit;
     public float min;
+    public float max;
     public int waterY;
     private int groundY;
     public int groundLevel;
@@ -15,29 +17,23 @@ public class Levels {
     public float water;
     private float elevationRange;
 
-    public Levels(int height, int seaLevel) {
-        this(height, 0, seaLevel);
-    }
-
-    public Levels(int height, int depth, int seaLevel) {
+    public Levels(int terrainScaleFactor, int height, int depth, int seaLevel) {
+        this.terrainScaleFactor = Math.max(1, terrainScaleFactor);
         this.worldHeight = Math.max(1, height);
         this.worldDepth = Math.max(0, depth);
-        this.unit = NoiseUtil.div(1, this.worldHeight);
+        this.unit = NoiseUtil.div(1, this.terrainScaleFactor);
         this.min = this.scale(-this.worldDepth);
         this.waterLevel = seaLevel;
         this.groundLevel = this.waterLevel + 1;
-        this.waterY = Math.min(this.waterLevel - 1, this.worldHeight);
-        this.groundY = Math.min(this.groundLevel - 1, this.worldHeight);
-        this.ground = NoiseUtil.div(this.groundY, this.worldHeight);
-        this.water = NoiseUtil.div(this.waterY, this.worldHeight);
+        this.waterY = Math.min(this.waterLevel - 1, this.terrainScaleFactor);
+        this.groundY = Math.min(this.groundLevel - 1, this.terrainScaleFactor);
+        this.ground = NoiseUtil.div(this.groundY, this.terrainScaleFactor);
+        this.water = NoiseUtil.div(this.waterY, this.terrainScaleFactor);
         this.elevationRange = 1.0F - this.water;
     }
     
     public int scale(float value) {
-//        if (value >= 1.0F) {
-//            return this.worldHeight - 1;
-//        }
-        return (int) (value * this.worldHeight);
+        return (int) (value * this.terrainScaleFactor);
     }
     
     public float elevation(float value) {
@@ -55,14 +51,18 @@ public class Levels {
     }
     
     public float scale(int level) {
-        return NoiseUtil.div(level, this.worldHeight);
+        return NoiseUtil.div(level, this.terrainScaleFactor);
     }
     
     public float water(int amount) {
-        return NoiseUtil.div(this.waterY + amount, this.worldHeight);
+        return NoiseUtil.div(this.waterY + amount, this.terrainScaleFactor);
     }
     
     public float ground(int amount) {
-        return NoiseUtil.div(this.groundY + amount, this.worldHeight);
+        return NoiseUtil.div(this.groundY + amount, this.terrainScaleFactor);
+    }
+
+    public float getNormalizedInlandElevation(float rawCellHeight) {
+        return (scale(rawCellHeight) - waterLevel) / (float) (worldHeight - waterLevel);
     }
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/DecorateSnowFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/DecorateSnowFeature.java
@@ -139,7 +139,7 @@ public class DecorateSnowFeature extends Feature<Config> {
     }
     
     private static void smoothSnow(ChunkAccess chunk, BlockPos.MutableBlockPos pos, Cell cell, Levels levels, float min) {
-        float height = cell.height * levels.worldHeight;
+        float height = cell.height * levels.terrainScaleFactor;
         float depth = getDepth(height);
         if (depth > min) {
             int level = getLevel(depth);

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/DecorateSnowFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/DecorateSnowFeature.java
@@ -139,8 +139,9 @@ public class DecorateSnowFeature extends Feature<Config> {
     }
     
     private static void smoothSnow(ChunkAccess chunk, BlockPos.MutableBlockPos pos, Cell cell, Levels levels, float min) {
-        float height = cell.height * levels.terrainScaleFactor;
-        float depth = getDepth(height);
+
+		float heightWithFractionalComponent = cell.height / levels.unit;
+        float depth = getDepth(heightWithFractionalComponent);
         if (depth > min) {
             int level = getLevel(depth);
             BlockState layer = getState(level);


### PR DESCRIPTION
Makes the topographical, biome and hypsometric overlays max world height aware so their gradient range is defined based on the worldHeight and scales with it accordingly.

---

### y448
<img width="1920" height="1050" alt="y448" src="https://github.com/user-attachments/assets/81f09a1a-5f5c-461b-b26f-6097b29fa438" />

### y752
<img width="1920" height="1050" alt="y752" src="https://github.com/user-attachments/assets/be351fa4-46aa-46f4-9548-3a0ef8e06575" />

### Y1024
<img width="1920" height="1050" alt="y1024" src="https://github.com/user-attachments/assets/40ff4467-798f-4926-83af-9418e49a18af" />
