### PR TITLE
fix: Remove architectury-api dependency

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/RTFCommon.java
+++ b/common/src/main/java/raccoonman/reterraforged/RTFCommon.java
@@ -47,7 +47,6 @@ public class RTFCommon {
 		BiomeModifiers.bootstrap();
 		RTFSurfaceRules.bootstrap();
 		StructureRules.bootstrap();
-		DynamicOreLifecycle.bootstrap();
 
 		RegistryUtil.createDataRegistry(RTFRegistries.NOISE, Noise.DIRECT_CODEC, false);
 		RegistryUtil.createDataRegistry(RTFRegistries.PRESET, Preset.DIRECT_CODEC, false);

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinServerLevel.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinServerLevel.java
@@ -1,0 +1,17 @@
+package raccoonman.reterraforged.mixin;
+
+import net.minecraft.server.level.ServerLevel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOreLifecycle;
+
+@Mixin(ServerLevel.class)
+public class MixinServerLevel {
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void reterraforged$onLevelInit(CallbackInfo ci) {
+        DynamicOreLifecycle.onLevelLoad((ServerLevel) (Object) this);
+    }
+}

--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinServerStarted.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinServerStarted.java
@@ -1,0 +1,23 @@
+package raccoonman.reterraforged.mixin;
+
+import net.minecraft.server.MinecraftServer;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOreLifecycle;
+
+@Mixin(MinecraftServer.class)
+public class MixinServerStarted {
+
+    @Inject(
+            method = "runServer",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/server/MinecraftServer;buildServerStatus()Lnet/minecraft/network/protocol/status/ServerStatus;"
+            )
+    )
+    private void reterraforged$onServerStarted(CallbackInfo ci) {
+        DynamicOreLifecycle.onServerStarted((MinecraftServer) (Object) this);
+    }
+}

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreLifecycle.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/ore/DynamicOreLifecycle.java
@@ -1,6 +1,5 @@
 package raccoonman.reterraforged.world.worldgen.feature.ore;
 
-import dev.architectury.event.events.common.LifecycleEvent;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
@@ -11,29 +10,19 @@ import raccoonman.reterraforged.world.worldgen.RTFRandomState;
 import raccoonman.reterraforged.world.worldgen.feature.ore.DynamicOrePlan.VerticalFrame;
 
 public final class DynamicOreLifecycle {
-	private static boolean bootstrapped;
 
 	private DynamicOreLifecycle() {
 	}
 
-	public static synchronized void bootstrap() {
-		if (bootstrapped) {
-			return;
-		}
-		bootstrapped = true;
-		LifecycleEvent.SERVER_LEVEL_LOAD.register(DynamicOreLifecycle::onLevelLoad);
-		LifecycleEvent.SERVER_STARTED.register(DynamicOreLifecycle::onServerStarted);
-	}
-
-	private static void onLevelLoad(ServerLevel level) {
+	public static void onLevelLoad(ServerLevel level) {
 		if (Level.OVERWORLD.equals(level.dimension())) {
 			refresh(level);
 		}
 	}
 
-	private static void onServerStarted(MinecraftServer server) {
+	public static void onServerStarted(MinecraftServer server) {
 		if (server instanceof RTFMinecraftServer owner
-			&& owner.getDynamicOrePlan().verticalFrame().isEmpty()) {
+				&& owner.getDynamicOrePlan().verticalFrame().isEmpty()) {
 			refresh(server);
 		}
 	}
@@ -56,26 +45,26 @@ public final class DynamicOreLifecycle {
 			return;
 		}
 		if (!((Object)overworld.getChunkSource().randomState() instanceof RTFRandomState randomState)
-			|| randomState.generatorContext() == null) {
+				|| randomState.generatorContext() == null) {
 			owner.publishDynamicOrePlan(DynamicOrePlan.empty());
 			return;
 		}
 
 		ChunkGenerator generator = overworld.getChunkSource().getGenerator();
 		DynamicOrePlan plan = new DynamicOrePlanner().build(
-			server.registryAccess(),
-			generator,
-			generator.getBiomeSource().possibleBiomes(),
-			new VerticalFrame(
-				overworld.getMinBuildHeight(),
-				overworld.getMaxBuildHeight() - 1,
-				generator.getSeaLevel()
-			)
+				server.registryAccess(),
+				generator,
+				generator.getBiomeSource().possibleBiomes(),
+				new VerticalFrame(
+						overworld.getMinBuildHeight(),
+						overworld.getMaxBuildHeight() - 1,
+						generator.getSeaLevel()
+				)
 		);
 		owner.publishDynamicOrePlan(plan);
 		RTFCommon.LOGGER.info("Dynamic ore contract inventory: {}", plan.summary());
 		plan.failures().forEach(failure -> RTFCommon.LOGGER.warn(
-			"Dynamic ore contract inspection failure: {}", failure
+				"Dynamic ore contract inspection failure: {}", failure
 		));
 	}
 }

--- a/common/src/main/resources/reterraforged-common.mixins.json
+++ b/common/src/main/resources/reterraforged-common.mixins.json
@@ -57,6 +57,8 @@
 		"MixinOceanMonumentPiece",
 		"MixinOceanMonumentStructure",
 		"MixinJigsawStructure",
+		"MixinServerLevel",
+		"MixinServerStarted",
 		"terrablender.MixinParameterList",
 		"terrablender.MixinClimateSampler",
 		"terrablender.MixinNamespacedSurfaceRuleSource",


### PR DESCRIPTION
In the recent ore changes an architectury-api dependency snuck in that we don't want. This changeset removes it and uses native Mixin hooks instead to achieve the same thing.

---

Trivially confirmed ultradeep /ultratall ores still spawning.
