### PR TITLE
fix: Even faster river gaskets

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
@@ -20,6 +20,8 @@ import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
 import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSettings;
 
+import java.util.Arrays;
+
 public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
 
     // Pre-allocated array of 256 Cells per thread (zero allocation during worldgen)
@@ -109,38 +111,15 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
         BlockState defaultWaterState = Blocks.WATER.defaultBlockState();
         float oceanHeightOffset = levels.water;
 
-        // --- 2D WATER CACHE (Populated only for chunks with active rivers) ---
+        // Reset the lazy water y cache
+        // Fast primitive fill instead of a compulsory 1600 evaluation loop otherwise
         int[] neighborWaterYCache = WATER_Y_CACHE.get();
-
-        for (int dz = -12; dz < 28; dz++) {
-            for (int dx = -12; dx < 28; dx++) {
-                int worldX = minBlockX + dx;
-                int worldZ = minBlockZ + dz;
-
-                generatorContext.lookup.applyCell(
-                        neighborCell.reset(),
-                        worldX,
-                        worldZ,
-                        false,
-                        false
-                );
-
-                float water = (ContinentalHydrology.getComplexWaterHeight(
-                        neighborCell.waterTable,
-                        neighborCell.globalContinentScale,
-                        neighborCell.continentSizeModifier)
-                ) + oceanHeightOffset;
-
-                int waterY = levels.scale(water);
-                int cacheIndex = (dx + 12) + ((dz + 12) * 40);
-                neighborWaterYCache[cacheIndex] = waterY;
-            }
-        }
+        Arrays.fill(neighborWaterYCache, Integer.MIN_VALUE);
 
         Long2ObjectOpenHashMap<BlockState> paintCache = PAINT_CACHE.get();
         paintCache.clear();
 
