### PR TITLE
improvement: make 3d preview depth better

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview3D.java
@@ -110,6 +110,12 @@ public class Preview3D extends Button implements IPreviewHandler {
         return this.width <= 0 || this.height <= 0;
     }
 
+    private static float calculateBlockWidth(int width, int height, int tileSize) {
+        float scaleX = (float) width / (float) tileSize;
+        float scaleY = ((float) height / (float) tileSize) * 2.0f;
+        return Math.max(scaleX, scaleY);
+    }
+
     @Override
     public int[] createRasterData(Tile activeTile, BiomePreview.Sidecar activeBiomes, RenderMode mode, Levels levels, WorldSettings.Properties properties, RasterParams params) {
         int width = params.width;
@@ -119,7 +125,7 @@ public class Preview3D extends Button implements IPreviewHandler {
         java.util.Arrays.fill(pixels, 0xFF000000);
 
         int tileSize = activeTile.getBlockSize().size();
-        float rawBlockW = (float) width / (float) tileSize * 0.85f;
+        float rawBlockW = calculateBlockWidth(width, height, tileSize);
         int halfW = Math.max(1, (int) (rawBlockW / 2.0f));
         int halfH = Math.max(1, halfW / 2);
         int blockW = halfW * 2;
@@ -344,7 +350,7 @@ public class Preview3D extends Button implements IPreviewHandler {
                 if (ix >= 0 && ix < tileSize && iz >= 0 && iz < tileSize) {
                     Cell cell = activeTile.lookup(ix, iz);
 
-                    float rawBlockW = (float) this.width / (float) tileSize * 0.85f;
+                    float rawBlockW = calculateBlockWidth(this.width, this.height, tileSize);
                     int halfW = Math.max(1, (int) (rawBlockW / 2.0f));
                     int halfH = Math.max(1, halfW / 2);
 
@@ -410,7 +416,7 @@ public class Preview3D extends Button implements IPreviewHandler {
                 return false;
             }
 
-            float rawBlockW = (float) this.width / (float) tileSize * 0.85f;
+            float rawBlockW = calculateBlockWidth(this.width, this.height, tileSize);
             int halfW = Math.max(1, (int) (rawBlockW / 2.0f));
             int halfH = Math.max(1, halfW / 2);
 


### PR DESCRIPTION
Improves depth perception in the 3d preview and resolves much of the vertical stretching that was occurring across zoom levels.

Can clearly now see steppes for instance and zooming in close on valleys is more detailed.

---

<img width="1183" height="1182" alt="image" src="https://github.com/user-attachments/assets/51c761de-201a-48f5-bbf9-e77914e569e6" />

<img width="1218" height="1540" alt="image" src="https://github.com/user-attachments/assets/2172bed6-a34c-4ed7-93ae-1f5e978baacf" />

<img width="1180" height="1185" alt="image" src="https://github.com/user-attachments/assets/7cdafe4a-ab46-44fb-b8e5-496fb56d8d44" />

--- 