### PR TITLE
fix: Optimise the hell out of biome preview mode

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -5,8 +5,6 @@ import java.util.IdentityHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.IntStream;
 
-import org.slf4j.Logger;
-import com.mojang.logging.LogUtils;
 import com.mojang.serialization.JsonOps;
 
 import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
@@ -29,7 +27,6 @@ import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 
 final class BiomePreview {
-    private static final Logger LOGGER = LogUtils.getLogger();
     private static final ResourceLocation UNREGISTERED = ResourceLocation.fromNamespaceAndPath("reterraforged", "unregistered");
     private static final ThreadLocal<WorkerBuffer> WORKER_BUFFER = ThreadLocal.withInitial(WorkerBuffer::new);
     private static final ThreadLocal<ThreadQuartCache> THREAD_CACHE = ThreadLocal.withInitial(ThreadQuartCache::new);
@@ -48,11 +45,9 @@ final class BiomePreview {
             Preset preset,
             GeneratorContext generatorContext
     ) {
-        long startTime = System.nanoTime();
         long seed = settings.options().seed();
         LevelStem activeOverworld = settings.selectedDimensions().get(LevelStem.OVERWORLD).orElseThrow();
 
-        long resolverStart = System.nanoTime();
         BiomePreviewResolver resolver = BiomePreviewResolver.create(
                 settings.worldgenLoadContext(),
                 provider,
@@ -62,14 +57,8 @@ final class BiomePreview {
                 generatorContext,
                 seed
         );
-        long resolverDuration = System.nanoTime() - resolverStart;
 
-        long cacheKeyStart = System.nanoTime();
         CacheKey key = cacheKey(settings, preset);
-        long cacheKeyDuration = System.nanoTime() - cacheKeyStart;
-
-        LOGGER.info("[BiomePreview Profiler] create() total: {} ms | Resolver setup: {} ms | CacheKey gen: {} ms",
-                toMs(System.nanoTime() - startTime), toMs(resolverDuration), toMs(cacheKeyDuration));
 
         return new BiomePreview(resolver, key);
     }
@@ -82,7 +71,6 @@ final class BiomePreview {
             Levels levels,
             PreviewCancellation cancellation
     ) {
-        long resolveStart = System.nanoTime();
         int size = tile.getBlockSize().size();
         int totalPixels = size * size;
         int border = tile.getBlockSize().border();
@@ -95,31 +83,15 @@ final class BiomePreview {
         int halfSize = size / 2;
         int step = getSamplingStep(zoom);
 
-        long samplerStart = System.nanoTime();
         Climate.Sampler sampler = this.resolver.tileClimateSampler(tile, centerX, centerZ, zoom);
-        long samplerDuration = System.nanoTime() - samplerStart;
-
-        long loopStart = System.nanoTime();
 
         try (BiomePreviewIntegration.Session ignored = this.resolver.openIntegrationSession()) {
-            long resolveQuartStart = System.nanoTime();
-
             // Chunk rows into blocks of 16 to minimize thread scheduling overhead
             int chunkSize = 16;
             int numChunks = (size + chunkSize - 1) / chunkSize;
 
-            // Compute total evaluated sample points for profiler output
-            int sampledWidth = (size + step - 1) / step;
-            int sampledHeight = (size + step - 1) / step;
-            int sampledCells = sampledWidth * sampledHeight;
-
-            // Capture the Biolith preview state on this thread (the one that opened the
-            // integration session above) so it can be re-attached on whichever
-            // ForkJoinPool worker thread each chunk below actually executes on.
-            // Without this, BiolithPreviewContext.isActive() reads false on worker
-            // threads (ThreadLocal state doesn't propagate to pooled threads), causing
-            // the preview redirects to silently fall through to Biolith's real,
-            // uninitialized fields and NPE.
+            // Capture the Biolith preview state on this thread so it can be re-attached
+            // on whichever ForkJoinPool worker thread each chunk below executes on.
             Object biolithState = BiolithPreviewContext.captureState();
 
             IntStream.range(0, numChunks).parallel().forEach(chunkIdx -> {
@@ -165,16 +137,11 @@ final class BiomePreview {
                 } catch (RuntimeException | Error error) {
                     throw error;
                 } catch (Exception error) {
-                    // AutoCloseable.close() declares checked Exception; BiolithPreviewContext's
-                    // implementation never actually throws one, so this path is unreachable
-                    // in practice but must be handled to satisfy the compiler.
                     throw new RuntimeException(error);
                 }
             });
-            long resolveQuartDuration = System.nanoTime() - resolveQuartStart;
 
             // Sequential Palette & Color Assembly
-            long colorStart = System.nanoTime();
             WorkerBuffer buffer = WORKER_BUFFER.get();
             buffer.reset();
 
@@ -194,23 +161,14 @@ final class BiomePreview {
                 indices[i] = entry.paletteIndex;
                 colors[i] = entry.color;
             }
-            long colorDuration = System.nanoTime() - colorStart;
 
-            Sidecar sidecar = new Sidecar(
+            return new Sidecar(
                     size,
                     buffer.palette.toArray(new String[0]),
                     indices,
                     colors,
                     this.resolver.warning()
             );
-
-            long loopTime = System.nanoTime() - loopStart;
-            long totalResolveTime = System.nanoTime() - resolveStart;
-
-            LOGGER.info("[BiomePreview Profiler] resolve() total: {} ms | Loop total: {} ms (Sampler: {} ms, Parallel Quart Resolve: {} ms across {} cells, Palette/Colors: {} ms)",
-                    toMs(totalResolveTime), toMs(loopTime), toMs(samplerDuration), toMs(resolveQuartDuration), sampledCells, toMs(colorDuration));
-
-            return sidecar;
         } finally {
             WORKER_BUFFER.get().reset();
         }
@@ -225,7 +183,6 @@ final class BiomePreview {
             Levels levels,
             PreviewCancellation cancellation
     ) {
-        long start = System.nanoTime();
         int size = tile.getBlockSize().size();
         PreviewComputationCache.SidecarKey key = new PreviewComputationCache.SidecarKey(
                 this.cacheKey,
@@ -234,29 +191,17 @@ final class BiomePreview {
                 zoom,
                 size
         );
-        Sidecar result = cache.sidecar(key, () -> this.resolve(tile, centerX, centerZ, zoom, levels, cancellation)).join();
-        LOGGER.info("[BiomePreview Profiler] resolveCached() total wait: {} ms", toMs(System.nanoTime() - start));
-        return result;
+        return cache.sidecar(key, () -> this.resolve(tile, centerX, centerZ, zoom, levels, cancellation)).join();
     }
 
     static CacheKey cacheKey(WorldCreationContext settings, Preset preset) {
-        long start = System.nanoTime();
-
-        long jsonStart = System.nanoTime();
         String presetJson = Preset.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, preset)
                 .result()
                 .map(Object::toString)
                 .orElse("");
-        long jsonDuration = System.nanoTime() - jsonStart;
 
-        long registryStart = System.nanoTime();
         int biomeCount = (int) settings.worldgenLoadContext().lookupOrThrow(Registries.BIOME).listElements().count();
-        long registryDuration = System.nanoTime() - registryStart;
-
         String biomeSource = settings.selectedDimensions().overworld().getBiomeSource().getClass().getName();
-
-        LOGGER.info("[BiomePreview Profiler] cacheKey() total: {} ms | JSON Codec: {} ms | Registry Count: {} ms",
-                toMs(System.nanoTime() - start), toMs(jsonDuration), toMs(registryDuration));
 
         return new CacheKey(
                 settings.options().seed(),
@@ -275,10 +220,6 @@ final class BiomePreview {
             return 2; // 2 blocks/px: 2x2 pixels share 1 Quart
         }
         return 1;     // >= 4 blocks/px: 1+ Quarts per pixel
-    }
-
-    private static String toMs(long nanos) {
-        return String.format("%.2f", nanos / 1_000_000.0);
     }
 
     private static int surfaceY(Cell cell, Levels levels) {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -2,8 +2,6 @@ package raccoonman.reterraforged.client.gui.screen.presetconfig;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
-import java.util.List;
-import java.util.Map;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
@@ -24,6 +22,7 @@ import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 
 final class BiomePreview {
     private static final ResourceLocation UNREGISTERED = ResourceLocation.fromNamespaceAndPath("reterraforged", "unregistered");
+    private static final ThreadLocal<WorkerBuffer> WORKER_BUFFER = ThreadLocal.withInitial(WorkerBuffer::new);
 
     private final BiomePreviewResolver resolver;
     private final CacheKey cacheKey;
@@ -65,24 +64,14 @@ final class BiomePreview {
         short[] indices = new short[size * size];
         int[] colors = new int[size * size];
 
-        List<String> palette = new ArrayList<>(16);
-        Map<Biome, Entry> entryCache = new IdentityHashMap<>(32);
+        WorkerBuffer buffer = WORKER_BUFFER.get();
+        buffer.reset();
 
         int halfSize = size / 2;
         Climate.Sampler sampler = this.resolver.tileClimateSampler(tile, centerX, centerZ, zoom);
 
-        // Mutable holder to satisfy lambda effectively-final constraint
-        final class LocalQuartCache {
-            int qX = Integer.MIN_VALUE;
-            int qY = Integer.MIN_VALUE;
-            int qZ = Integer.MIN_VALUE;
-            Holder<Biome> biome = null;
-        }
-        final LocalQuartCache quartCache = new LocalQuartCache();
-
         try (BiomePreviewIntegration.Session ignored = this.resolver.openIntegrationSession()) {
             tile.iterate((cell, x, z) -> {
-                // Check cancellation once per row
                 if (x == 0) cancellation.check();
 
                 int blockX = centerX + (x - halfSize) * zoom;
@@ -94,32 +83,42 @@ final class BiomePreview {
                 int qZ = QuartPos.fromBlock(blockZ);
 
                 Holder<Biome> biome;
-                if (qX == quartCache.qX && qY == quartCache.qY && qZ == quartCache.qZ && quartCache.biome != null) {
-                    biome = quartCache.biome;
+                if (qX == buffer.lastQX && qY == buffer.lastQY && qZ == buffer.lastQZ && buffer.lastBiome != null) {
+                    biome = buffer.lastBiome;
                 } else {
                     biome = this.resolver.resolveQuart(qX, qY, qZ, sampler);
-                    quartCache.qX = qX;
-                    quartCache.qY = qY;
-                    quartCache.qZ = qZ;
-                    quartCache.biome = biome;
+                    buffer.lastQX = qX;
+                    buffer.lastQY = qY;
+                    buffer.lastQZ = qZ;
+                    buffer.lastBiome = biome;
                 }
 
                 Biome rawBiome = biome.value();
-                Entry entry = entryCache.get(rawBiome);
+                Entry entry = buffer.entryCache.get(rawBiome);
                 if (entry == null) {
                     ResourceLocation id = biome.unwrapKey().map(ResourceKey::location).orElse(UNREGISTERED);
-                    short paletteIdx = (short) palette.size();
-                    palette.add(id.toString());
-                    entry = new Entry(paletteIdx, BiomePreviewColors.color(biome, id));
-                    entryCache.put(rawBiome, entry);
+                    short paletteIdx = (short) buffer.palette.size();
+                    buffer.palette.add(id.toString());
+                    entry = buffer.obtainEntry(paletteIdx, BiomePreviewColors.color(biome, id));
+                    buffer.entryCache.put(rawBiome, entry);
                 }
 
                 int index = z * size + x;
                 indices[index] = entry.paletteIndex;
                 colors[index] = entry.color;
             });
+
+            return new Sidecar(
+                    this.cacheKey,
+                    size,
+                    buffer.palette.toArray(new String[0]),
+                    indices,
+                    colors,
+                    this.resolver.warning()
+            );
+        } finally {
+            buffer.reset(); // Release Holder<Biome> and registry references to avoid memory leaks
         }
-        return new Sidecar(this.cacheKey, size, palette.toArray(new String[0]), indices, colors, this.resolver.warning());
     }
 
     Sidecar resolveCached(
@@ -143,7 +142,6 @@ final class BiomePreview {
     }
 
     static CacheKey cacheKey(WorldCreationContext settings, Preset preset) {
-        // Fast structural fingerprinting instead of full JSON serialization & registry sorting
         int presetHash = preset.hashCode();
         int biomeCount = (int) settings.worldgenLoadContext().lookupOrThrow(Registries.BIOME).listElements().count();
         String biomeSource = settings.selectedDimensions().overworld().getBiomeSource().getClass().getName();
@@ -163,7 +161,47 @@ final class BiomePreview {
         return Math.max(minY, Math.min(maxY, levels.scale(cell.height)));
     }
 
-    private record Entry(short paletteIndex, int color) {}
+    private static final class Entry {
+        short paletteIndex;
+        int color;
+    }
+
+    private static final class WorkerBuffer {
+        final IdentityHashMap<Biome, Entry> entryCache = new IdentityHashMap<>(32);
+        final ArrayList<String> palette = new ArrayList<>(32);
+        final ArrayList<Entry> entryPool = new ArrayList<>(32);
+
+        int lastQX = Integer.MIN_VALUE;
+        int lastQY = Integer.MIN_VALUE;
+        int lastQZ = Integer.MIN_VALUE;
+        Holder<Biome> lastBiome = null;
+
+        private int entryPoolIndex = 0;
+
+        Entry obtainEntry(short paletteIndex, int color) {
+            Entry entry;
+            if (this.entryPoolIndex < this.entryPool.size()) {
+                entry = this.entryPool.get(this.entryPoolIndex);
+            } else {
+                entry = new Entry();
+                this.entryPool.add(entry);
+            }
+            this.entryPoolIndex++;
+            entry.paletteIndex = paletteIndex;
+            entry.color = color;
+            return entry;
+        }
+
+        void reset() {
+            this.entryCache.clear();
+            this.palette.clear();
+            this.entryPoolIndex = 0;
+            this.lastQX = Integer.MIN_VALUE;
+            this.lastQY = Integer.MIN_VALUE;
+            this.lastQZ = Integer.MIN_VALUE;
+            this.lastBiome = null;
+        }
+    }
 
     record CacheKey(long seed, int presetHash, int dataConfigHash, String biomeSource, int biomeCount) {}
 

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -3,19 +3,21 @@ package raccoonman.reterraforged.client.gui.screen.presetconfig;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 
+import com.mojang.serialization.JsonOps;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
 import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.WorldDataConfiguration;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Climate;
 import net.minecraft.world.level.dimension.LevelStem;
-import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.world.worldgen.GeneratorContext;
-import raccoonman.reterraforged.world.worldgen.biome.BiomePreviewResolver;
 import raccoonman.reterraforged.world.worldgen.biome.BiomePreviewIntegration;
+import raccoonman.reterraforged.world.worldgen.biome.BiomePreviewResolver;
 import raccoonman.reterraforged.world.worldgen.cell.Cell;
 import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
@@ -141,14 +143,17 @@ final class BiomePreview {
     }
 
     static CacheKey cacheKey(WorldCreationContext settings, Preset preset) {
-        int presetHash = preset.hashCode();
+        String presetJson = Preset.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, preset)
+                .result()
+                .map(Object::toString)
+                .orElse("");
         int biomeCount = (int) settings.worldgenLoadContext().lookupOrThrow(Registries.BIOME).listElements().count();
         String biomeSource = settings.selectedDimensions().overworld().getBiomeSource().getClass().getName();
 
         return new CacheKey(
                 settings.options().seed(),
-                presetHash,
-                settings.dataConfiguration().hashCode(),
+                presetJson,
+                settings.dataConfiguration(),
                 biomeSource,
                 biomeCount
         );
@@ -202,7 +207,13 @@ final class BiomePreview {
         }
     }
 
-    record CacheKey(long seed, int presetHash, int dataConfigHash, String biomeSource, int biomeCount) {}
+    record CacheKey(
+            long seed,
+            String presetJson,
+            WorldDataConfiguration dataConfig,
+            String biomeSource,
+            int biomeCount
+    ) {}
 
     static final class Sidecar {
         private final int size;

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -2,8 +2,13 @@ package raccoonman.reterraforged.client.gui.screen.presetconfig;
 
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.stream.IntStream;
 
+import org.slf4j.Logger;
+import com.mojang.logging.LogUtils;
 import com.mojang.serialization.JsonOps;
+
 import net.minecraft.client.gui.screens.worldselection.WorldCreationContext;
 import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
@@ -23,8 +28,10 @@ import raccoonman.reterraforged.world.worldgen.cell.heightmap.Levels;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 
 final class BiomePreview {
+    private static final Logger LOGGER = LogUtils.getLogger();
     private static final ResourceLocation UNREGISTERED = ResourceLocation.fromNamespaceAndPath("reterraforged", "unregistered");
     private static final ThreadLocal<WorkerBuffer> WORKER_BUFFER = ThreadLocal.withInitial(WorkerBuffer::new);
+    private static final ThreadLocal<ThreadQuartCache> THREAD_CACHE = ThreadLocal.withInitial(ThreadQuartCache::new);
 
     private final BiomePreviewResolver resolver;
     private final CacheKey cacheKey;
@@ -40,8 +47,11 @@ final class BiomePreview {
             Preset preset,
             GeneratorContext generatorContext
     ) {
+        long startTime = System.nanoTime();
         long seed = settings.options().seed();
         LevelStem activeOverworld = settings.selectedDimensions().get(LevelStem.OVERWORLD).orElseThrow();
+
+        long resolverStart = System.nanoTime();
         BiomePreviewResolver resolver = BiomePreviewResolver.create(
                 settings.worldgenLoadContext(),
                 provider,
@@ -51,7 +61,16 @@ final class BiomePreview {
                 generatorContext,
                 seed
         );
-        return new BiomePreview(resolver, cacheKey(settings, preset));
+        long resolverDuration = System.nanoTime() - resolverStart;
+
+        long cacheKeyStart = System.nanoTime();
+        CacheKey key = cacheKey(settings, preset);
+        long cacheKeyDuration = System.nanoTime() - cacheKeyStart;
+
+        LOGGER.info("[BiomePreview Profiler] create() total: {} ms | Resolver setup: {} ms | CacheKey gen: {} ms",
+                toMs(System.nanoTime() - startTime), toMs(resolverDuration), toMs(cacheKeyDuration));
+
+        return new BiomePreview(resolver, key);
     }
 
     Sidecar resolve(
@@ -62,40 +81,88 @@ final class BiomePreview {
             Levels levels,
             PreviewCancellation cancellation
     ) {
+        long resolveStart = System.nanoTime();
         int size = tile.getBlockSize().size();
-        short[] indices = new short[size * size];
-        int[] colors = new int[size * size];
+        int totalPixels = size * size;
+        int border = tile.getBlockSize().border();
 
-        WorkerBuffer buffer = WORKER_BUFFER.get();
-        buffer.reset();
+        @SuppressWarnings("unchecked")
+        Holder<Biome>[] resolvedBiomes = new Holder[totalPixels];
+        short[] indices = new short[totalPixels];
+        int[] colors = new int[totalPixels];
 
         int halfSize = size / 2;
+        int step = getSamplingStep(zoom);
+
+        long samplerStart = System.nanoTime();
         Climate.Sampler sampler = this.resolver.tileClimateSampler(tile, centerX, centerZ, zoom);
+        long samplerDuration = System.nanoTime() - samplerStart;
+
+        long loopStart = System.nanoTime();
 
         try (BiomePreviewIntegration.Session ignored = this.resolver.openIntegrationSession()) {
-            tile.iterate((cell, x, z) -> {
-                if (x == 0) cancellation.check();
+            long resolveQuartStart = System.nanoTime();
 
-                int blockX = centerX + (x - halfSize) * zoom;
-                int blockZ = centerZ + (z - halfSize) * zoom;
-                int surfaceY = surfaceY(cell, levels);
+            // Chunk rows into blocks of 16 to minimize thread scheduling overhead
+            int chunkSize = 16;
+            int numChunks = (size + chunkSize - 1) / chunkSize;
 
-                int qX = QuartPos.fromBlock(blockX);
-                int qY = QuartPos.fromBlock(surfaceY);
-                int qZ = QuartPos.fromBlock(blockZ);
+            // Compute total evaluated sample points for profiler output
+            int sampledWidth = (size + step - 1) / step;
+            int sampledHeight = (size + step - 1) / step;
+            int sampledCells = sampledWidth * sampledHeight;
 
-                Holder<Biome> biome;
-                if (qX == buffer.lastQX && qY == buffer.lastQY && qZ == buffer.lastQZ && buffer.lastBiome != null) {
-                    biome = buffer.lastBiome;
-                } else {
-                    biome = this.resolver.resolveQuart(qX, qY, qZ, sampler);
-                    buffer.lastQX = qX;
-                    buffer.lastQY = qY;
-                    buffer.lastQZ = qZ;
-                    buffer.lastBiome = biome;
+            IntStream.range(0, numChunks).parallel().forEach(chunkIdx -> {
+                cancellation.check();
+                ThreadQuartCache cache = THREAD_CACHE.get();
+                cache.clear();
+
+                int startZ = chunkIdx * chunkSize;
+                int endZ = Math.min(size, startZ + chunkSize);
+
+                for (int z = startZ; z < endZ; z += step) {
+                    int blockZ = centerZ + (z - halfSize) * zoom;
+                    int relZ = border + z;
+                    int maxZ = Math.min(size, z + step);
+
+                    for (int x = 0; x < size; x += step) {
+                        int blockX = centerX + (x - halfSize) * zoom;
+                        int relX = border + x;
+                        Cell cell = tile.getCellRaw(relX, relZ);
+                        int surfaceY = surfaceY(cell, levels);
+
+                        int qX = QuartPos.fromBlock(blockX);
+                        int qY = QuartPos.fromBlock(surfaceY);
+                        int qZ = QuartPos.fromBlock(blockZ);
+
+                        Holder<Biome> biome = cache.get(qX, qY, qZ);
+                        if (biome == null) {
+                            biome = this.resolver.resolveQuart(qX, qY, qZ, sampler);
+                            cache.put(qX, qY, qZ, biome);
+                        }
+
+                        // Fill pixel block for the current stride
+                        int maxX = Math.min(size, x + step);
+                        for (int fillZ = z; fillZ < maxZ; fillZ++) {
+                            int rowOffset = fillZ * size;
+                            for (int fillX = x; fillX < maxX; fillX++) {
+                                resolvedBiomes[rowOffset + fillX] = biome;
+                            }
+                        }
+                    }
                 }
+            });
+            long resolveQuartDuration = System.nanoTime() - resolveQuartStart;
 
+            // Sequential Palette & Color Assembly
+            long colorStart = System.nanoTime();
+            WorkerBuffer buffer = WORKER_BUFFER.get();
+            buffer.reset();
+
+            for (int i = 0; i < totalPixels; i++) {
+                Holder<Biome> biome = resolvedBiomes[i];
                 Biome rawBiome = biome.value();
+
                 Entry entry = buffer.entryCache.get(rawBiome);
                 if (entry == null) {
                     ResourceLocation id = biome.unwrapKey().map(ResourceKey::location).orElse(UNREGISTERED);
@@ -105,20 +172,28 @@ final class BiomePreview {
                     buffer.entryCache.put(rawBiome, entry);
                 }
 
-                int index = z * size + x;
-                indices[index] = entry.paletteIndex;
-                colors[index] = entry.color;
-            });
+                indices[i] = entry.paletteIndex;
+                colors[i] = entry.color;
+            }
+            long colorDuration = System.nanoTime() - colorStart;
 
-            return new Sidecar(
+            Sidecar sidecar = new Sidecar(
                     size,
                     buffer.palette.toArray(new String[0]),
                     indices,
                     colors,
                     this.resolver.warning()
             );
+
+            long loopTime = System.nanoTime() - loopStart;
+            long totalResolveTime = System.nanoTime() - resolveStart;
+
+            LOGGER.info("[BiomePreview Profiler] resolve() total: {} ms | Loop total: {} ms (Sampler: {} ms, Parallel Quart Resolve: {} ms across {} cells, Palette/Colors: {} ms)",
+                    toMs(totalResolveTime), toMs(loopTime), toMs(samplerDuration), toMs(resolveQuartDuration), sampledCells, toMs(colorDuration));
+
+            return sidecar;
         } finally {
-            buffer.reset(); // Release Holder<Biome> and registry references to avoid memory leaks
+            WORKER_BUFFER.get().reset();
         }
     }
 
@@ -131,6 +206,7 @@ final class BiomePreview {
             Levels levels,
             PreviewCancellation cancellation
     ) {
+        long start = System.nanoTime();
         int size = tile.getBlockSize().size();
         PreviewComputationCache.SidecarKey key = new PreviewComputationCache.SidecarKey(
                 this.cacheKey,
@@ -139,16 +215,29 @@ final class BiomePreview {
                 zoom,
                 size
         );
-        return cache.sidecar(key, () -> this.resolve(tile, centerX, centerZ, zoom, levels, cancellation)).join();
+        Sidecar result = cache.sidecar(key, () -> this.resolve(tile, centerX, centerZ, zoom, levels, cancellation)).join();
+        LOGGER.info("[BiomePreview Profiler] resolveCached() total wait: {} ms", toMs(System.nanoTime() - start));
+        return result;
     }
 
     static CacheKey cacheKey(WorldCreationContext settings, Preset preset) {
+        long start = System.nanoTime();
+
+        long jsonStart = System.nanoTime();
         String presetJson = Preset.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, preset)
                 .result()
                 .map(Object::toString)
                 .orElse("");
+        long jsonDuration = System.nanoTime() - jsonStart;
+
+        long registryStart = System.nanoTime();
         int biomeCount = (int) settings.worldgenLoadContext().lookupOrThrow(Registries.BIOME).listElements().count();
+        long registryDuration = System.nanoTime() - registryStart;
+
         String biomeSource = settings.selectedDimensions().overworld().getBiomeSource().getClass().getName();
+
+        LOGGER.info("[BiomePreview Profiler] cacheKey() total: {} ms | JSON Codec: {} ms | Registry Count: {} ms",
+                toMs(System.nanoTime() - start), toMs(jsonDuration), toMs(registryDuration));
 
         return new CacheKey(
                 settings.options().seed(),
@@ -157,6 +246,20 @@ final class BiomePreview {
                 biomeSource,
                 biomeCount
         );
+    }
+
+    private static int getSamplingStep(int zoom) {
+        if (zoom <= 1) {
+            return 4; // 1 block/px: 4x4 pixels share 1 Quart
+        }
+        if (zoom == 2) {
+            return 2; // 2 blocks/px: 2x2 pixels share 1 Quart
+        }
+        return 1;     // >= 4 blocks/px: 1+ Quarts per pixel
+    }
+
+    private static String toMs(long nanos) {
+        return String.format("%.2f", nanos / 1_000_000.0);
     }
 
     private static int surfaceY(Cell cell, Levels levels) {
@@ -174,11 +277,6 @@ final class BiomePreview {
         final IdentityHashMap<Biome, Entry> entryCache = new IdentityHashMap<>(32);
         final ArrayList<String> palette = new ArrayList<>(32);
         final ArrayList<Entry> entryPool = new ArrayList<>(32);
-
-        int lastQX = Integer.MIN_VALUE;
-        int lastQY = Integer.MIN_VALUE;
-        int lastQZ = Integer.MIN_VALUE;
-        Holder<Biome> lastBiome = null;
 
         private int entryPoolIndex = 0;
 
@@ -200,10 +298,42 @@ final class BiomePreview {
             this.entryCache.clear();
             this.palette.clear();
             this.entryPoolIndex = 0;
-            this.lastQX = Integer.MIN_VALUE;
-            this.lastQY = Integer.MIN_VALUE;
-            this.lastQZ = Integer.MIN_VALUE;
-            this.lastBiome = null;
+        }
+    }
+
+    /**
+     * Fast thread-local direct-mapped cache for Quart coordinates to prevent redundant calls.
+     */
+    private static final class ThreadQuartCache {
+        private static final int MASK = 255; // 256 entries
+        private final long[] keys = new long[256];
+        @SuppressWarnings("unchecked")
+        private final Holder<Biome>[] values = new Holder[256];
+
+        ThreadQuartCache() {
+            clear();
+        }
+
+        void clear() {
+            java.util.Arrays.fill(keys, Long.MIN_VALUE);
+            java.util.Arrays.fill(values, null);
+        }
+
+        Holder<Biome> get(int qX, int qY, int qZ) {
+            long key = pack(qX, qY, qZ);
+            int slot = (int) (key & MASK);
+            return keys[slot] == key ? values[slot] : null;
+        }
+
+        void put(int qX, int qY, int qZ, Holder<Biome> biome) {
+            long key = pack(qX, qY, qZ);
+            int slot = (int) (key & MASK);
+            keys[slot] = key;
+            values[slot] = biome;
+        }
+
+        private static long pack(int qX, int qY, int qZ) {
+            return (((long) qX & 0x3FFFFF) << 42) | (((long) qY & 0xFFFFF) << 22) | ((long) qZ & 0x3FFFFF);
         }
     }
 

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -109,7 +109,6 @@ final class BiomePreview {
             });
 
             return new Sidecar(
-                    this.cacheKey,
                     size,
                     buffer.palette.toArray(new String[0]),
                     indices,
@@ -206,15 +205,13 @@ final class BiomePreview {
     record CacheKey(long seed, int presetHash, int dataConfigHash, String biomeSource, int biomeCount) {}
 
     static final class Sidecar {
-        private final CacheKey cacheKey;
         private final int size;
         private final String[] palette;
         private final short[] indices;
         private final int[] colors;
         private final String warning;
 
-        private Sidecar(CacheKey cacheKey, int size, String[] palette, short[] indices, int[] colors, String warning) {
-            this.cacheKey = cacheKey;
+        private Sidecar(int size, String[] palette, short[] indices, int[] colors, String warning) {
             this.size = size;
             this.palette = palette;
             this.indices = indices;
@@ -228,10 +225,6 @@ final class BiomePreview {
 
         int color(int x, int z) {
             return this.colors[this.index(x, z)];
-        }
-
-        CacheKey cacheKey() {
-            return this.cacheKey;
         }
 
         String warning() {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -61,8 +61,7 @@ final class BiomePreview {
             PreviewCancellation cancellation
     ) {
         int size = tile.getBlockSize().size();
-        short[] indices = new short[size * size];
-        int[] colors = new int[size * size];
+        byte[] indices = new byte[size * size];
 
         WorkerBuffer buffer = WORKER_BUFFER.get();
         buffer.reset();
@@ -97,27 +96,32 @@ final class BiomePreview {
                 Entry entry = buffer.entryCache.get(rawBiome);
                 if (entry == null) {
                     ResourceLocation id = biome.unwrapKey().map(ResourceKey::location).orElse(UNREGISTERED);
-                    short paletteIdx = (short) buffer.palette.size();
+                    byte paletteIdx = (byte) buffer.palette.size();
+                    int color = BiomePreviewColors.color(biome, id);
                     buffer.palette.add(id.toString());
-                    entry = buffer.obtainEntry(paletteIdx, BiomePreviewColors.color(biome, id));
+                    buffer.paletteColors.add(color);
+                    entry = buffer.obtainEntry(paletteIdx);
                     buffer.entryCache.put(rawBiome, entry);
                 }
 
-                int index = z * size + x;
-                indices[index] = entry.paletteIndex;
-                colors[index] = entry.color;
+                indices[z * size + x] = entry.paletteIndex;
             });
+
+            int[] paletteColors = new int[buffer.paletteColors.size()];
+            for (int i = 0; i < paletteColors.length; i++) {
+                paletteColors[i] = buffer.paletteColors.get(i);
+            }
 
             return new Sidecar(
                     this.cacheKey,
                     size,
                     buffer.palette.toArray(new String[0]),
+                    paletteColors,
                     indices,
-                    colors,
                     this.resolver.warning()
             );
         } finally {
-            buffer.reset(); // Release Holder<Biome> and registry references to avoid memory leaks
+            buffer.reset();
         }
     }
 
@@ -162,13 +166,13 @@ final class BiomePreview {
     }
 
     private static final class Entry {
-        short paletteIndex;
-        int color;
+        byte paletteIndex;
     }
 
     private static final class WorkerBuffer {
         final IdentityHashMap<Biome, Entry> entryCache = new IdentityHashMap<>(32);
         final ArrayList<String> palette = new ArrayList<>(32);
+        final ArrayList<Integer> paletteColors = new ArrayList<>(32);
         final ArrayList<Entry> entryPool = new ArrayList<>(32);
 
         int lastQX = Integer.MIN_VALUE;
@@ -178,7 +182,7 @@ final class BiomePreview {
 
         private int entryPoolIndex = 0;
 
-        Entry obtainEntry(short paletteIndex, int color) {
+        Entry obtainEntry(byte paletteIndex) {
             Entry entry;
             if (this.entryPoolIndex < this.entryPool.size()) {
                 entry = this.entryPool.get(this.entryPoolIndex);
@@ -188,13 +192,13 @@ final class BiomePreview {
             }
             this.entryPoolIndex++;
             entry.paletteIndex = paletteIndex;
-            entry.color = color;
             return entry;
         }
 
         void reset() {
             this.entryCache.clear();
             this.palette.clear();
+            this.paletteColors.clear();
             this.entryPoolIndex = 0;
             this.lastQX = Integer.MIN_VALUE;
             this.lastQY = Integer.MIN_VALUE;
@@ -209,29 +213,27 @@ final class BiomePreview {
         private final CacheKey cacheKey;
         private final int size;
         private final String[] palette;
-        private final short[] indices;
-        private final int[] colors;
+        private final int[] paletteColors;
+        private final byte[] indices;
         private final String warning;
 
-        private Sidecar(CacheKey cacheKey, int size, String[] palette, short[] indices, int[] colors, String warning) {
+        private Sidecar(CacheKey cacheKey, int size, String[] palette, int[] paletteColors, byte[] indices, String warning) {
             this.cacheKey = cacheKey;
             this.size = size;
             this.palette = palette;
+            this.paletteColors = paletteColors;
             this.indices = indices;
-            this.colors = colors;
             this.warning = warning;
         }
 
         String id(int x, int z) {
-            return this.palette[this.indices[this.index(x, z)]];
+            int idx = Byte.toUnsignedInt(this.indices[this.index(x, z)]);
+            return this.palette[idx];
         }
 
         int color(int x, int z) {
-            return this.colors[this.index(x, z)];
-        }
-
-        CacheKey cacheKey() {
-            return this.cacheKey;
+            int idx = Byte.toUnsignedInt(this.indices[this.index(x, z)]);
+            return this.paletteColors[idx];
         }
 
         String warning() {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -61,7 +61,8 @@ final class BiomePreview {
             PreviewCancellation cancellation
     ) {
         int size = tile.getBlockSize().size();
-        byte[] indices = new byte[size * size];
+        short[] indices = new short[size * size];
+        int[] colors = new int[size * size];
 
         WorkerBuffer buffer = WORKER_BUFFER.get();
         buffer.reset();
@@ -96,32 +97,27 @@ final class BiomePreview {
                 Entry entry = buffer.entryCache.get(rawBiome);
                 if (entry == null) {
                     ResourceLocation id = biome.unwrapKey().map(ResourceKey::location).orElse(UNREGISTERED);
-                    byte paletteIdx = (byte) buffer.palette.size();
-                    int color = BiomePreviewColors.color(biome, id);
+                    short paletteIdx = (short) buffer.palette.size();
                     buffer.palette.add(id.toString());
-                    buffer.paletteColors.add(color);
-                    entry = buffer.obtainEntry(paletteIdx);
+                    entry = buffer.obtainEntry(paletteIdx, BiomePreviewColors.color(biome, id));
                     buffer.entryCache.put(rawBiome, entry);
                 }
 
-                indices[z * size + x] = entry.paletteIndex;
+                int index = z * size + x;
+                indices[index] = entry.paletteIndex;
+                colors[index] = entry.color;
             });
-
-            int[] paletteColors = new int[buffer.paletteColors.size()];
-            for (int i = 0; i < paletteColors.length; i++) {
-                paletteColors[i] = buffer.paletteColors.get(i);
-            }
 
             return new Sidecar(
                     this.cacheKey,
                     size,
                     buffer.palette.toArray(new String[0]),
-                    paletteColors,
                     indices,
+                    colors,
                     this.resolver.warning()
             );
         } finally {
-            buffer.reset();
+            buffer.reset(); // Release Holder<Biome> and registry references to avoid memory leaks
         }
     }
 
@@ -166,13 +162,13 @@ final class BiomePreview {
     }
 
     private static final class Entry {
-        byte paletteIndex;
+        short paletteIndex;
+        int color;
     }
 
     private static final class WorkerBuffer {
         final IdentityHashMap<Biome, Entry> entryCache = new IdentityHashMap<>(32);
         final ArrayList<String> palette = new ArrayList<>(32);
-        final ArrayList<Integer> paletteColors = new ArrayList<>(32);
         final ArrayList<Entry> entryPool = new ArrayList<>(32);
 
         int lastQX = Integer.MIN_VALUE;
@@ -182,7 +178,7 @@ final class BiomePreview {
 
         private int entryPoolIndex = 0;
 
-        Entry obtainEntry(byte paletteIndex) {
+        Entry obtainEntry(short paletteIndex, int color) {
             Entry entry;
             if (this.entryPoolIndex < this.entryPool.size()) {
                 entry = this.entryPool.get(this.entryPoolIndex);
@@ -192,13 +188,13 @@ final class BiomePreview {
             }
             this.entryPoolIndex++;
             entry.paletteIndex = paletteIndex;
+            entry.color = color;
             return entry;
         }
 
         void reset() {
             this.entryCache.clear();
             this.palette.clear();
-            this.paletteColors.clear();
             this.entryPoolIndex = 0;
             this.lastQX = Integer.MIN_VALUE;
             this.lastQY = Integer.MIN_VALUE;
@@ -213,27 +209,29 @@ final class BiomePreview {
         private final CacheKey cacheKey;
         private final int size;
         private final String[] palette;
-        private final int[] paletteColors;
-        private final byte[] indices;
+        private final short[] indices;
+        private final int[] colors;
         private final String warning;
 
-        private Sidecar(CacheKey cacheKey, int size, String[] palette, int[] paletteColors, byte[] indices, String warning) {
+        private Sidecar(CacheKey cacheKey, int size, String[] palette, short[] indices, int[] colors, String warning) {
             this.cacheKey = cacheKey;
             this.size = size;
             this.palette = palette;
-            this.paletteColors = paletteColors;
             this.indices = indices;
+            this.colors = colors;
             this.warning = warning;
         }
 
         String id(int x, int z) {
-            int idx = Byte.toUnsignedInt(this.indices[this.index(x, z)]);
-            return this.palette[idx];
+            return this.palette[this.indices[this.index(x, z)]];
         }
 
         int color(int x, int z) {
-            int idx = Byte.toUnsignedInt(this.indices[this.index(x, z)]);
-            return this.paletteColors[idx];
+            return this.colors[this.index(x, z)];
+        }
+
+        CacheKey cacheKey() {
+            return this.cacheKey;
         }
 
         String warning() {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -1,14 +1,14 @@
 package raccoonman.reterraforged.client.gui.screen.presetconfig;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-
-import com.mojang.serialization.JsonOps;
 
 import net.minecraft.core.Holder;
 import net.minecraft.core.QuartPos;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Climate;
@@ -34,101 +34,126 @@ final class BiomePreview {
     }
 
     static BiomePreview create(
-        WorldCreationContext settings,
-        net.minecraft.core.HolderLookup.Provider provider,
-        Preset preset,
-        GeneratorContext generatorContext
+            WorldCreationContext settings,
+            net.minecraft.core.HolderLookup.Provider provider,
+            Preset preset,
+            GeneratorContext generatorContext
     ) {
         long seed = settings.options().seed();
         LevelStem activeOverworld = settings.selectedDimensions().get(LevelStem.OVERWORLD).orElseThrow();
         BiomePreviewResolver resolver = BiomePreviewResolver.create(
-            settings.worldgenLoadContext(),
-            provider,
-            activeOverworld.type(),
-            activeOverworld.generator(),
-            preset,
-            generatorContext,
-            seed
+                settings.worldgenLoadContext(),
+                provider,
+                activeOverworld.type(),
+                activeOverworld.generator(),
+                preset,
+                generatorContext,
+                seed
         );
         return new BiomePreview(resolver, cacheKey(settings, preset));
     }
 
     Sidecar resolve(
-        Tile tile,
-        int centerX,
-        int centerZ,
-        int zoom,
-        Levels levels,
-        PreviewCancellation cancellation
+            Tile tile,
+            int centerX,
+            int centerZ,
+            int zoom,
+            Levels levels,
+            PreviewCancellation cancellation
     ) {
         int size = tile.getBlockSize().size();
-        String[] ids = new String[size * size];
-		int[] colors = new int[size * size];
-		Map<ResourceLocation, Entry> entries = new HashMap<>();
-		int halfSize = size / 2;
-		Climate.Sampler sampler = this.resolver.tileClimateSampler(tile, centerX, centerZ, zoom);
+        short[] indices = new short[size * size];
+        int[] colors = new int[size * size];
+
+        List<String> palette = new ArrayList<>(16);
+        Map<Biome, Entry> entryCache = new IdentityHashMap<>(32);
+
+        int halfSize = size / 2;
+        Climate.Sampler sampler = this.resolver.tileClimateSampler(tile, centerX, centerZ, zoom);
+
+        // Mutable holder to satisfy lambda effectively-final constraint
+        final class LocalQuartCache {
+            int qX = Integer.MIN_VALUE;
+            int qY = Integer.MIN_VALUE;
+            int qZ = Integer.MIN_VALUE;
+            Holder<Biome> biome = null;
+        }
+        final LocalQuartCache quartCache = new LocalQuartCache();
 
         try (BiomePreviewIntegration.Session ignored = this.resolver.openIntegrationSession()) {
             tile.iterate((cell, x, z) -> {
-                cancellation.check();
+                // Check cancellation once per row
+                if (x == 0) cancellation.check();
+
                 int blockX = centerX + (x - halfSize) * zoom;
                 int blockZ = centerZ + (z - halfSize) * zoom;
                 int surfaceY = surfaceY(cell, levels);
-				Holder<Biome> biome = this.resolver.resolveQuart(
-					QuartPos.fromBlock(blockX),
-					QuartPos.fromBlock(surfaceY),
-					QuartPos.fromBlock(blockZ),
-					sampler
-				);
-                ResourceLocation id = biome.unwrapKey().map(key -> key.location()).orElse(UNREGISTERED);
-                Entry entry = entries.computeIfAbsent(
-                    id,
-                    key -> new Entry(key.toString(), BiomePreviewColors.color(biome, key))
-                );
+
+                int qX = QuartPos.fromBlock(blockX);
+                int qY = QuartPos.fromBlock(surfaceY);
+                int qZ = QuartPos.fromBlock(blockZ);
+
+                Holder<Biome> biome;
+                if (qX == quartCache.qX && qY == quartCache.qY && qZ == quartCache.qZ && quartCache.biome != null) {
+                    biome = quartCache.biome;
+                } else {
+                    biome = this.resolver.resolveQuart(qX, qY, qZ, sampler);
+                    quartCache.qX = qX;
+                    quartCache.qY = qY;
+                    quartCache.qZ = qZ;
+                    quartCache.biome = biome;
+                }
+
+                Biome rawBiome = biome.value();
+                Entry entry = entryCache.get(rawBiome);
+                if (entry == null) {
+                    ResourceLocation id = biome.unwrapKey().map(ResourceKey::location).orElse(UNREGISTERED);
+                    short paletteIdx = (short) palette.size();
+                    palette.add(id.toString());
+                    entry = new Entry(paletteIdx, BiomePreviewColors.color(biome, id));
+                    entryCache.put(rawBiome, entry);
+                }
+
                 int index = z * size + x;
-                ids[index] = entry.id;
+                indices[index] = entry.paletteIndex;
                 colors[index] = entry.color;
             });
         }
-        return new Sidecar(this.cacheKey, size, ids, colors, this.resolver.warning());
+        return new Sidecar(this.cacheKey, size, palette.toArray(new String[0]), indices, colors, this.resolver.warning());
     }
 
     Sidecar resolveCached(
-        PreviewComputationCache cache,
-        Tile tile,
-        int centerX,
-        int centerZ,
-        int zoom,
-        Levels levels,
-        PreviewCancellation cancellation
+            PreviewComputationCache cache,
+            Tile tile,
+            int centerX,
+            int centerZ,
+            int zoom,
+            Levels levels,
+            PreviewCancellation cancellation
     ) {
         int size = tile.getBlockSize().size();
         PreviewComputationCache.SidecarKey key = new PreviewComputationCache.SidecarKey(
-            this.cacheKey,
-            centerX,
-            centerZ,
-            zoom,
-            size
+                this.cacheKey,
+                centerX,
+                centerZ,
+                zoom,
+                size
         );
         return cache.sidecar(key, () -> this.resolve(tile, centerX, centerZ, zoom, levels, cancellation)).join();
     }
 
     static CacheKey cacheKey(WorldCreationContext settings, Preset preset) {
-        String encodedPreset = Preset.DIRECT_CODEC.encodeStart(JsonOps.INSTANCE, preset)
-            .getOrThrow(message -> new IllegalStateException("Failed to fingerprint preview preset: " + message))
-            .toString();
-        List<String> biomeIds = settings.worldgenLoadContext().lookupOrThrow(Registries.BIOME)
-            .listElementIds()
-            .map(key -> key.location().toString())
-            .sorted()
-            .toList();
+        // Fast structural fingerprinting instead of full JSON serialization & registry sorting
+        int presetHash = preset.hashCode();
+        int biomeCount = (int) settings.worldgenLoadContext().lookupOrThrow(Registries.BIOME).listElements().count();
         String biomeSource = settings.selectedDimensions().overworld().getBiomeSource().getClass().getName();
+
         return new CacheKey(
-            settings.options().seed(),
-            encodedPreset,
-            settings.dataConfiguration().toString(),
-            biomeSource,
-            biomeIds
+                settings.options().seed(),
+                presetHash,
+                settings.dataConfiguration().hashCode(),
+                biomeSource,
+                biomeCount
         );
     }
 
@@ -138,29 +163,29 @@ final class BiomePreview {
         return Math.max(minY, Math.min(maxY, levels.scale(cell.height)));
     }
 
-    private record Entry(String id, int color) {
-    }
+    private record Entry(short paletteIndex, int color) {}
 
-    record CacheKey(long seed, String preset, String dataConfiguration, String biomeSource, List<String> biomeIds) {
-    }
+    record CacheKey(long seed, int presetHash, int dataConfigHash, String biomeSource, int biomeCount) {}
 
     static final class Sidecar {
         private final CacheKey cacheKey;
         private final int size;
-        private final String[] ids;
+        private final String[] palette;
+        private final short[] indices;
         private final int[] colors;
         private final String warning;
 
-        private Sidecar(CacheKey cacheKey, int size, String[] ids, int[] colors, String warning) {
+        private Sidecar(CacheKey cacheKey, int size, String[] palette, short[] indices, int[] colors, String warning) {
             this.cacheKey = cacheKey;
             this.size = size;
-            this.ids = ids;
+            this.palette = palette;
+            this.indices = indices;
             this.colors = colors;
             this.warning = warning;
         }
 
         String id(int x, int z) {
-            return this.ids[this.index(x, z)];
+            return this.palette[this.indices[this.index(x, z)]];
         }
 
         int color(int x, int z) {

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/BiomePreview.java
@@ -19,6 +19,7 @@ import net.minecraft.world.level.WorldDataConfiguration;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.Climate;
 import net.minecraft.world.level.dimension.LevelStem;
+import raccoonman.reterraforged.compat.biolith.BiolithPreviewContext;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 import raccoonman.reterraforged.world.worldgen.GeneratorContext;
 import raccoonman.reterraforged.world.worldgen.biome.BiomePreviewIntegration;
@@ -112,44 +113,62 @@ final class BiomePreview {
             int sampledHeight = (size + step - 1) / step;
             int sampledCells = sampledWidth * sampledHeight;
 
+            // Capture the Biolith preview state on this thread (the one that opened the
+            // integration session above) so it can be re-attached on whichever
+            // ForkJoinPool worker thread each chunk below actually executes on.
+            // Without this, BiolithPreviewContext.isActive() reads false on worker
+            // threads (ThreadLocal state doesn't propagate to pooled threads), causing
+            // the preview redirects to silently fall through to Biolith's real,
+            // uninitialized fields and NPE.
+            Object biolithState = BiolithPreviewContext.captureState();
+
             IntStream.range(0, numChunks).parallel().forEach(chunkIdx -> {
                 cancellation.check();
                 ThreadQuartCache cache = THREAD_CACHE.get();
                 cache.clear();
 
-                int startZ = chunkIdx * chunkSize;
-                int endZ = Math.min(size, startZ + chunkSize);
+                try (AutoCloseable biolithAttach = BiolithPreviewContext.attach(biolithState)) {
+                    int startZ = chunkIdx * chunkSize;
+                    int endZ = Math.min(size, startZ + chunkSize);
 
-                for (int z = startZ; z < endZ; z += step) {
-                    int blockZ = centerZ + (z - halfSize) * zoom;
-                    int relZ = border + z;
-                    int maxZ = Math.min(size, z + step);
+                    for (int z = startZ; z < endZ; z += step) {
+                        int blockZ = centerZ + (z - halfSize) * zoom;
+                        int relZ = border + z;
+                        int maxZ = Math.min(size, z + step);
 
-                    for (int x = 0; x < size; x += step) {
-                        int blockX = centerX + (x - halfSize) * zoom;
-                        int relX = border + x;
-                        Cell cell = tile.getCellRaw(relX, relZ);
-                        int surfaceY = surfaceY(cell, levels);
+                        for (int x = 0; x < size; x += step) {
+                            int blockX = centerX + (x - halfSize) * zoom;
+                            int relX = border + x;
+                            Cell cell = tile.getCellRaw(relX, relZ);
+                            int surfaceY = surfaceY(cell, levels);
 
-                        int qX = QuartPos.fromBlock(blockX);
-                        int qY = QuartPos.fromBlock(surfaceY);
-                        int qZ = QuartPos.fromBlock(blockZ);
+                            int qX = QuartPos.fromBlock(blockX);
+                            int qY = QuartPos.fromBlock(surfaceY);
+                            int qZ = QuartPos.fromBlock(blockZ);
 
-                        Holder<Biome> biome = cache.get(qX, qY, qZ);
-                        if (biome == null) {
-                            biome = this.resolver.resolveQuart(qX, qY, qZ, sampler);
-                            cache.put(qX, qY, qZ, biome);
-                        }
+                            Holder<Biome> biome = cache.get(qX, qY, qZ);
+                            if (biome == null) {
+                                biome = this.resolver.resolveQuart(qX, qY, qZ, sampler);
+                                cache.put(qX, qY, qZ, biome);
+                            }
 
-                        // Fill pixel block for the current stride
-                        int maxX = Math.min(size, x + step);
-                        for (int fillZ = z; fillZ < maxZ; fillZ++) {
-                            int rowOffset = fillZ * size;
-                            for (int fillX = x; fillX < maxX; fillX++) {
-                                resolvedBiomes[rowOffset + fillX] = biome;
+                            // Fill pixel block for the current stride
+                            int maxX = Math.min(size, x + step);
+                            for (int fillZ = z; fillZ < maxZ; fillZ++) {
+                                int rowOffset = fillZ * size;
+                                for (int fillX = x; fillX < maxX; fillX++) {
+                                    resolvedBiomes[rowOffset + fillX] = biome;
+                                }
                             }
                         }
                     }
+                } catch (RuntimeException | Error error) {
+                    throw error;
+                } catch (Exception error) {
+                    // AutoCloseable.close() declares checked Exception; BiolithPreviewContext's
+                    // implementation never actually throws one, so this path is unreachable
+                    // in practice but must be handled to satisfy the compiler.
+                    throw new RuntimeException(error);
                 }
             });
             long resolveQuartDuration = System.nanoTime() - resolveQuartStart;

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/Preview2D.java
@@ -151,16 +151,15 @@ public class Preview2D extends Button implements IPreviewHandler {
     }
 
     private void uploadPixelData(int[] pixelData) {
-        if (STATIC_TEXTURE == null) {
-            getOrCreateTexture();
-        }
+        if (STATIC_TEXTURE == null || pixelData == null) return;
         NativeImage pixels = STATIC_TEXTURE.getPixels();
-        if (pixels == null || pixelData == null) return;
+        if (pixels == null) return;
 
         int tileWidth = (int) Math.sqrt(pixelData.length);
         for (int bz = 0; bz < tileWidth; bz++) {
+            int rowOffset = bz * tileWidth;
             for (int bx = 0; bx < tileWidth; bx++) {
-                pixels.setPixelRGBA(bx, bz, pixelData[bz * tileWidth + bx]);
+                pixels.setPixelRGBA(bx, bz, pixelData[rowOffset + bx]);
             }
         }
         STATIC_TEXTURE.upload();

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCache.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCache.java
@@ -46,7 +46,7 @@ final class PreviewComputationCache implements AutoCloseable {
             return existing.retain();
         }
 
-        TileEntry entry = new TileEntry(key, tile);
+        TileEntry entry = new TileEntry(tile);
         this.tiles.put(key, entry);
         TileLease lease = entry.retain();
         this.trimTiles();
@@ -171,14 +171,12 @@ final class PreviewComputationCache implements AutoCloseable {
     }
 
     private final class TileEntry {
-        private final TileKey key;
         private final Tile tile;
         private int references;
         private boolean evicted;
         private boolean recycled;
 
-        private TileEntry(TileKey key, Tile tile) {
-            this.key = key;
+        private TileEntry(Tile tile) {
             this.tile = tile;
         }
 

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCache.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCache.java
@@ -1,10 +1,11 @@
 package raccoonman.reterraforged.client.gui.screen.presetconfig;
 
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 import java.util.function.Supplier;
 
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
@@ -12,54 +13,81 @@ import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 /**
  * A screen-scoped cache for immutable preview results.
  *
- * Tiles are pooled/mutable objects in the generator, so callers receive leases
- * rather than the raw tile.  An entry is only recycled after it has been evicted
- * and its last lease is released.  This makes sharing between the 2D and 3D
- * previews safe while keeping the cache bounded to the current editor screen.
+ * Provides zero-allocation LRU eviction, decoupled locking, and async sidecar offloading.
  */
 final class PreviewComputationCache implements AutoCloseable {
     private static final int MAX_TILE_ENTRIES = 6;
     private static final int MAX_SIDECAR_ENTRIES = 8;
 
-    private final LinkedHashMap<TileKey, TileEntry> tiles = new LinkedHashMap<>(16, 0.75F, true);
-    private final LinkedHashMap<SidecarKey, CompletableFuture<BiomePreview.Sidecar>> sidecars = new LinkedHashMap<>(16, 0.75F, true);
+    private final Object tileLock = new Object();
+    private final Object sidecarLock = new Object();
+
+    private final LinkedHashMap<TileKey, TileEntry> tiles = new LinkedHashMap<>(16, 0.75F, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<TileKey, TileEntry> eldest) {
+            if (size() > MAX_TILE_ENTRIES && eldest.getValue().references == 0) {
+                eldest.getValue().evict();
+                return true;
+            }
+            return false;
+        }
+    };
+
+    private final LinkedHashMap<SidecarKey, CompletableFuture<BiomePreview.Sidecar>> sidecars = new LinkedHashMap<>(16, 0.75F, true) {
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<SidecarKey, CompletableFuture<BiomePreview.Sidecar>> eldest) {
+            return size() > MAX_SIDECAR_ENTRIES && eldest.getValue().isDone();
+        }
+    };
+
     private boolean closed;
 
-    synchronized TileLease acquire(TileKey key) {
-        if (this.closed) {
-            return null;
+    TileLease acquire(TileKey key) {
+        synchronized (this.tileLock) {
+            if (this.closed) {
+                return null;
+            }
+            TileEntry entry = this.tiles.get(key);
+            return entry == null ? null : entry.retain();
         }
-        TileEntry entry = this.tiles.get(key);
-        return entry == null ? null : entry.retain();
     }
 
-    synchronized TileLease store(TileKey key, Tile tile) {
+    TileLease store(TileKey key, Tile tile) {
         Objects.requireNonNull(tile, "tile");
-        if (this.closed) {
-            tile.close();
-            return null;
-        }
+        synchronized (this.tileLock) {
+            if (this.closed) {
+                tile.close();
+                return null;
+            }
 
-        TileEntry existing = this.tiles.get(key);
-        if (existing != null) {
-            tile.close();
-            return existing.retain();
-        }
+            TileEntry existing = this.tiles.get(key);
+            if (existing != null) {
+                tile.close();
+                return existing.retain();
+            }
 
-        TileEntry entry = new TileEntry(tile);
-        this.tiles.put(key, entry);
-        TileLease lease = entry.retain();
-        this.trimTiles();
-        return lease;
+            TileEntry entry = new TileEntry(tile);
+            this.tiles.put(key, entry);
+            return entry.retain();
+        }
     }
 
     CompletableFuture<BiomePreview.Sidecar> sidecar(
-        SidecarKey key,
-        Supplier<BiomePreview.Sidecar> supplier
+            SidecarKey key,
+            Supplier<BiomePreview.Sidecar> supplier
+    ) {
+        return sidecar(key, supplier, ForkJoinPool.commonPool());
+    }
+
+    CompletableFuture<BiomePreview.Sidecar> sidecar(
+            SidecarKey key,
+            Supplier<BiomePreview.Sidecar> supplier,
+            Executor executor
     ) {
         CompletableFuture<BiomePreview.Sidecar> future;
         boolean owner = false;
-        synchronized (this) {
+
+        synchronized (this.sidecarLock) {
             if (this.closed) {
                 return CompletableFuture.failedFuture(new IllegalStateException("Preview cache is closed"));
             }
@@ -67,62 +95,44 @@ final class PreviewComputationCache implements AutoCloseable {
             if (future == null) {
                 future = new CompletableFuture<>();
                 this.sidecars.put(key, future);
-                this.trimSidecars();
                 owner = true;
             }
         }
 
         if (owner) {
-            try {
-                future.complete(supplier.get());
-            } catch (Throwable throwable) {
-                future.completeExceptionally(throwable);
-                synchronized (this) {
-                    if (this.sidecars.get(key) == future) {
-                        this.sidecars.remove(key);
-                    }
-                }
-            } finally {
-                synchronized (this) {
-                    this.trimSidecars();
-                }
-            }
+            final CompletableFuture<BiomePreview.Sidecar> targetFuture = future;
+            CompletableFuture.supplyAsync(supplier, executor)
+                    .whenComplete((result, throwable) -> {
+                        if (throwable != null) {
+                            targetFuture.completeExceptionally(throwable);
+                            synchronized (this.sidecarLock) {
+                                if (this.sidecars.get(key) == targetFuture) {
+                                    this.sidecars.remove(key);
+                                }
+                            }
+                        } else {
+                            targetFuture.complete(result);
+                        }
+                    });
         }
         return future;
     }
 
-    private void trimTiles() {
-        Iterator<Map.Entry<TileKey, TileEntry>> iterator = this.tiles.entrySet().iterator();
-        while (this.tiles.size() > MAX_TILE_ENTRIES && iterator.hasNext()) {
-            TileEntry entry = iterator.next().getValue();
-            if (entry.references == 0) {
-                iterator.remove();
-                entry.evict();
-            }
-        }
-    }
-
-    private void trimSidecars() {
-        Iterator<Map.Entry<SidecarKey, CompletableFuture<BiomePreview.Sidecar>>> iterator = this.sidecars.entrySet().iterator();
-        while (this.sidecars.size() > MAX_SIDECAR_ENTRIES && iterator.hasNext()) {
-            Map.Entry<SidecarKey, CompletableFuture<BiomePreview.Sidecar>> entry = iterator.next();
-            if (entry.getValue().isDone()) {
-                iterator.remove();
-            }
-        }
-    }
-
     @Override
-    public synchronized void close() {
-        if (this.closed) {
-            return;
+    public void close() {
+        synchronized (this.tileLock) {
+            synchronized (this.sidecarLock) {
+                if (this.closed) {
+                    return;
+                }
+                this.closed = true;
+                for (TileEntry entry : this.tiles.values()) {
+                    entry.evict();
+                }
+                this.tiles.clear();
+                this.sidecars.clear();
+            }
         }
-        this.closed = true;
-        for (TileEntry entry : this.tiles.values()) {
-            entry.evict();
-        }
-        this.tiles.clear();
-        this.sidecars.clear();
     }
 
     record TileKey(BiomePreview.CacheKey revision, int centerX, int centerZ, int zoom, int size, boolean biomePipeline) {
@@ -151,7 +161,7 @@ final class PreviewComputationCache implements AutoCloseable {
             if (current == null) {
                 throw new IllegalStateException("Preview tile lease is closed");
             }
-            synchronized (PreviewComputationCache.this) {
+            synchronized (PreviewComputationCache.this.tileLock) {
                 return current.retain();
             }
         }
@@ -163,9 +173,8 @@ final class PreviewComputationCache implements AutoCloseable {
                 return;
             }
             this.entry = null;
-            synchronized (PreviewComputationCache.this) {
+            synchronized (PreviewComputationCache.this.tileLock) {
                 current.release();
-                PreviewComputationCache.this.trimTiles();
             }
         }
     }

--- a/common/src/main/java/raccoonman/reterraforged/compat/biolith/BiolithPreviewContext.java
+++ b/common/src/main/java/raccoonman/reterraforged/compat/biolith/BiolithPreviewContext.java
@@ -40,6 +40,26 @@ public final class BiolithPreviewContext {
 	private BiolithPreviewContext() {
 	}
 
+	public static Object captureState() {
+		return ACTIVE.get();
+	}
+
+	public static AutoCloseable attach(Object captured) {
+		if (!(captured instanceof State state)) {
+			return () -> {
+			};
+		}
+		State previous = ACTIVE.get();
+		ACTIVE.set(state);
+		return () -> {
+			if (previous == null) {
+				ACTIVE.remove();
+			} else {
+				ACTIVE.set(previous);
+			}
+		};
+	}
+
 	public static void preInitializeBiomeLookup(RegistryAccess registries) {
 		try {
 			BiomeCoordinator.setEarlyBiomeLookup(registries.lookupOrThrow(Registries.BIOME));

--- a/common/src/main/java/raccoonman/reterraforged/compat/biolith/BiolithPreviewContext.java
+++ b/common/src/main/java/raccoonman/reterraforged/compat/biolith/BiolithPreviewContext.java
@@ -61,10 +61,7 @@ public final class BiolithPreviewContext {
 	}
 
 	public static void preInitializeBiomeLookup(RegistryAccess registries) {
-		try {
-			BiomeCoordinator.setEarlyBiomeLookup(registries.lookupOrThrow(Registries.BIOME));
-		} catch (RuntimeException | LinkageError ignored) {
-		}
+		BiomeCoordinator.setEarlyBiomeLookup(registries.lookupOrThrow(Registries.BIOME));
 	}
 
 	public static BiomePreviewIntegration.Session open(

--- a/common/src/main/java/raccoonman/reterraforged/mixin/terrablender/MixinParameterList.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/terrablender/MixinParameterList.java
@@ -132,21 +132,22 @@ class MixinParameterList<T> implements TerraBlenderParameterList<T> {
 	}
 
 	@ModifyArg(
-		method = "initializeForTerraBlender",
-		at = @At(
-			value = "INVOKE",
-			target = "Lnet/minecraft/world/level/biome/Climate$RTree;create(Ljava/util/List;)Lnet/minecraft/world/level/biome/Climate$RTree;"
-		),
-		index = 0,
-		require = 1
+			method = "initializeForTerraBlender",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/world/level/biome/Climate$RTree;create(Ljava/util/List;)Lnet/minecraft/world/level/biome/Climate$RTree;"
+			),
+			index = 0,
+			require = 1
 	)
 	private List<Pair<Climate.ParameterPoint, T>> reterraforged$captureRegionalEntries(
-		List<Pair<Climate.ParameterPoint, T>> entries
+			List<Pair<Climate.ParameterPoint, T>> entries
 	) {
+		List<Pair<Climate.ParameterPoint, T>> deduplicated = reterraforged$deduplicateEntries(entries);
 		if (this.reterraforged$bandingPreset != null) {
-			this.reterraforged$pendingRegionalEntries.add(List.copyOf(entries));
+			this.reterraforged$pendingRegionalEntries.add(deduplicated);
 		}
-		return entries;
+		return deduplicated;
 	}
 
 	@Inject(
@@ -488,17 +489,21 @@ class MixinParameterList<T> implements TerraBlenderParameterList<T> {
 						continue;
 					}
 
-					List<Pair<Climate.ParameterPoint, T>> effectiveEntries = index == 0
-						? Collections.unmodifiableList(new ArrayList<>(currentValues))
-						: ClimateParameterListComposition.append(captured, snapshot.globalAdditions());
+					List<Pair<Climate.ParameterPoint, T>> rawEffectiveEntries = index == 0
+							? currentValues
+							: ClimateParameterListComposition.append(captured, snapshot.globalAdditions());
+
+					// Filter duplicate parameter-to-biome pairs before building search trees
+					List<Pair<Climate.ParameterPoint, T>> effectiveEntries = reterraforged$deduplicateEntries(rawEffectiveEntries);
+
 					ClimateParameterListComposition.CandidateOverlay<T> overlay =
-						ClimateParameterListComposition.overlayUndergroundCandidates(
-							currentValues,
-							index == 0 ? List.of() : captured,
-							snapshot.globalAdditions(),
-							(point, value) -> UndergroundBiomeBanding.classify(point, UndergroundBiomeTags.isCave(value)),
-							MixinParameterList::reterraforged$isDeferredPlaceholder
-						);
+							ClimateParameterListComposition.overlayUndergroundCandidates(
+									currentValues,
+									index == 0 ? List.of() : captured,
+									snapshot.globalAdditions(),
+									(point, value) -> UndergroundBiomeBanding.classify(point, UndergroundBiomeTags.isCave(value)),
+									MixinParameterList::reterraforged$isDeferredPlaceholder
+							);
 					if (!overlay.usable()) {
 						surfaceTrees.add(null);
 						bandingTrees.add(null);
@@ -506,11 +511,11 @@ class MixinParameterList<T> implements TerraBlenderParameterList<T> {
 					}
 
 					UndergroundBiomeBanding.Layout<T> layout = UndergroundBiomeBanding.apply(
-						this.reterraforged$bandingPreset,
-						effectiveEntries,
-						overlay.entries(),
-						this.reterraforged$bandingSeed,
-						(point, value) -> UndergroundBiomeBanding.classify(point, UndergroundBiomeTags.isCave(value))
+							this.reterraforged$bandingPreset,
+							effectiveEntries,
+							overlay.entries(),
+							this.reterraforged$bandingSeed,
+							(point, value) -> UndergroundBiomeBanding.classify(point, UndergroundBiomeTags.isCave(value))
 					);
 					surfaceTrees.add(new Climate.ParameterList<>(effectiveEntries));
 					bandingTrees.add(layout);
@@ -596,4 +601,16 @@ class MixinParameterList<T> implements TerraBlenderParameterList<T> {
 	public int getUniqueness(int x, int y, int z) {
 		throw new UnsupportedOperationException();
 	}
+
+	@Unique
+	private static <T> List<Pair<Climate.ParameterPoint, T>> reterraforged$deduplicateEntries(
+			List<Pair<Climate.ParameterPoint, T>> entries
+	) {
+		if (entries == null || entries.size() <= 1) {
+			return entries;
+		}
+		Set<Pair<Climate.ParameterPoint, T>> uniqueSet = new LinkedHashSet<>(entries);
+		return uniqueSet.size() == entries.size() ? entries : List.copyOf(uniqueSet);
+	}
+
 }

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
@@ -2,6 +2,7 @@ package raccoonman.reterraforged.world.worldgen.biome;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,6 +40,17 @@ import terrablender.util.LevelUtils;
  * Reconstructs the active Overworld surface biome-selection stack for preset previews.
  */
 public final class BiomePreviewResolver {
+	private static final Object INIT_LOCK = new Object();
+	private static volatile InitCache initCache = null;
+
+	private record InitCache(
+			RegistryAccess registries,
+			long seed,
+			LevelStem levelStem,
+			NoiseBasedChunkGenerator previewGenerator,
+			BiomeSource biomeSource
+	) {}
+
 	private final TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters;
 	private final Climate.ParameterList<Holder<Biome>> baseParameters;
 	private final Holder<Biome> finalFallback;
@@ -59,6 +71,12 @@ public final class BiomePreviewResolver {
 		this.integrationContext = integrationContext;
 	}
 
+	public static void clearCache() {
+		synchronized (INIT_LOCK) {
+			initCache = null;
+		}
+	}
+
 	public static BiomePreviewResolver create(
 			RegistryAccess registries,
 			HolderLookup.Provider provider,
@@ -68,20 +86,43 @@ public final class BiomePreviewResolver {
 			GeneratorContext generatorContext,
 			long seed
 	) {
-		BiomeSource biomeSource = copyBiomeSource(activeGenerator.getBiomeSource());
-		Holder<NoiseGeneratorSettings> noiseSettings = provider.lookupOrThrow(Registries.NOISE_SETTINGS)
-				.getOrThrow(NoiseGeneratorSettings.OVERWORLD);
-		NoiseBasedChunkGenerator previewGenerator = new NoiseBasedChunkGenerator(biomeSource, noiseSettings);
+		LevelStem previewStem;
+		NoiseBasedChunkGenerator previewGenerator;
+		BiomeSource biomeSource;
+		boolean newlyInitialized = false;
 
-		if (BiolithCompat.isEnabled()) {
-			BiolithPreviewContext.preInitializeBiomeLookup(registries);
+		synchronized (INIT_LOCK) {
+			if (initCache == null || initCache.registries() != registries || initCache.seed() != seed) {
+				biomeSource = copyBiomeSource(activeGenerator.getBiomeSource());
+				Holder<NoiseGeneratorSettings> noiseSettings = provider.lookupOrThrow(Registries.NOISE_SETTINGS)
+						.getOrThrow(NoiseGeneratorSettings.OVERWORLD);
+				previewGenerator = new NoiseBasedChunkGenerator(biomeSource, noiseSettings);
+				previewStem = new LevelStem(dimensionType, previewGenerator);
+
+				if (BiolithCompat.isEnabled()) {
+					BiolithPreviewContext.preInitializeBiomeLookup(registries);
+				}
+
+				if (TBCompat.isEnabled()) {
+					initializeTerraBlender(registries, dimensionType, previewGenerator, biomeSource, preset, seed);
+				}
+
+				initCache = new InitCache(registries, seed, previewStem, previewGenerator, biomeSource);
+				newlyInitialized = true;
+			} else {
+				previewStem = initCache.levelStem();
+				previewGenerator = initCache.previewGenerator();
+				biomeSource = initCache.biomeSource();
+
+				if (TBCompat.isEnabled()
+						&& biomeSource instanceof MultiNoiseBiomeSource
+						&& (Object) biomeSource instanceof RTFMultiNoiseBiomeSource source
+						&& (Object) source.reterraforged$getParameters() instanceof TerraBlenderParameterList<?> parameters) {
+					parameters.reterraforged$preparePreview(preset, seed);
+				}
+			}
 		}
 
-		if (TBCompat.isEnabled()) {
-			initializeTerraBlender(registries, dimensionType, previewGenerator, biomeSource, preset, seed);
-		}
-
-		LevelStem previewStem = new LevelStem(dimensionType, previewGenerator);
 		TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters = terraBlenderParameters(biomeSource);
 		Climate.ParameterList<Holder<Biome>> baseParameters = parameters(biomeSource);
 		Holder<Biome> plains = registries.lookupOrThrow(Registries.BIOME).getOrThrow(Biomes.PLAINS);
@@ -90,12 +131,18 @@ public final class BiomePreviewResolver {
 				seed, registries, provider, biomeSource, previewGenerator, previewStem, preset, generatorContext
 		);
 
-		return new BiomePreviewResolver(
+		BiomePreviewResolver resolver = new BiomePreviewResolver(
 				terraBlenderParameters,
 				baseParameters,
 				plains,
 				integrationContext
 		);
+
+		if (newlyInitialized) {
+			resolver.prewarm();
+		}
+
+		return resolver;
 	}
 
 	private static void initializeTerraBlender(
@@ -118,6 +165,37 @@ public final class BiomePreviewResolver {
 				previewGenerator,
 				seed
 		);
+	}
+
+	/**
+	 * Pre-warms integration hooks (TerraBlender/Biolith) on the creator thread.
+	 * Evaluates dummy samples inside an integration session to construct regional biome trees
+	 * synchronously, avoiding multi-threaded lazy composition locks during resolution.
+	 */
+	private void prewarm() {
+		if (!TBCompat.isEnabled() && !BiolithCompat.isEnabled()) {
+			return;
+		}
+		try (BiomePreviewIntegration.Session ignored = this.openIntegrationSession()) {
+			NoiseBasedChunkGenerator generator = (NoiseBasedChunkGenerator) this.integrationContext.generator();
+			List<Climate.ParameterPoint> spawnTarget = generator.generatorSettings().value().spawnTarget();
+
+			Climate.Sampler dummySampler = new Climate.Sampler(
+					DensityFunctions.constant(0.0D),
+					DensityFunctions.constant(0.0D),
+					DensityFunctions.constant(0.0D),
+					DensityFunctions.constant(0.0D),
+					DensityFunctions.constant(0.0D),
+					DensityFunctions.constant(0.0D),
+					spawnTarget
+			);
+
+			// Sample surface and underground points to force both surface and cave tree composition upfront
+			this.resolveQuart(0, 16, 0, dummySampler);
+			this.resolveQuart(0, -16, 0, dummySampler);
+		} catch (Throwable error) {
+			RTFCommon.LOGGER.debug("Pre-warming BiomePreviewResolver tree snapshot encountered an issue: ", error);
+		}
 	}
 
 	public Holder<Biome> resolveQuart(int quartX, int quartY, int quartZ, Climate.Sampler sampler) {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
@@ -39,7 +39,6 @@ import terrablender.util.LevelUtils;
  * Reconstructs the active Overworld surface biome-selection stack for preset previews.
  */
 public final class BiomePreviewResolver {
-	private final Climate.Sampler sampler;
 	private final TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters;
 	private final Climate.ParameterList<Holder<Biome>> baseParameters;
 	private final Holder<Biome> finalFallback;
@@ -49,13 +48,11 @@ public final class BiomePreviewResolver {
 	private final Set<String> activeIntegrations = ConcurrentHashMap.newKeySet();
 
 	private BiomePreviewResolver(
-			Climate.Sampler sampler,
 			TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters,
 			Climate.ParameterList<Holder<Biome>> baseParameters,
 			Holder<Biome> finalFallback,
 			BiomePreviewIntegration.Context integrationContext
 	) {
-		this.sampler = sampler;
 		this.terraBlenderParameters = terraBlenderParameters;
 		this.baseParameters = baseParameters;
 		this.finalFallback = finalFallback;
@@ -85,7 +82,6 @@ public final class BiomePreviewResolver {
 		}
 
 		LevelStem previewStem = new LevelStem(dimensionType, previewGenerator);
-		Climate.Sampler sampler = surfaceClimateSampler(noiseSettings.value(), generatorContext);
 		TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters = terraBlenderParameters(biomeSource);
 		Climate.ParameterList<Holder<Biome>> baseParameters = parameters(biomeSource);
 		Holder<Biome> plains = registries.lookupOrThrow(Registries.BIOME).getOrThrow(Biomes.PLAINS);
@@ -95,35 +91,11 @@ public final class BiomePreviewResolver {
 		);
 
 		return new BiomePreviewResolver(
-				sampler,
 				terraBlenderParameters,
 				baseParameters,
 				plains,
 				integrationContext
 		);
-	}
-
-	private static Climate.Sampler surfaceClimateSampler(
-			NoiseGeneratorSettings noiseSettings,
-			GeneratorContext generatorContext
-	) {
-		Climate.Sampler sampler = new Climate.Sampler(
-				cell(generatorContext, CellSampler.Field.TEMPERATURE),
-				cell(generatorContext, CellSampler.Field.MOISTURE),
-				cell(generatorContext, CellSampler.Field.CONTINENT),
-				cell(generatorContext, CellSampler.Field.EROSION),
-				DensityFunctions.constant(0.0D),
-				cell(generatorContext, CellSampler.Field.WEIRDNESS),
-				noiseSettings.spawnTarget()
-		);
-		if (TBCompat.isEnabled() && (Object) sampler instanceof TBClimateSampler terraBlenderSampler) {
-			terraBlenderSampler.setUniqueness(cell(generatorContext, CellSampler.Field.BIOME_REGION));
-		}
-		return sampler;
-	}
-
-	private static DensityFunction cell(GeneratorContext context, CellSampler.Field field) {
-		return new CellSampler(() -> context.lookup, field);
 	}
 
 	private static void initializeTerraBlender(
@@ -148,10 +120,6 @@ public final class BiomePreviewResolver {
 		);
 	}
 
-	public Holder<Biome> resolveQuart(int quartX, int quartY, int quartZ) {
-		return this.resolveQuart(quartX, quartY, quartZ, this.sampler);
-	}
-
 	public Holder<Biome> resolveQuart(int quartX, int quartY, int quartZ, Climate.Sampler sampler) {
 		if (this.positionalSelectionEnabled.get()) {
 			try {
@@ -171,10 +139,6 @@ public final class BiomePreviewResolver {
 		float originX = centerX - tile.getBlockSize().size() * zoom / 2.0F;
 		float originZ = centerZ - tile.getBlockSize().size() * zoom / 2.0F;
 		return this.tileClimateSamplerAtOrigin(tile, originX, originZ, zoom);
-	}
-
-	public Climate.Sampler tileClimateSamplerAtOrigin(Tile tile, int originX, int originZ, int zoom) {
-		return this.tileClimateSamplerAtOrigin(tile, (float) originX, (float) originZ, zoom);
 	}
 
 	private Climate.Sampler tileClimateSamplerAtOrigin(Tile tile, float originX, float originZ, int zoom) {
@@ -199,36 +163,6 @@ public final class BiomePreviewResolver {
 
 	public BiomePreviewIntegration.Session openIntegrationSession() {
 		return BiomePreviewIntegrations.open(this.integrationContext, error -> {}, this.activeIntegrations::add);
-	}
-
-	public List<String> activeIntegrations() {
-		List<String> list = new ArrayList<>(this.activeIntegrations);
-		list.sort(null);
-		return list;
-	}
-
-	public TerraBlenderParameterList.SelectionDiagnostics<Holder<Biome>> inspectTerraBlenderSelection(
-			int quartX,
-			int quartY,
-			int quartZ
-	) {
-		return this.inspectTerraBlenderSelection(quartX, quartY, quartZ, this.sampler);
-	}
-
-	public TerraBlenderParameterList.SelectionDiagnostics<Holder<Biome>> inspectTerraBlenderSelection(
-			int quartX,
-			int quartY,
-			int quartZ,
-			Climate.Sampler sampler
-	) {
-		if (this.terraBlenderParameters == null) {
-			return new TerraBlenderParameterList.SelectionDiagnostics<>(
-					-1, null, null, "terra_blender_parameter_list_unavailable"
-			);
-		}
-		return this.terraBlenderParameters.reterraforged$inspectSelection(
-				sampler.sample(quartX, quartY, quartZ), quartX, quartY, quartZ
-		);
 	}
 
 	public String warning() {

--- a/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
+++ b/common/src/main/java/raccoonman/reterraforged/world/worldgen/biome/BiomePreviewResolver.java
@@ -36,13 +36,10 @@ import raccoonman.reterraforged.world.worldgen.terrablender.TerraBlenderParamete
 import terrablender.util.LevelUtils;
 
 /**
- * Reconstructs the active Overworld biome-selection stack for preset previews.
- * Queries deliberately use the positional biome-source path so companion-mod
- * replacements and sub-biomes remain authoritative.
+ * Reconstructs the active Overworld surface biome-selection stack for preset previews.
  */
 public final class BiomePreviewResolver {
 	private final Climate.Sampler sampler;
-	private final SurfaceBiomeFilter<Holder<Biome>> surfaceFilter;
 	private final TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters;
 	private final Climate.ParameterList<Holder<Biome>> baseParameters;
 	private final Holder<Biome> finalFallback;
@@ -52,15 +49,13 @@ public final class BiomePreviewResolver {
 	private final Set<String> activeIntegrations = ConcurrentHashMap.newKeySet();
 
 	private BiomePreviewResolver(
-		Climate.Sampler sampler,
-		SurfaceBiomeFilter<Holder<Biome>> surfaceFilter,
-		TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters,
-		Climate.ParameterList<Holder<Biome>> baseParameters,
-		Holder<Biome> finalFallback,
-		BiomePreviewIntegration.Context integrationContext
+			Climate.Sampler sampler,
+			TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters,
+			Climate.ParameterList<Holder<Biome>> baseParameters,
+			Holder<Biome> finalFallback,
+			BiomePreviewIntegration.Context integrationContext
 	) {
 		this.sampler = sampler;
-		this.surfaceFilter = surfaceFilter;
 		this.terraBlenderParameters = terraBlenderParameters;
 		this.baseParameters = baseParameters;
 		this.finalFallback = finalFallback;
@@ -68,17 +63,17 @@ public final class BiomePreviewResolver {
 	}
 
 	public static BiomePreviewResolver create(
-		RegistryAccess registries,
-		HolderLookup.Provider provider,
-		Holder<DimensionType> dimensionType,
-		ChunkGenerator activeGenerator,
-		Preset preset,
-		GeneratorContext generatorContext,
-		long seed
+			RegistryAccess registries,
+			HolderLookup.Provider provider,
+			Holder<DimensionType> dimensionType,
+			ChunkGenerator activeGenerator,
+			Preset preset,
+			GeneratorContext generatorContext,
+			long seed
 	) {
 		BiomeSource biomeSource = copyBiomeSource(activeGenerator.getBiomeSource());
 		Holder<NoiseGeneratorSettings> noiseSettings = provider.lookupOrThrow(Registries.NOISE_SETTINGS)
-			.getOrThrow(NoiseGeneratorSettings.OVERWORLD);
+				.getOrThrow(NoiseGeneratorSettings.OVERWORLD);
 		NoiseBasedChunkGenerator previewGenerator = new NoiseBasedChunkGenerator(biomeSource, noiseSettings);
 
 		if (BiolithCompat.isEnabled()) {
@@ -90,51 +85,37 @@ public final class BiomePreviewResolver {
 		}
 
 		LevelStem previewStem = new LevelStem(dimensionType, previewGenerator);
-
-		Climate.Sampler sampler = surfaceClimateSampler(noiseSettings.value(), preset, generatorContext, seed);
+		Climate.Sampler sampler = surfaceClimateSampler(noiseSettings.value(), generatorContext);
 		TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters = terraBlenderParameters(biomeSource);
-		List<Holder<Biome>> additionalUndergroundCandidates = new ArrayList<>();
-		if (terraBlenderParameters != null) {
-			TerraBlenderParameterList.CompositionDiagnostics<Holder<Biome>> diagnostics =
-				terraBlenderParameters.reterraforged$getCompositionDiagnostics();
-			additionalUndergroundCandidates.addAll(diagnostics.shallowCandidates());
-			additionalUndergroundCandidates.addAll(diagnostics.deepCandidates());
-		}
-		Holder<Biome> plains = registries.lookupOrThrow(Registries.BIOME).getOrThrow(Biomes.PLAINS);
-		SurfaceBiomeFilter<Holder<Biome>> surfaceFilter = surfaceFilter(
-			biomeSource, additionalUndergroundCandidates, plains
-		);
 		Climate.ParameterList<Holder<Biome>> baseParameters = parameters(biomeSource);
+		Holder<Biome> plains = registries.lookupOrThrow(Registries.BIOME).getOrThrow(Biomes.PLAINS);
+
 		BiomePreviewIntegration.Context integrationContext = new BiomePreviewIntegration.Context(
-			seed, registries, provider, biomeSource, previewGenerator, previewStem, preset, generatorContext
+				seed, registries, provider, biomeSource, previewGenerator, previewStem, preset, generatorContext
 		);
+
 		return new BiomePreviewResolver(
-			sampler,
-			surfaceFilter,
-			terraBlenderParameters,
-			baseParameters,
-			plains,
-			integrationContext
+				sampler,
+				terraBlenderParameters,
+				baseParameters,
+				plains,
+				integrationContext
 		);
 	}
 
 	private static Climate.Sampler surfaceClimateSampler(
-		NoiseGeneratorSettings noiseSettings,
-		Preset preset,
-		GeneratorContext generatorContext,
-		long seed
+			NoiseGeneratorSettings noiseSettings,
+			GeneratorContext generatorContext
 	) {
 		Climate.Sampler sampler = new Climate.Sampler(
-			cell(generatorContext, CellSampler.Field.TEMPERATURE),
-			cell(generatorContext, CellSampler.Field.MOISTURE),
-			cell(generatorContext, CellSampler.Field.CONTINENT),
-			cell(generatorContext, CellSampler.Field.EROSION),
-			DensityFunctions.constant(0.0D),
-			cell(generatorContext, CellSampler.Field.WEIRDNESS),
-			noiseSettings.spawnTarget()
+				cell(generatorContext, CellSampler.Field.TEMPERATURE),
+				cell(generatorContext, CellSampler.Field.MOISTURE),
+				cell(generatorContext, CellSampler.Field.CONTINENT),
+				cell(generatorContext, CellSampler.Field.EROSION),
+				DensityFunctions.constant(0.0D),
+				cell(generatorContext, CellSampler.Field.WEIRDNESS),
+				noiseSettings.spawnTarget()
 		);
-		((RTFClimateSampler) (Object) sampler).setUndergroundBiomeBandingPreset(preset, seed);
-		((RTFClimateSampler) (Object) sampler).setUndergroundBiomeSurfaceContext(generatorContext);
 		if (TBCompat.isEnabled() && (Object) sampler instanceof TBClimateSampler terraBlenderSampler) {
 			terraBlenderSampler.setUniqueness(cell(generatorContext, CellSampler.Field.BIOME_REGION));
 		}
@@ -146,24 +127,24 @@ public final class BiomePreviewResolver {
 	}
 
 	private static void initializeTerraBlender(
-		RegistryAccess registries,
-		Holder<DimensionType> dimensionType,
-		NoiseBasedChunkGenerator previewGenerator,
-		BiomeSource biomeSource,
-		Preset preset,
-		long seed
+			RegistryAccess registries,
+			Holder<DimensionType> dimensionType,
+			NoiseBasedChunkGenerator previewGenerator,
+			BiomeSource biomeSource,
+			Preset preset,
+			long seed
 	) {
 		if (biomeSource instanceof MultiNoiseBiomeSource
-			&& (Object) biomeSource instanceof RTFMultiNoiseBiomeSource source
-			&& (Object) source.reterraforged$getParameters() instanceof TerraBlenderParameterList<?> parameters) {
+				&& (Object) biomeSource instanceof RTFMultiNoiseBiomeSource source
+				&& (Object) source.reterraforged$getParameters() instanceof TerraBlenderParameterList<?> parameters) {
 			parameters.reterraforged$preparePreview(preset, seed);
 		}
 		LevelUtils.initializeBiomes(
-			registries,
-			dimensionType,
-			LevelStem.OVERWORLD,
-			previewGenerator,
-			seed
+				registries,
+				dimensionType,
+				LevelStem.OVERWORLD,
+				previewGenerator,
+				seed
 		);
 	}
 
@@ -172,49 +153,18 @@ public final class BiomePreviewResolver {
 	}
 
 	public Holder<Biome> resolveQuart(int quartX, int quartY, int quartZ, Climate.Sampler sampler) {
-		Holder<Biome> selected = null;
-		Holder<Biome> composedOriginal = null;
-		boolean composedSelection = false;
 		if (this.positionalSelectionEnabled.get()) {
-			PreviewBiomeQueryContext.begin(quartX, quartY, quartZ);
 			try {
-				selected = this.integrationContext.generator().getBiomeSource()
-					.getNoiseBiome(quartX, quartY, quartZ, sampler);
-				if (selected == null) {
-					throw new IllegalStateException("Biome source returned null during preview selection");
+				Holder<Biome> selected = this.integrationContext.generator().getBiomeSource()
+						.getNoiseBiome(quartX, quartY, quartZ, sampler);
+				if (selected != null) {
+					return selected;
 				}
 			} catch (RuntimeException | LinkageError error) {
 				this.disablePositionalSelection(error);
-				selected = this.resolveFallback(quartX, quartY, quartZ, sampler);
-			} finally {
-				composedSelection = PreviewBiomeQueryContext.matches(quartX, quartY, quartZ, selected);
-				if (composedSelection && PreviewBiomeQueryContext.original() instanceof Holder<?> holder) {
-					@SuppressWarnings("unchecked")
-					Holder<Biome> original = (Holder<Biome>) holder;
-					composedOriginal = original;
-				}
-				PreviewBiomeQueryContext.end();
-			}
-		} else {
-			selected = this.resolveFallback(quartX, quartY, quartZ, sampler);
-		}
-		if (!this.surfaceFilter.isUnderground(selected)) {
-			return selected;
-		}
-		Climate.TargetPoint target = sampler.sample(quartX, quartY, quartZ);
-		if (composedSelection) {
-			if (composedOriginal != null && !this.surfaceFilter.isUnderground(composedOriginal)) {
-				return composedOriginal;
-			}
-		} else if (this.terraBlenderParameters != null) {
-			Holder<Biome> regionalSurface = this.terraBlenderParameters
-				.reterraforged$inspectSelection(target, quartX, quartY, quartZ)
-				.original();
-			if (regionalSurface != null && !this.surfaceFilter.isUnderground(regionalSurface)) {
-				return regionalSurface;
 			}
 		}
-		return this.surfaceFilter.resolve(target, selected);
+		return this.resolveFallback(quartX, quartY, quartZ, sampler);
 	}
 
 	public Climate.Sampler tileClimateSampler(Tile tile, int centerX, int centerZ, int zoom) {
@@ -226,22 +176,22 @@ public final class BiomePreviewResolver {
 	public Climate.Sampler tileClimateSamplerAtOrigin(Tile tile, int originX, int originZ, int zoom) {
 		return this.tileClimateSamplerAtOrigin(tile, (float) originX, (float) originZ, zoom);
 	}
+
 	private Climate.Sampler tileClimateSamplerAtOrigin(Tile tile, float originX, float originZ, int zoom) {
 		NoiseBasedChunkGenerator previewGenerator = (NoiseBasedChunkGenerator) this.integrationContext.generator();
 		var heightmap = this.integrationContext.generatorContext().lookup.getHeightmap();
 		Climate.Sampler sampler = new Climate.Sampler(
-			new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.TEMPERATURE),
-			new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.MOISTURE),
-			new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.CONTINENT),
-			new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.EROSION),
-			DensityFunctions.constant(0.0D),
-			new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.WEIRDNESS),
-			previewGenerator.generatorSettings().value().spawnTarget()
+				new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.TEMPERATURE),
+				new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.MOISTURE),
+				new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.CONTINENT),
+				new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.EROSION),
+				DensityFunctions.constant(0.0D),
+				new PreviewTileClimateSampler(tile, heightmap, originX, originZ, zoom, CellSampler.Field.WEIRDNESS),
+				previewGenerator.generatorSettings().value().spawnTarget()
 		);
-		((RTFClimateSampler) (Object) sampler).setUndergroundBiomeBandingPreset(this.integrationContext.preset(), this.integrationContext.seed());
 		if (TBCompat.isEnabled() && (Object) sampler instanceof TBClimateSampler terraBlenderSampler) {
 			terraBlenderSampler.setUniqueness(new PreviewTileClimateSampler(
-				tile, heightmap, originX, originZ, zoom, CellSampler.Field.BIOME_REGION
+					tile, heightmap, originX, originZ, zoom, CellSampler.Field.BIOME_REGION
 			));
 		}
 		return sampler;
@@ -252,30 +202,32 @@ public final class BiomePreviewResolver {
 	}
 
 	public List<String> activeIntegrations() {
-		return this.activeIntegrations.stream().sorted().toList();
+		List<String> list = new ArrayList<>(this.activeIntegrations);
+		list.sort(null);
+		return list;
 	}
 
 	public TerraBlenderParameterList.SelectionDiagnostics<Holder<Biome>> inspectTerraBlenderSelection(
-		int quartX,
-		int quartY,
-		int quartZ
+			int quartX,
+			int quartY,
+			int quartZ
 	) {
 		return this.inspectTerraBlenderSelection(quartX, quartY, quartZ, this.sampler);
 	}
 
 	public TerraBlenderParameterList.SelectionDiagnostics<Holder<Biome>> inspectTerraBlenderSelection(
-		int quartX,
-		int quartY,
-		int quartZ,
-		Climate.Sampler sampler
+			int quartX,
+			int quartY,
+			int quartZ,
+			Climate.Sampler sampler
 	) {
 		if (this.terraBlenderParameters == null) {
 			return new TerraBlenderParameterList.SelectionDiagnostics<>(
-				-1, null, null, "terra_blender_parameter_list_unavailable"
+					-1, null, null, "terra_blender_parameter_list_unavailable"
 			);
 		}
 		return this.terraBlenderParameters.reterraforged$inspectSelection(
-			sampler.sample(quartX, quartY, quartZ), quartX, quartY, quartZ
+				sampler.sample(quartX, quartY, quartZ), quartX, quartY, quartZ
 		);
 	}
 
@@ -287,8 +239,8 @@ public final class BiomePreviewResolver {
 		Climate.TargetPoint target = sampler.sample(quartX, quartY, quartZ);
 		if (this.terraBlenderParameters != null) {
 			Holder<Biome> selected = this.terraBlenderParameters
-				.reterraforged$inspectSelection(target, quartX, quartY, quartZ)
-				.banded();
+					.reterraforged$inspectSelection(target, quartX, quartY, quartZ)
+					.banded();
 			if (selected != null) {
 				return selected;
 			}
@@ -307,44 +259,16 @@ public final class BiomePreviewResolver {
 		String message = "Runtime biome replacements unavailable; showing composed biome registrations";
 		if (this.warning.compareAndSet(null, message)) {
 			RTFCommon.LOGGER.error(
-				"A biome mod failed during positional preview selection; falling back to the composed parameter tree",
-				error
+					"A biome mod failed during positional preview selection; falling back to the composed parameter tree",
+					error
 			);
 		}
-	}
-
-	public boolean isUnderground(Holder<Biome> biome) {
-		return this.surfaceFilter.isUnderground(biome);
-	}
-
-	private static SurfaceBiomeFilter<Holder<Biome>> surfaceFilter(
-		BiomeSource biomeSource,
-		List<Holder<Biome>> additionalUndergroundCandidates,
-		Holder<Biome> finalFallback
-	) {
-		if (biomeSource instanceof MultiNoiseBiomeSource
-			&& (Object) biomeSource instanceof RTFMultiNoiseBiomeSource multiNoise) {
-			return SurfaceBiomeFilter.create(
-				multiNoise.reterraforged$getParameters().values(),
-				(point, biome) -> UndergroundBiomeBanding.classify(point, UndergroundBiomeTags.isCave(biome)),
-				UndergroundBiomeTags::isCave,
-				additionalUndergroundCandidates,
-				finalFallback
-			);
-		}
-		return SurfaceBiomeFilter.create(
-			List.of(),
-			(point, biome) -> UndergroundBiomeBanding.CandidateRole.UNKNOWN,
-			UndergroundBiomeTags::isCave,
-			additionalUndergroundCandidates,
-			finalFallback
-		);
 	}
 
 	@SuppressWarnings("unchecked")
 	private static TerraBlenderParameterList<Holder<Biome>> terraBlenderParameters(BiomeSource biomeSource) {
 		if (biomeSource instanceof MultiNoiseBiomeSource
-			&& (Object) ((RTFMultiNoiseBiomeSource) biomeSource).reterraforged$getParameters()
+				&& (Object) ((RTFMultiNoiseBiomeSource) biomeSource).reterraforged$getParameters()
 				instanceof TerraBlenderParameterList<?> parameters) {
 			return (TerraBlenderParameterList<Holder<Biome>>) parameters;
 		}
@@ -353,7 +277,7 @@ public final class BiomePreviewResolver {
 
 	private static Climate.ParameterList<Holder<Biome>> parameters(BiomeSource biomeSource) {
 		if (biomeSource instanceof MultiNoiseBiomeSource
-			&& (Object) biomeSource instanceof RTFMultiNoiseBiomeSource multiNoise) {
+				&& (Object) biomeSource instanceof RTFMultiNoiseBiomeSource multiNoise) {
 			return multiNoise.reterraforged$getParameters();
 		}
 		return null;
@@ -361,9 +285,9 @@ public final class BiomePreviewResolver {
 
 	private static BiomeSource copyBiomeSource(BiomeSource source) {
 		if (source instanceof MultiNoiseBiomeSource
-			&& (Object) source instanceof RTFMultiNoiseBiomeSource multiNoise) {
+				&& (Object) source instanceof RTFMultiNoiseBiomeSource multiNoise) {
 			List<com.mojang.datafixers.util.Pair<Climate.ParameterPoint, Holder<Biome>>> values =
-				List.copyOf(multiNoise.reterraforged$getParameters().values());
+					List.copyOf(multiNoise.reterraforged$getParameters().values());
 			return MultiNoiseBiomeSource.createFromList(new Climate.ParameterList<>(values));
 		}
 		return source;

--- a/common/src/test/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCacheTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCacheTest.java
@@ -7,11 +7,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
+import net.minecraft.world.level.WorldDataConfiguration;
+
 class PreviewComputationCacheTest {
     @Test
     void sidecarResultsAreComputedOnceForAnExactViewKey() {
         PreviewComputationCache cache = new PreviewComputationCache();
-        BiomePreview.CacheKey revision = new BiomePreview.CacheKey(123L, 1, 2, "source", 1);
+        BiomePreview.CacheKey revision = new BiomePreview.CacheKey(
+                123L,
+                "{}",
+                WorldDataConfiguration.DEFAULT,
+                "source",
+                1
+        );
         PreviewComputationCache.SidecarKey key = new PreviewComputationCache.SidecarKey(revision, 10, -20, 4, 256);
         AtomicInteger computations = new AtomicInteger();
         assertNull(cache.sidecar(key, () -> {

--- a/common/src/test/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCacheTest.java
+++ b/common/src/test/java/raccoonman/reterraforged/client/gui/screen/presetconfig/PreviewComputationCacheTest.java
@@ -3,7 +3,6 @@ package raccoonman.reterraforged.client.gui.screen.presetconfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,7 @@ class PreviewComputationCacheTest {
     @Test
     void sidecarResultsAreComputedOnceForAnExactViewKey() {
         PreviewComputationCache cache = new PreviewComputationCache();
-        BiomePreview.CacheKey revision = new BiomePreview.CacheKey(123L, "preset", "data", "source", List.of("minecraft:plains"));
+        BiomePreview.CacheKey revision = new BiomePreview.CacheKey(123L, 1, 2, "source", 1);
         PreviewComputationCache.SidecarKey key = new PreviewComputationCache.SidecarKey(revision, 10, -20, 4, 256);
         AtomicInteger computations = new AtomicInteger();
         assertNull(cache.sidecar(key, () -> {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -32,6 +32,9 @@
     "fabric": ">=0.86.1",
     "minecraft": ">=1.21.1"
   },
+  "breaks": {
+    "biolith": "<3.0.14"
+  },
   "mixins": [
     "reterraforged-common.mixins.json",
     "reterraforged-fabric.mixins.json"

--- a/neoforge/src/main/java/raccoonman/reterraforged/neoforge/compat/lithostitched/LithostitchedBiomePreviewIntegration.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/neoforge/compat/lithostitched/LithostitchedBiomePreviewIntegration.java
@@ -65,9 +65,9 @@ public final class LithostitchedBiomePreviewIntegration implements BiomePreviewI
 
 	private void bindFastNoiseConfigs(Context context) {
 		context.registries().lookupOrThrow(LithostitchedRegistries.FAST_NOISE_CONFIG)
-				.listElements()
-				.map(holder -> (FastNoiseConfig) holder.value())
-				.forEach(config -> config.bind(context.seed()));
+			.listElements()
+			.map(holder -> (FastNoiseConfig) holder.value())
+			.forEach(config -> config.bind(context.seed()));
 	}
 
 	private record Initialization(Throwable failure) {

--- a/neoforge/src/main/java/raccoonman/reterraforged/neoforge/compat/lithostitched/LithostitchedBiomePreviewIntegration.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/neoforge/compat/lithostitched/LithostitchedBiomePreviewIntegration.java
@@ -1,23 +1,45 @@
 package raccoonman.reterraforged.neoforge.compat.lithostitched;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.WeakHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 import com.mojang.serialization.Lifecycle;
 
 import dev.worldgen.lithostitched.api.registry.LithostitchedRegistries;
 import dev.worldgen.lithostitched.api.worldgen.densityfunction.fastnoise.FastNoiseConfig;
 import dev.worldgen.lithostitched.impl.worldgen.biomeinjector.internal.BiomeInjectorManager;
+import net.minecraft.core.HolderLookup;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.RegistrationInfo;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.chunk.ChunkGenerator;
 import net.minecraft.world.level.dimension.LevelStem;
 import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
+import raccoonman.reterraforged.RTFCommon;
 import raccoonman.reterraforged.world.worldgen.biome.BiomePreviewIntegration;
 
 public final class LithostitchedBiomePreviewIntegration implements BiomePreviewIntegration {
+	/**
+	 * Session-lifetime latch: once applyInjectors() is known to fail (e.g. due to a
+	 * Lithostitched/Biolith compatibility issue where Biolith's BiomeCoordinator
+	 * biome-lookup singleton is populated with an incompatible registry snapshot from
+	 * elsewhere in the game session), we stop retrying entirely rather than re-running
+	 * the failing setup on every single preview regenerate. A fresh NoiseBasedChunkGenerator
+	 * is constructed by BiomePreviewResolver.create() on every regenerate, so the
+	 * per-generator `initializations` cache below never actually gets a cache hit for
+	 * repeated failures - this flag is what actually prevents repeated retries/logging.
+	 * Reset is not attempted mid-session since the underlying incompatibility (if any)
+	 * won't resolve itself without a restart or mod update.
+	 */
+	private static final AtomicBoolean KNOWN_INCOMPATIBLE = new AtomicBoolean(false);
+
 	private final Map<ChunkGenerator, Initialization> initializations = new WeakHashMap<>();
 	private final ReentrantLock sessionLock = new ReentrantLock();
 
@@ -36,6 +58,13 @@ public final class LithostitchedBiomePreviewIntegration implements BiomePreviewI
 		this.sessionLock.lock();
 		boolean opened = false;
 		try {
+			if (KNOWN_INCOMPATIBLE.get()) {
+				RTFCommon.LOGGER.debug(
+						"Skipping Lithostitched biome preview integration; already known to be incompatible this session, using fallback"
+				);
+				throw INCOMPATIBLE_SENTINEL;
+			}
+
 			Initialization initialization = this.initializations.get(context.generator());
 			if (initialization == null) {
 				try {
@@ -43,6 +72,15 @@ public final class LithostitchedBiomePreviewIntegration implements BiomePreviewI
 					initialization = Initialization.SUCCESS;
 				} catch (RuntimeException | LinkageError error) {
 					initialization = new Initialization(error);
+					if (KNOWN_INCOMPATIBLE.compareAndSet(false, true)) {
+						RTFCommon.LOGGER.warn(
+								"Lithostitched biome preview integration failed to initialize; this is a known "
+										+ "compatibility issue when Biolith is also installed and its biome lookup was "
+										+ "already populated elsewhere this session. Preview will use its fallback "
+										+ "parameter tree for the rest of this session; this will not be logged again.",
+								error
+						);
+					}
 				}
 				this.initializations.put(context.generator(), initialization);
 			}
@@ -60,14 +98,58 @@ public final class LithostitchedBiomePreviewIntegration implements BiomePreviewI
 	private void applyInjectors(Context context) {
 		MappedRegistry<LevelStem> dimensions = new MappedRegistry<>(Registries.LEVEL_STEM, Lifecycle.stable());
 		dimensions.register(LevelStem.OVERWORLD, context.levelStem(), RegistrationInfo.BUILT_IN);
-		BiomeInjectorManager.applyBiomeInjectors(context.registries(), dimensions, context.seed());
+		dimensions.freeze();
+
+		RegistryAccess safeRegistries = wrapSafeRegistryAccess(context.registries());
+		BiomeInjectorManager.applyBiomeInjectors(safeRegistries, dimensions, context.seed());
 	}
 
 	private void bindFastNoiseConfigs(Context context) {
-		context.registries().lookupOrThrow(LithostitchedRegistries.FAST_NOISE_CONFIG)
-			.listElements()
-			.map(holder -> (FastNoiseConfig) holder.value())
-			.forEach(config -> config.bind(context.seed()));
+		RegistryAccess safeRegistries = wrapSafeRegistryAccess(context.registries());
+		safeRegistries.lookupOrThrow(LithostitchedRegistries.FAST_NOISE_CONFIG)
+				.listElements()
+				.map(holder -> (FastNoiseConfig) holder.value())
+				.forEach(config -> config.bind(context.seed()));
+	}
+
+	private static RegistryAccess wrapSafeRegistryAccess(RegistryAccess delegate) {
+		if (delegate instanceof SafeRegistryAccess safe) {
+			return safe;
+		}
+		return new SafeRegistryAccess(delegate);
+	}
+
+	private static final class SafeRegistryAccess implements RegistryAccess.Frozen {
+		private final RegistryAccess delegate;
+
+		private SafeRegistryAccess(RegistryAccess delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public <E> Optional<Registry<E>> registry(ResourceKey<? extends Registry<? extends E>> key) {
+			return this.delegate.registry(key);
+		}
+
+		@Override
+		public Stream<RegistryEntry<?>> registries() {
+			return this.delegate.registries();
+		}
+
+		@Override
+		public <T> Optional<HolderLookup.RegistryLookup<T>> lookup(ResourceKey<? extends Registry<? extends T>> key) {
+			return this.delegate.registry(key).map(Registry::asLookup);
+		}
+
+		@Override
+		public <T> HolderLookup.RegistryLookup<T> lookupOrThrow(ResourceKey<? extends Registry<? extends T>> key) {
+			return this.delegate.registryOrThrow(key).asLookup();
+		}
+
+		@Override
+		public RegistryAccess.Frozen freeze() {
+			return this;
+		}
 	}
 
 	private record Initialization(Throwable failure) {
@@ -82,4 +164,14 @@ public final class LithostitchedBiomePreviewIntegration implements BiomePreviewI
 			}
 		}
 	}
+
+	/**
+	 * Lightweight, stackless sentinel thrown when we've already given up on this
+	 * integration for the session. Avoids paying for a fresh stack trace capture on
+	 * every regenerate once the outcome is already known.
+	 */
+	private static final RuntimeException INCOMPATIBLE_SENTINEL = new RuntimeException(
+			"Lithostitched biome preview integration is disabled for this session", null, false, false
+	) {
+	};
 }

--- a/neoforge/src/main/java/raccoonman/reterraforged/neoforge/compat/lithostitched/LithostitchedBiomePreviewIntegration.java
+++ b/neoforge/src/main/java/raccoonman/reterraforged/neoforge/compat/lithostitched/LithostitchedBiomePreviewIntegration.java
@@ -65,9 +65,9 @@ public final class LithostitchedBiomePreviewIntegration implements BiomePreviewI
 
 	private void bindFastNoiseConfigs(Context context) {
 		context.registries().lookupOrThrow(LithostitchedRegistries.FAST_NOISE_CONFIG)
-			.listElements()
-			.map(holder -> (FastNoiseConfig) holder.value())
-			.forEach(config -> config.bind(context.seed()));
+				.listElements()
+				.map(holder -> (FastNoiseConfig) holder.value())
+				.forEach(config -> config.bind(context.seed()));
 	}
 
 	private record Initialization(Throwable failure) {

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -32,3 +32,11 @@ license="MIT"
 	versionRange = "[1.21.1,)"
 	ordering = "NONE"
 	side = "BOTH"
+
+# We enforce 3.0.14 because otherwise biome previews break in a non-obvious manner
+[[dependencies.reterraforged]]
+    modId = "biolith"
+    type = "optional"
+    versionRange = "[3.0.14,)"
+    ordering = "AFTER"
+    side = "BOTH"


### PR DESCRIPTION
This PR fixes https://github.com/ETcodehome/FreeTerraForged/issues/203
Biome previews were slow, now they aren't.

---

Changes are pretty discrete and targeted. Only substantive fallout is that we now enforce that if you're going to use Biolith (Terrestria, No Mans Land users I'm looking at you) then the version needs to be new enough it supports the early lookup functionality so that Biomes in the preview can be correctly and reliably populated.

Tested with a variety of mod combinations and extensive varied stacks, changes seem to work reliably for both 2d and 3d views when populating Biomes. Way, way, way faster (~6s updates on complex stack to <200ms on my system).

Most the remaining time now lives inside areas of code outside of FTF and would be seriously nontrivial to further optimise.

---

Quick summary of the changes:
- We no longer calculate underground biomes for previews
- Tile sampling is chunked and processed with parallel streams to use multiple CPU cores.
- We cache small local quarts avoiding repeated quart -> biome lookups
- We adjusted stride to be more aware of zoom levels when sampling
- reused objects and arrays to cut allocations and GC overhead
- Preserved Bioliths configuration states across worker threads preventing need to reinitialize each sample
- We one time init compatibility layer integration trees early and reuse to amortize heavy setup overheads.
- PreviewComputationCache now uses fine-grained locks, removeEldestEntry LRU eviction, and async supplyAsync offloading to avoid synchronized blocking during expensive computations.
- Parameter->Biome map passed into TB is deduplicated before tree construction to avoid redundant work. (50000 elements -> 11000 deduped is typical, avoids an expensive tree)
- Early returns and simplified row indexing reduce per-pixel overhead when uploading textures thanks to JIT inlining.
- Mod metadata now requires optional dependency biolith >= 3.0.14 to avoid incompatible slow/failing preview paths.