-        // --- SPARSE MAIN ITERATION: Process ONLY river columns ---
+        // Process only river columns here
         for (int i = 0; i < riverCount; i++) {
             int index = riverIndices[i];
             int x = index & 15;
@@ -149,7 +128,7 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
             int blockX = minBlockX + x;
             int blockZ = minBlockZ + z;
 
-            // Re-use already evaluated cell directly from cache
+            // Reuse any already evaluated cell directly from the cache
             Cell cell = chunkCells[index];
 
             float targetWaterLevel = (ContinentalHydrology.getComplexWaterHeight(
@@ -214,11 +193,16 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                                 int targetX = blockX + dx;
                                 int targetZ = blockZ + dz;
 
-                                int cacheX = (targetX - minBlockX) + 12;
-                                int cacheZ = (targetZ - minBlockZ) + 12;
-                                int cacheIndex = cacheX + (cacheZ * 40);
-
-                                int neighbourWaterY = neighborWaterYCache[cacheIndex];
+                                int neighbourWaterY = getOrComputeWaterY(
+                                        targetX, targetZ,
+                                        minBlockX, minBlockZ,
+                                        chunkCells,
+                                        levels,
+                                        oceanHeightOffset,
+                                        generatorContext,
+                                        neighborCell,
+                                        neighborWaterYCache
+                                );
 
                                 if (y > neighbourWaterY) {
                                     continue;
@@ -277,6 +261,63 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
             }
         }
         return true;
+    }
+
+    /**
+     * Lazy lookup for neighbor water height.
+     * Directly reuses CHUNK_CELLS for internal coordinates and caches external lookups on demand.
+     */
+    private static int getOrComputeWaterY(
+            int targetX, int targetZ,
+            int minBlockX, int minBlockZ,
+            Cell[] chunkCells,
+            Levels levels,
+            float oceanHeightOffset,
+            GeneratorContext generatorContext,
+            Cell neighborCell,
+            int[] cache
+    ) {
+        int relX = targetX - minBlockX;
+        int relZ = targetZ - minBlockZ;
+
+        // Reuse cached cell directly if the coordinate is within the current chunk bounds
+        if (relX >= 0 && relX < 16 && relZ >= 0 && relZ < 16) {
+            Cell cell = chunkCells[relX + (relZ * 16)];
+            float water = ContinentalHydrology.getComplexWaterHeight(
+                    cell.waterTable,
+                    cell.globalContinentScale,
+                    cell.continentSizeModifier
+            ) + oceanHeightOffset;
+            return levels.scale(water);
+        }
+
+        // Lazy computation & threadlocal caching for out of chunk coordinates
+        int cacheX = relX + 12;
+        int cacheZ = relZ + 12;
+        int cacheIndex = cacheX + (cacheZ * 40);
+
+        int cachedValue = cache[cacheIndex];
+        if (cachedValue != Integer.MIN_VALUE) {
+            return cachedValue;
+        }
+
+        generatorContext.lookup.applyCell(
+                neighborCell.reset(),
+                targetX,
+                targetZ,
+                false,
+                false
+        );
+
+        float water = ContinentalHydrology.getComplexWaterHeight(
+                neighborCell.waterTable,
+                neighborCell.globalContinentScale,
+                neighborCell.continentSizeModifier
+        ) + oceanHeightOffset;
+
+        int computedY = levels.scale(water);
+        cache[cacheIndex] = computedY;
+        return computedY;
     }
 
     private static boolean isTerrainPaint(BlockState state) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
@@ -22,10 +22,19 @@ import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSe
 
 public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
 
-    // One cell allocated PER THREAD, reused indefinitely across feature calls
-    private static final ThreadLocal<Cell> LOCAL_CELL = ThreadLocal.withInitial(Cell::new);
-    private static final ThreadLocal<Cell> NEIGHBOUR_CELL = ThreadLocal.withInitial(Cell::new);
+    // Pre-allocated array of 256 Cells per thread (zero allocation during worldgen)
+    private static final ThreadLocal<Cell[]> CHUNK_CELLS = ThreadLocal.withInitial(() -> {
+        Cell[] cells = new Cell[256];
+        for (int i = 0; i < 256; i++) {
+            cells[i] = new Cell();
+        }
+        return cells;
+    });
 
+    // Holds the indices (0-255) of columns that actually contain rivers
+    private static final ThreadLocal<int[]> RIVER_INDICES = ThreadLocal.withInitial(() -> new int[256]);
+
+    private static final ThreadLocal<Cell> NEIGHBOUR_CELL = ThreadLocal.withInitial(Cell::new);
     private static final ThreadLocal<int[]> WATER_Y_CACHE = ThreadLocal.withInitial(() -> new int[40 * 40]);
     private static final ThreadLocal<Long2ObjectOpenHashMap<BlockState>> PAINT_CACHE =
             ThreadLocal.withInitial(Long2ObjectOpenHashMap::new);
@@ -53,44 +62,58 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
         WorldGenLevel level = placeContext.level();
         RandomState randomState = level.getLevel().getChunkSource().randomState();
 
-        // guard against interfering with non rtf content
         if (!((Object) randomState instanceof RTFRandomState rtfRandomState)) {
             return false;
         }
 
-        // guard against no rtf generator context
         GeneratorContext generatorContext = rtfRandomState.generatorContext();
         if (generatorContext == null) {
             return false;
         }
 
-        // get the cell we are checking efficiently
-        Cell cell = LOCAL_CELL.get();
-        generatorContext.lookup.applyCell(cell, placeContext.origin().getX(), placeContext.origin().getZ(), false, false);
+        BlockPos origin = placeContext.origin();
+        int minBlockX = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getX()));
+        int minBlockZ = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getZ()));
 
-        // Performance guard - prevent checking cells that are not near rivers
-        if (cell.riverZone == RiverCarverSettings.RiverZone.None || cell.riverZone == RiverCarverSettings.RiverZone.ValleyFadeout) {
+        Cell[] chunkCells = CHUNK_CELLS.get();
+        int[] riverIndices = RIVER_INDICES.get();
+        int riverCount = 0;
+
+        // --- SINGLE-PASS CELL EVALUATION & INDEX FILTER ---
+        for (int z = 0; z < 16; z++) {
+            for (int x = 0; x < 16; x++) {
+                int index = x + (z * 16);
+                int worldX = minBlockX + x;
+                int worldZ = minBlockZ + z;
+
+                Cell cell = chunkCells[index].reset();
+                generatorContext.lookup.applyCell(cell, worldX, worldZ, false, false);
+
+                if (cell.riverZone != RiverCarverSettings.RiverZone.None
+                        && cell.riverZone != RiverCarverSettings.RiverZone.ValleyFadeout) {
+                    riverIndices[riverCount++] = index;
+                }
+            }
+        }
+
+        // Fast exit for ~80%+ of non-river chunks before touching secondary caches or world blocks
+        if (riverCount == 0) {
             return false;
         }
 
         Levels levels = generatorContext.lookup.getHeightmap().levels();
-        BlockPos origin = placeContext.origin();
-
-        int minBlockX = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getX()));
-        int minBlockZ = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getZ()));
-
         Cell neighborCell = NEIGHBOUR_CELL.get();
         PosHolder pos = POS_HOLDER.get();
 
         BlockState fallbackState = Blocks.STONE.defaultBlockState();
+        BlockState defaultWaterState = Blocks.WATER.defaultBlockState();
         float oceanHeightOffset = levels.water;
 
-        // CACHE 1: 2D Cache for water cell evaluations
+        // --- 2D WATER CACHE (Populated only for chunks with active rivers) ---
         int[] neighborWaterYCache = WATER_Y_CACHE.get();
 
         for (int dz = -12; dz < 28; dz++) {
             for (int dx = -12; dx < 28; dx++) {
-
                 int worldX = minBlockX + dx;
                 int worldZ = minBlockZ + dz;
 
@@ -102,141 +125,150 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                         false
                 );
 
-                float water =
-                        (ContinentalHydrology.getComplexWaterHeight(
-                                neighborCell.waterTable,
-                                neighborCell.globalContinentScale,
-                                neighborCell.continentSizeModifier)
-                        ) + oceanHeightOffset;
+                float water = (ContinentalHydrology.getComplexWaterHeight(
+                        neighborCell.waterTable,
+                        neighborCell.globalContinentScale,
+                        neighborCell.continentSizeModifier)
+                ) + oceanHeightOffset;
 
                 int waterY = levels.scale(water);
-
                 int cacheIndex = (dx + 12) + ((dz + 12) * 40);
                 neighborWaterYCache[cacheIndex] = waterY;
             }
         }
 
-        // CACHE 2: Fast 3D Cache for the horizontal terrain paint lookups
         Long2ObjectOpenHashMap<BlockState> paintCache = PAINT_CACHE.get();
         paintCache.clear();
 
-        for (int x = 0; x < 16; x++) {
-            for (int z = 0; z < 16; z++) {
-                int blockX = minBlockX + x;
-                int blockZ = minBlockZ + z;
+        // --- SPARSE MAIN ITERATION: Process ONLY river columns ---
+        for (int i = 0; i < riverCount; i++) {
+            int index = riverIndices[i];
+            int x = index & 15;
+            int z = index >> 4;
 
-                generatorContext.lookup.applyCell(cell.reset(), blockX, blockZ, false, false);
+            int blockX = minBlockX + x;
+            int blockZ = minBlockZ + z;
 
-                float targetWaterLevel =
-                        (ContinentalHydrology.getComplexWaterHeight(
-                                cell.waterTable,
-                                cell.globalContinentScale,
-                                cell.continentSizeModifier)
-                        ) + oceanHeightOffset;
-                int localWaterY = levels.scale(targetWaterLevel);
-                int currentFloorHeight = levels.scale(cell.height);
+            // Re-use already evaluated cell directly from cache
+            Cell cell = chunkCells[index];
 
-                int scanTopY = Math.max(localWaterY, currentFloorHeight);
-                int scanBottomY = Math.min(localWaterY, currentFloorHeight) - 8;
-                scanBottomY = Math.max(scanBottomY, levels.scale(levels.water));
+            float targetWaterLevel = (ContinentalHydrology.getComplexWaterHeight(
+                    cell.waterTable,
+                    cell.globalContinentScale,
+                    cell.continentSizeModifier)
+            ) + oceanHeightOffset;
 
-                // CACHE 3: structural state once per X/Z column using heightmap
-                BlockState structuralState = null;
-                int columnTopY = level.getChunk(origin).getHeight(
-                        Heightmap.Types.OCEAN_FLOOR_WG,
-                        blockX, blockZ
-                );
-                if (columnTopY >= level.getMinBuildHeight()) {
-                    pos.sample.set(blockX, columnTopY, blockZ);
-                    BlockState topState = level.getBlockState(pos.sample);
-                    if (!topState.isAir() && !topState.is(Blocks.CAVE_AIR) && !topState.is(Blocks.WATER)) {
-                        structuralState = topState;
+            int localWaterY = levels.scale(targetWaterLevel);
+            int currentFloorHeight = levels.scale(cell.height);
+
+            int scanTopY = Math.max(localWaterY, currentFloorHeight);
+            int scanBottomY = Math.min(localWaterY, currentFloorHeight) - 8;
+            scanBottomY = Math.max(scanBottomY, levels.scale(levels.water));
+
+            // Sample column structural block
+            BlockState structuralState = null;
+            int columnTopY = level.getChunk(origin).getHeight(
+                    Heightmap.Types.OCEAN_FLOOR_WG,
+                    blockX, blockZ
+            );
+            if (columnTopY >= level.getMinBuildHeight()) {
+                pos.sample.set(blockX, columnTopY, blockZ);
+                BlockState topState = level.getBlockState(pos.sample);
+                if (!topState.isAir() && !topState.is(Blocks.CAVE_AIR) && !topState.is(Blocks.WATER)) {
+                    structuralState = topState;
+                }
+            }
+            if (structuralState == null) {
+                structuralState = fallbackState;
+            }
+
+            for (int y = scanTopY; y >= scanBottomY; y--) {
+                pos.current.set(blockX, y, blockZ);
+                BlockState currentState = level.getBlockState(pos.current);
+
+                boolean isWater = currentState.is(Blocks.WATER) && currentState.getFluidState().isSource();
+                boolean isCarvedAir = currentState.isAir() || currentState.is(Blocks.CAVE_AIR);
+
+                // Reconstruct carved water blocks in river channels
+                if (isCarvedAir && y <= localWaterY && y >= currentFloorHeight) {
+                    level.setBlock(pos.current, defaultWaterState, 2);
+                    isWater = true;
+                }
+
+                if (isWater) {
+                    // Gasket BELOW
+                    pos.belowNeighbor.set(blockX, y - 1, blockZ);
+                    BlockState belowState = level.getBlockState(pos.belowNeighbor);
+                    if (belowState.isAir() || belowState.is(Blocks.CAVE_AIR)) {
+                        level.setBlock(pos.belowNeighbor, structuralState, 2);
                     }
-                }
-                if (structuralState == null) {
-                    structuralState = fallbackState;
-                }
 
-                for (int y = scanTopY; y >= scanBottomY; y--) {
+                    // Gasket HORIZONTAL
+                    int radius = placeContext.random().nextInt(5) + 3;
+                    int radiusSq = radius * radius;
 
-                    pos.current.set(blockX, y, blockZ);
-                    BlockState currentState = level.getBlockState(pos.current);
+                    for (int dx = -radius; dx <= radius; dx++) {
+                        for (int dz = -radius; dz <= radius; dz++) {
+                            if (dx * dx + dz * dz <= radiusSq) {
 
-                    if (currentState.is(Blocks.WATER) && currentState.getFluidState().isSource()) {
+                                int targetX = blockX + dx;
+                                int targetZ = blockZ + dz;
 
-                        // Ensure air directly below the current water block gets gasketed
-                        pos.belowNeighbor.set(blockX, y - 1, blockZ);
-                        BlockState belowState = level.getBlockState(pos.belowNeighbor);
-                        if (belowState.isAir() || belowState.is(Blocks.CAVE_AIR)) {
-                            level.setBlock(pos.belowNeighbor, structuralState, 2);
-                        }
+                                int cacheX = (targetX - minBlockX) + 12;
+                                int cacheZ = (targetZ - minBlockZ) + 12;
+                                int cacheIndex = cacheX + (cacheZ * 40);
 
-                        int radius = placeContext.random().nextInt(5) + 3;
-                        int radiusSq = radius * radius;
+                                int neighbourWaterY = neighborWaterYCache[cacheIndex];
 
-                        for (int dx = -radius; dx <= radius; dx++) {
-                            for (int dz = -radius; dz <= radius; dz++) {
-                                if (dx * dx + dz * dz <= radiusSq) {
+                                if (y > neighbourWaterY) {
+                                    continue;
+                                }
 
-                                    int targetX = blockX + dx;
-                                    int targetZ = blockZ + dz;
+                                pos.neighbor.set(targetX, y, targetZ);
+                                BlockState neighborState = level.getBlockState(pos.neighbor);
 
-                                    int cacheX = (targetX - minBlockX) + 12;
-                                    int cacheZ = (targetZ - minBlockZ) + 12;
-                                    int cacheIndex = cacheX + (cacheZ * 40);
+                                if (neighborState.isAir() || neighborState.is(Blocks.CAVE_AIR)) {
+                                    pos.belowNeighbor.set(targetX, y - 1, targetZ);
+                                    BlockState belowNeighborState = level.getBlockState(pos.belowNeighbor);
 
-                                    int neighbourWaterY = neighborWaterYCache[cacheIndex];
-
-                                    if (y > neighbourWaterY) {
+                                    if (belowNeighborState.is(Blocks.WATER)) {
                                         continue;
                                     }
 
-                                    pos.neighbor.set(targetX, y, targetZ);
-                                    BlockState neighborState = level.getBlockState(pos.neighbor);
+                                    BlockState finalPlacementState = structuralState;
+                                    pos.testAbove.set(targetX, y + 1, targetZ);
+                                    BlockState stateAbove = level.getBlockState(pos.testAbove);
 
-                                    if (neighborState.isAir() || neighborState.is(Blocks.CAVE_AIR)) {
-                                        pos.belowNeighbor.set(targetX, y - 1, targetZ);
-                                        BlockState belowNeighborState = level.getBlockState(pos.belowNeighbor);
+                                    if (stateAbove.isAir() || stateAbove.is(Blocks.CAVE_AIR) || stateAbove.is(Blocks.WATER)) {
+                                        long posHash = BlockPos.asLong(targetX, y, targetZ);
 
-                                        if (belowNeighborState.is(Blocks.WATER)) {
-                                            continue;
-                                        }
+                                        if (paintCache.containsKey(posHash)) {
+                                            finalPlacementState = paintCache.get(posHash);
+                                        } else {
+                                            BlockState foundPaint = structuralState;
 
-                                        BlockState finalPlacementState = structuralState;
-                                        pos.testAbove.set(targetX, y + 1, targetZ);
-                                        BlockState stateAbove = level.getBlockState(pos.testAbove);
+                                            searchLoop:
+                                            for (int dist = 1; dist <= 4; dist++) {
+                                                for (Direction dir : HORIZONTAL_DIRECTIONS) {
+                                                    pos.testSide.set(
+                                                            targetX + (dir.getStepX() * dist),
+                                                            y,
+                                                            targetZ + (dir.getStepZ() * dist)
+                                                    );
+                                                    BlockState nearbyState = level.getBlockState(pos.testSide);
 
-                                        if (stateAbove.isAir() || stateAbove.is(Blocks.CAVE_AIR) || stateAbove.is(Blocks.WATER)) {
-                                            long posHash = BlockPos.asLong(targetX, y, targetZ);
-
-                                            if (paintCache.containsKey(posHash)) {
-                                                finalPlacementState = paintCache.get(posHash);
-                                            } else {
-                                                BlockState foundPaint = structuralState;
-
-                                                searchLoop:
-                                                for (int dist = 1; dist <= 4; dist++) {
-                                                    for (Direction dir : HORIZONTAL_DIRECTIONS) {
-                                                        pos.testSide.set(
-                                                                targetX + (dir.getStepX() * dist),
-                                                                y,
-                                                                targetZ + (dir.getStepZ() * dist)
-                                                        );
-                                                        BlockState nearbyState = level.getBlockState(pos.testSide);
-
-                                                        if (isTerrainPaint(nearbyState)) {
-                                                            foundPaint = nearbyState;
-                                                            break searchLoop;
-                                                        }
+                                                    if (isTerrainPaint(nearbyState)) {
+                                                        foundPaint = nearbyState;
+                                                        break searchLoop;
                                                     }
                                                 }
-                                                paintCache.put(posHash, foundPaint);
-                                                finalPlacementState = foundPaint;
                                             }
+                                            paintCache.put(posHash, foundPaint);
+                                            finalPlacementState = foundPaint;
                                         }
-
-                                        level.setBlock(pos.neighbor, finalPlacementState, 2);
                                     }
+
+                                    level.setBlock(pos.neighbor, finalPlacementState, 2);
                                 }
                             }
                         }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/feature/RiverGasketFeature.java
@@ -8,62 +8,85 @@ import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.WorldGenLevel;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.FeaturePlaceContext;
 import net.minecraft.world.level.levelgen.feature.configurations.NoneFeatureConfiguration;
 import raccoonman.reterraforged.world.worldgen.GeneratorContext;
+import raccoonman.reterraforged.world.worldgen.RTFRandomState;
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
-import raccoonman.reterraforged.world.worldgen.cell.heightmap.WorldLookup;
 import raccoonman.reterraforged.world.worldgen.cell.rivermap.ContinentalHydrology;
-
-import java.util.Arrays;
+import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSettings;
 
 public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
+
+    // One cell allocated PER THREAD, reused indefinitely across feature calls
+    private static final ThreadLocal<Cell> LOCAL_CELL = ThreadLocal.withInitial(Cell::new);
+    private static final ThreadLocal<Cell> NEIGHBOUR_CELL = ThreadLocal.withInitial(Cell::new);
+
+    private static final ThreadLocal<int[]> WATER_Y_CACHE = ThreadLocal.withInitial(() -> new int[40 * 40]);
+    private static final ThreadLocal<Long2ObjectOpenHashMap<BlockState>> PAINT_CACHE =
+            ThreadLocal.withInitial(Long2ObjectOpenHashMap::new);
+    private static final ThreadLocal<PosHolder> POS_HOLDER = ThreadLocal.withInitial(PosHolder::new);
 
     private static final Direction[] HORIZONTAL_DIRECTIONS = {
             Direction.NORTH, Direction.SOUTH, Direction.EAST, Direction.WEST
     };
+
+    private static class PosHolder {
+        final BlockPos.MutableBlockPos current = new BlockPos.MutableBlockPos();
+        final BlockPos.MutableBlockPos neighbor = new BlockPos.MutableBlockPos();
+        final BlockPos.MutableBlockPos belowNeighbor = new BlockPos.MutableBlockPos();
+        final BlockPos.MutableBlockPos sample = new BlockPos.MutableBlockPos();
+        final BlockPos.MutableBlockPos testAbove = new BlockPos.MutableBlockPos();
+        final BlockPos.MutableBlockPos testSide = new BlockPos.MutableBlockPos();
+    }
 
     public RiverGasketFeature(Codec<NoneFeatureConfiguration> codec) {
         super(codec);
     }
 
     @Override
-    public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> context) {
-        WorldGenLevel level = context.level();
+    public boolean place(FeaturePlaceContext<NoneFeatureConfiguration> placeContext) {
+        WorldGenLevel level = placeContext.level();
+        RandomState randomState = level.getLevel().getChunkSource().randomState();
 
-        if ( !((Object) level.getLevel().getChunkSource().randomState() instanceof raccoonman.reterraforged.world.worldgen.RTFRandomState rtfRandomState)) {
+        // guard against interfering with non rtf content
+        if (!((Object) randomState instanceof RTFRandomState rtfRandomState)) {
             return false;
         }
 
+        // guard against no rtf generator context
         GeneratorContext generatorContext = rtfRandomState.generatorContext();
         if (generatorContext == null) {
             return false;
         }
 
-        WorldLookup worldLookup = new WorldLookup(generatorContext);
-        Levels levels = worldLookup.getHeightmap().levels();
-        BlockPos origin = context.origin();
+        // get the cell we are checking efficiently
+        Cell cell = LOCAL_CELL.get();
+        generatorContext.lookup.applyCell(cell, placeContext.origin().getX(), placeContext.origin().getZ(), false, false);
+
+        // Performance guard - prevent checking cells that are not near rivers
+        if (cell.riverZone == RiverCarverSettings.RiverZone.None || cell.riverZone == RiverCarverSettings.RiverZone.ValleyFadeout) {
+            return false;
+        }
+
+        Levels levels = generatorContext.lookup.getHeightmap().levels();
+        BlockPos origin = placeContext.origin();
 
         int minBlockX = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getX()));
         int minBlockZ = SectionPos.sectionToBlockCoord(SectionPos.blockToSectionCoord(origin.getZ()));
 
-        Cell cell = new Cell();
-        Cell neighborCell = new Cell();
-
-        BlockPos.MutableBlockPos currentPos = new BlockPos.MutableBlockPos();
-        BlockPos.MutableBlockPos neighborPos = new BlockPos.MutableBlockPos();
-        BlockPos.MutableBlockPos belowNeighborPos = new BlockPos.MutableBlockPos();
-        BlockPos.MutableBlockPos samplePos = new BlockPos.MutableBlockPos();
-        BlockPos.MutableBlockPos testAbovePos = new BlockPos.MutableBlockPos();
-        BlockPos.MutableBlockPos testSidePos = new BlockPos.MutableBlockPos();
+        Cell neighborCell = NEIGHBOUR_CELL.get();
+        PosHolder pos = POS_HOLDER.get();
 
         BlockState fallbackState = Blocks.STONE.defaultBlockState();
         float oceanHeightOffset = levels.water;
 
         // CACHE 1: 2D Cache for water cell evaluations
-        int[] neighborWaterYCache = new int[40 * 40];
+        int[] neighborWaterYCache = WATER_Y_CACHE.get();
 
         for (int dz = -12; dz < 28; dz++) {
             for (int dx = -12; dx < 28; dx++) {
@@ -71,7 +94,7 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                 int worldX = minBlockX + dx;
                 int worldZ = minBlockZ + dz;
 
-                worldLookup.applyCell(
+                generatorContext.lookup.applyCell(
                         neighborCell.reset(),
                         worldX,
                         worldZ,
@@ -94,21 +117,22 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
         }
 
         // CACHE 2: Fast 3D Cache for the horizontal terrain paint lookups
-        Long2ObjectOpenHashMap<BlockState> paintCache = new Long2ObjectOpenHashMap<>();
+        Long2ObjectOpenHashMap<BlockState> paintCache = PAINT_CACHE.get();
+        paintCache.clear();
 
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
                 int blockX = minBlockX + x;
                 int blockZ = minBlockZ + z;
 
-                worldLookup.applyCell(cell.reset(), blockX, blockZ, false, false);
+                generatorContext.lookup.applyCell(cell.reset(), blockX, blockZ, false, false);
 
                 float targetWaterLevel =
-                    (ContinentalHydrology.getComplexWaterHeight(
-                            cell.waterTable,
-                            cell.globalContinentScale,
-                            cell.continentSizeModifier)
-                    ) + oceanHeightOffset;
+                        (ContinentalHydrology.getComplexWaterHeight(
+                                cell.waterTable,
+                                cell.globalContinentScale,
+                                cell.continentSizeModifier)
+                        ) + oceanHeightOffset;
                 int localWaterY = levels.scale(targetWaterLevel);
                 int currentFloorHeight = levels.scale(cell.height);
 
@@ -119,12 +143,12 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                 // CACHE 3: structural state once per X/Z column using heightmap
                 BlockState structuralState = null;
                 int columnTopY = level.getChunk(origin).getHeight(
-                        net.minecraft.world.level.levelgen.Heightmap.Types.OCEAN_FLOOR_WG,
+                        Heightmap.Types.OCEAN_FLOOR_WG,
                         blockX, blockZ
                 );
                 if (columnTopY >= level.getMinBuildHeight()) {
-                    samplePos.set(blockX, columnTopY, blockZ);
-                    BlockState topState = level.getBlockState(samplePos);
+                    pos.sample.set(blockX, columnTopY, blockZ);
+                    BlockState topState = level.getBlockState(pos.sample);
                     if (!topState.isAir() && !topState.is(Blocks.CAVE_AIR) && !topState.is(Blocks.WATER)) {
                         structuralState = topState;
                     }
@@ -135,19 +159,19 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
 
                 for (int y = scanTopY; y >= scanBottomY; y--) {
 
-                    currentPos.set(blockX, y, blockZ);
-                    BlockState currentState = level.getBlockState(currentPos);
+                    pos.current.set(blockX, y, blockZ);
+                    BlockState currentState = level.getBlockState(pos.current);
 
                     if (currentState.is(Blocks.WATER) && currentState.getFluidState().isSource()) {
 
                         // Ensure air directly below the current water block gets gasketed
-                        belowNeighborPos.set(blockX, y - 1, blockZ);
-                        BlockState belowState = level.getBlockState(belowNeighborPos);
+                        pos.belowNeighbor.set(blockX, y - 1, blockZ);
+                        BlockState belowState = level.getBlockState(pos.belowNeighbor);
                         if (belowState.isAir() || belowState.is(Blocks.CAVE_AIR)) {
-                            level.setBlock(belowNeighborPos, structuralState, 2);
+                            level.setBlock(pos.belowNeighbor, structuralState, 2);
                         }
 
-                        int radius = context.random().nextInt(5) + 3;
+                        int radius = placeContext.random().nextInt(5) + 3;
                         int radiusSq = radius * radius;
 
                         for (int dx = -radius; dx <= radius; dx++) {
@@ -167,20 +191,20 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                                         continue;
                                     }
 
-                                    neighborPos.set(targetX, y, targetZ);
-                                    BlockState neighborState = level.getBlockState(neighborPos);
+                                    pos.neighbor.set(targetX, y, targetZ);
+                                    BlockState neighborState = level.getBlockState(pos.neighbor);
 
                                     if (neighborState.isAir() || neighborState.is(Blocks.CAVE_AIR)) {
-                                        belowNeighborPos.set(targetX, y - 1, targetZ);
-                                        BlockState belowNeighborState = level.getBlockState(belowNeighborPos);
+                                        pos.belowNeighbor.set(targetX, y - 1, targetZ);
+                                        BlockState belowNeighborState = level.getBlockState(pos.belowNeighbor);
 
                                         if (belowNeighborState.is(Blocks.WATER)) {
                                             continue;
                                         }
 
                                         BlockState finalPlacementState = structuralState;
-                                        testAbovePos.set(targetX, y + 1, targetZ);
-                                        BlockState stateAbove = level.getBlockState(testAbovePos);
+                                        pos.testAbove.set(targetX, y + 1, targetZ);
+                                        BlockState stateAbove = level.getBlockState(pos.testAbove);
 
                                         if (stateAbove.isAir() || stateAbove.is(Blocks.CAVE_AIR) || stateAbove.is(Blocks.WATER)) {
                                             long posHash = BlockPos.asLong(targetX, y, targetZ);
@@ -193,12 +217,12 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                                                 searchLoop:
                                                 for (int dist = 1; dist <= 4; dist++) {
                                                     for (Direction dir : HORIZONTAL_DIRECTIONS) {
-                                                        testSidePos.set(
+                                                        pos.testSide.set(
                                                                 targetX + (dir.getStepX() * dist),
                                                                 y,
                                                                 targetZ + (dir.getStepZ() * dist)
                                                         );
-                                                        BlockState nearbyState = level.getBlockState(testSidePos);
+                                                        BlockState nearbyState = level.getBlockState(pos.testSide);
 
                                                         if (isTerrainPaint(nearbyState)) {
                                                             foundPaint = nearbyState;
@@ -211,7 +235,7 @@ public class RiverGasketFeature extends Feature<NoneFeatureConfiguration> {
                                             }
                                         }
 
-                                        level.setBlock(neighborPos, finalPlacementState, 2);
+                                        level.setBlock(pos.neighbor, finalPlacementState, 2);
                                     }
                                 }
                             }


### PR DESCRIPTION
Fixes #192 once and for all.

---

### Fix approach

- we now threadlocal create all the cell references to prevent reassignment every loop, trading a small amount of memory (like tiny) for runtime performance
- we now completely ignore non riverzone or valleyfadeout tagged river cells so we only process immediately adjacent to the rivers.
- we now threadlocal cache the entire array of chunk cells, trading about 1mb of memory for far better performance (approx 50kb / thread)
- we now only iterate the relevant cells rather than the full 40x40 grid
- other small tweaks to overall logic flow to exit earlier, faster with less overhead when its irrelevant.
- reuse cell cache to do zone sampling
- avoid upfront waterY caching for entire 40x40 - now only lazy init when required

---

### Performance

Gaskets no longer show up in profiling and CPS is through the roof (at least in my tests, only small subset uploaded here)

<img width="2846" height="778" alt="image" src="https://github.com/user-attachments/assets/530de7f8-d456-4216-ba0c-6fcbb75def14" />

<img width="767" height="305" alt="image" src="https://github.com/user-attachments/assets/a98b7fc9-78ec-4750-a2d7-1abedd298bdc" />

<img width="724" height="942" alt="image" src="https://github.com/user-attachments/assets/63538a9c-41bd-4664-a7d9-b5e4d8a1344a" />

<img width="764" height="1196" alt="image" src="https://github.com/user-attachments/assets/837588c4-a804-41c0-8088-7dbffe2b15c9" />

---

### Testing and validation
- [x] Confirmed gaskets spawn by powering down a heap of 30 river worlds under various presets
- [x] Confirmed carvers and ravines are fully well managed post changes
- [x] Confirmed ice behaves correctly
- [x] Confirmed terrain repainter chooses terrain blocks correctly still and blends in the changes well.
- [x] Generated /chunky radius 5000 and confirmed no memory leaks, hangs or generation issues



