### PR TITLE
fix: Neuter disabled cave features

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/data/RTFLanguageProvider.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/data/RTFLanguageProvider.java
@@ -33,7 +33,7 @@ public final class RTFLanguageProvider {
 			this.add(RTFTranslationKeys.GUI_RIVERS_PRESET_NAME, "Modern - Default with 3D Rivers");
 			this.add(RTFTranslationKeys.GUI_WORLD_SETTINGS_TITLE, "World Settings");
 			this.add(RTFTranslationKeys.GUI_SURFACE_SETTINGS_TITLE, "Surface Settings (Experimental)");
-			this.add(RTFTranslationKeys.GUI_CAVE_SETTINGS_TITLE, "Cave Settings (Experimental)");
+			this.add(RTFTranslationKeys.GUI_UNDERGROUND_SETTINGS_TITLE, "Underground Settings");
 			this.add(RTFTranslationKeys.GUI_CLIMATE_SETTINGS_TITLE, "Climate Settings");
 			this.add(RTFTranslationKeys.GUI_TERRAIN_SETTINGS_TITLE, "Terrain Settings");
 			this.add(RTFTranslationKeys.GUI_RIVER_SETTINGS_TITLE, "River Settings");

--- a/common/src/main/java/raccoonman/reterraforged/client/data/RTFTranslationKeys.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/data/RTFTranslationKeys.java
@@ -1,6 +1,5 @@
 package raccoonman.reterraforged.client.data;
 
-import net.minecraft.network.chat.Component;
 import raccoonman.reterraforged.RTFCommon;
 
 public final class RTFTranslationKeys {
@@ -35,7 +34,7 @@ public final class RTFTranslationKeys {
 	public static final String GUI_COMMUNITY1_PRESET_NAME = resolve("gui.preset.community1.name");
 	public static final String GUI_WORLD_SETTINGS_TITLE = resolve("gui.worldSettings.title");
 	public static final String GUI_SURFACE_SETTINGS_TITLE = resolve("gui.surfaceSettings.title");
-	public static final String GUI_CAVE_SETTINGS_TITLE = resolve("gui.caveSettings.title");
+	public static final String GUI_UNDERGROUND_SETTINGS_TITLE = resolve("gui.undergroundSettings.title");
 	public static final String GUI_CLIMATE_SETTINGS_TITLE = resolve("gui.climateSettings.title");
 	public static final String GUI_TERRAIN_SETTINGS_TITLE = resolve("gui.terrainSettings.title");
 	public static final String GUI_RIVER_SETTINGS_TITLE = resolve("gui.riverSettings.title");

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/CaveSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/CaveSettingsPage.java
@@ -17,11 +17,8 @@ public class CaveSettingsPage extends PresetEditorPage {
 	private Slider cheeseCaveProbability;
 	private Slider spaghettiProbability;
 	private Slider noodleCaveProbability;
-	private Slider carverCaveProbability;
-	private Slider deepCarverCaveProbability;
 	private Slider ravineProbability;
 	private CycleButton<Boolean> largeOreVeins;
-	private CycleButton<Boolean> legacyCarverDistribution;
 	
 	public CaveSettingsPage(PresetConfigScreen screen, PresetEntry preset) {
 		super(screen, preset);
@@ -59,23 +56,12 @@ public class CaveSettingsPage extends PresetEditorPage {
 			caves.noodleCaveProbability = (float) slider.scaleValue(value);
 			return value;
 		});
-		this.carverCaveProbability = PresetWidgets.createFloatSlider(caves.caveCarverProbability, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_CAVE_CARVER_PROBABILITY, (slider, value) -> {
-			caves.caveCarverProbability = (float) slider.scaleValue(value);
-			return value;
-		});
-		this.deepCarverCaveProbability = PresetWidgets.createFloatSlider(caves.deepCaveCarverProbability, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_DEEP_CAVE_CARVER_PROBABILITY, (slider, value) -> {
-			caves.deepCaveCarverProbability = (float) slider.scaleValue(value);
-			return value;
-		});
 		this.ravineProbability = PresetWidgets.createFloatSlider(caves.ravineCarverProbability, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_RAVINE_CARVER_PROBABILITY, (slider, value) -> {
 			caves.ravineCarverProbability = (float) slider.scaleValue(value);
 			return value;
 		});
 		this.largeOreVeins = PresetWidgets.createToggle(caves.largeOreVeins, RTFTranslationKeys.GUI_BUTTON_LARGE_ORE_VEINS, (button, value) -> {
 			caves.largeOreVeins = value;
-		});
-		this.legacyCarverDistribution = PresetWidgets.createToggle(caves.legacyCarverDistribution, RTFTranslationKeys.GUI_BUTTON_LEGACY_CARVER_DISTRIBUTION, (button, value) -> {
-			caves.legacyCarverDistribution = value;
 		});
 
 		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_NOISE_CAVES));
@@ -86,11 +72,8 @@ public class CaveSettingsPage extends PresetEditorPage {
 		this.left.addWidget(this.noodleCaveProbability);
 
 		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_CARVERS));
-		this.left.addWidget(this.carverCaveProbability);
-		this.left.addWidget(this.deepCarverCaveProbability);
 		this.left.addWidget(this.ravineProbability);
 		this.left.addWidget(this.largeOreVeins);
-		this.left.addWidget(this.legacyCarverDistribution);
 	}
 	
 	@Override

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/ClimateSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/ClimateSettingsPage.java
@@ -28,11 +28,6 @@ class ClimateSettingsPage extends PresetEditorPage {
 	private Slider moistureBias;
 	
 	private Slider biomeSize;
-	private Slider undergroundBiomeSize;
-	private Slider undergroundBiomeVerticalSize;
-	private Slider undergroundBiomeCoverage;
-	private Slider undergroundBiomeClimateInfluence;
-	private CycleButton<Boolean> undergroundBiomeBanding;
 	private Slider macroNoiseSize;
 	private Slider biomeWarpScale;
 	private Slider biomeWarpStrength;
@@ -123,37 +118,11 @@ class ClimateSettingsPage extends PresetEditorPage {
 		});
 
 		ClimateSettings.BiomeShape biomeShape = climate.biomeShape;
-		int maximumUndergroundVerticalSize = PresetSettingsBounds.maximumUndergroundBiomeVerticalSize(
-			preset.world().properties.worldHeight,
-			preset.world().properties.worldDepth
-		);
-		biomeShape.undergroundBiomeVerticalSize = Math.min(
-			biomeShape.undergroundBiomeVerticalSize,
-			maximumUndergroundVerticalSize
-		);
+
 		this.biomeSize = PresetWidgets.createIntSlider(biomeShape.biomeSize, ClimateSettings.BiomeShape.MIN_BIOME_SIZE, ClimateSettings.BiomeShape.MAX_BIOME_SIZE, RTFTranslationKeys.GUI_SLIDER_BIOME_SIZE, (slider, value) -> {
 			biomeShape.biomeSize = (int) slider.scaleValue(value);
 			this.regenerate();
 			return value;
-		});
-		this.undergroundBiomeSize = PresetWidgets.createIntSlider(biomeShape.undergroundBiomeSize, ClimateSettings.BiomeShape.MIN_BIOME_SIZE, ClimateSettings.BiomeShape.MAX_BIOME_SIZE, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_SIZE, (slider, value) -> {
-			biomeShape.undergroundBiomeSize = (int) slider.scaleValue(value);
-			return value;
-		});
-		this.undergroundBiomeVerticalSize = PresetWidgets.createIntSlider(biomeShape.undergroundBiomeVerticalSize, ClimateSettings.BiomeShape.MIN_UNDERGROUND_VERTICAL_SIZE, maximumUndergroundVerticalSize, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_VERTICAL_SIZE, (slider, value) -> {
-			biomeShape.undergroundBiomeVerticalSize = (int) slider.scaleValue(value);
-			return value;
-		});
-		this.undergroundBiomeCoverage = PresetWidgets.createFloatSlider(biomeShape.undergroundBiomeCoverage, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_COVERAGE, (slider, value) -> {
-			biomeShape.undergroundBiomeCoverage = (float) slider.scaleValue(value);
-			return value;
-		});
-		this.undergroundBiomeClimateInfluence = PresetWidgets.createFloatSlider(biomeShape.undergroundBiomeClimateInfluence, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_CLIMATE_INFLUENCE, (slider, value) -> {
-			biomeShape.undergroundBiomeClimateInfluence = (float) slider.scaleValue(value);
-			return value;
-		});
-		this.undergroundBiomeBanding = PresetWidgets.createToggle(biomeShape.undergroundBiomeBanding, RTFTranslationKeys.GUI_BUTTON_UNDERGROUND_BIOME_BANDING, (button, value) -> {
-			biomeShape.undergroundBiomeBanding = value;
 		});
 		this.macroNoiseSize = PresetWidgets.createIntSlider(biomeShape.macroNoiseSize, 1, 20, RTFTranslationKeys.GUI_SLIDER_MACRO_NOISE_SIZE, (slider, value) -> {
 			biomeShape.macroNoiseSize = (int) slider.scaleValue(value);
@@ -224,13 +193,6 @@ class ClimateSettingsPage extends PresetEditorPage {
 		this.left.addWidget(this.biomeWarpScale);
 		this.left.addWidget(this.biomeWarpStrength);
 
-		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_UNDERGROUND_BIOMES));
-		this.left.addWidget(this.undergroundBiomeSize);
-		this.left.addWidget(this.undergroundBiomeVerticalSize);
-		this.left.addWidget(this.undergroundBiomeCoverage);
-		this.left.addWidget(this.undergroundBiomeClimateInfluence);
-		this.left.addWidget(this.undergroundBiomeBanding);
-
 		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_BIOME_EDGE_SHAPE));
 		this.left.addWidget(this.biomeEdgeType);
 		this.left.addWidget(this.biomeEdgeScale);
@@ -242,7 +204,7 @@ class ClimateSettingsPage extends PresetEditorPage {
 
 	@Override
 	public Optional<Page> previous() {
-		return Optional.of(new CaveSettingsPage(this.screen, this.preset));
+		return Optional.of(new UndergroundSettingsPage(this.screen, this.preset));
 	}
 
 	@Override

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/SurfaceSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/SurfaceSettingsPage.java
@@ -114,6 +114,6 @@ public class SurfaceSettingsPage extends PresetEditorPage {
 
 	@Override
 	public Optional<Page> next() {
-		return Optional.of(new CaveSettingsPage(this.screen, this.preset));
+		return Optional.of(new UndergroundSettingsPage(this.screen, this.preset));
 	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/UndergroundSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/UndergroundSettingsPage.java
@@ -9,9 +9,10 @@ import raccoonman.reterraforged.client.gui.screen.page.LinkedPageScreen.Page;
 import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetListPage.PresetEntry;
 import raccoonman.reterraforged.client.gui.widget.Slider;
 import raccoonman.reterraforged.data.worldgen.preset.settings.CaveSettings;
+import raccoonman.reterraforged.data.worldgen.preset.settings.ClimateSettings;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
 
-public class CaveSettingsPage extends PresetEditorPage {
+public class UndergroundSettingsPage extends PresetEditorPage {
 	private Slider entranceCaveProbability;
 	private Slider cheeseCaveDepthOffset;
 	private Slider cheeseCaveProbability;
@@ -19,14 +20,20 @@ public class CaveSettingsPage extends PresetEditorPage {
 	private Slider noodleCaveProbability;
 	private Slider ravineProbability;
 	private CycleButton<Boolean> largeOreVeins;
+
+	private Slider undergroundBiomeSize;
+	private Slider undergroundBiomeVerticalSize;
+	private Slider undergroundBiomeCoverage;
+	private Slider undergroundBiomeClimateInfluence;
+	private CycleButton<Boolean> undergroundBiomeBanding;
 	
-	public CaveSettingsPage(PresetConfigScreen screen, PresetEntry preset) {
+	public UndergroundSettingsPage(PresetConfigScreen screen, PresetEntry preset) {
 		super(screen, preset);
 	}
 
 	@Override
 	public Component title() {
-		return Component.translatable(RTFTranslationKeys.GUI_CAVE_SETTINGS_TITLE);
+		return Component.translatable(RTFTranslationKeys.GUI_UNDERGROUND_SETTINGS_TITLE);
 	}
 
 	@Override
@@ -35,6 +42,18 @@ public class CaveSettingsPage extends PresetEditorPage {
 
 		Preset preset = this.preset.getPreset();
 		CaveSettings caves = preset.caves();
+		ClimateSettings climate = preset.climate();
+		ClimateSettings.BiomeShape biomeShape = climate.biomeShape;
+
+		int maximumUndergroundVerticalSize = PresetSettingsBounds.maximumUndergroundBiomeVerticalSize(
+				preset.world().properties.worldHeight,
+				preset.world().properties.worldDepth
+		);
+
+		biomeShape.undergroundBiomeVerticalSize = Math.min(
+				biomeShape.undergroundBiomeVerticalSize,
+				maximumUndergroundVerticalSize
+		);
 
 		this.entranceCaveProbability = PresetWidgets.createFloatSlider(caves.entranceCaveProbability, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_ENTRANCE_CAVE_PROBABILITY, (slider, value) -> {
 			caves.entranceCaveProbability = (float) slider.scaleValue(value);
@@ -64,6 +83,26 @@ public class CaveSettingsPage extends PresetEditorPage {
 			caves.largeOreVeins = value;
 		});
 
+		this.undergroundBiomeSize = PresetWidgets.createIntSlider(biomeShape.undergroundBiomeSize, ClimateSettings.BiomeShape.MIN_BIOME_SIZE, ClimateSettings.BiomeShape.MAX_BIOME_SIZE, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_SIZE, (slider, value) -> {
+			biomeShape.undergroundBiomeSize = (int) slider.scaleValue(value);
+			return value;
+		});
+		this.undergroundBiomeVerticalSize = PresetWidgets.createIntSlider(biomeShape.undergroundBiomeVerticalSize, ClimateSettings.BiomeShape.MIN_UNDERGROUND_VERTICAL_SIZE, maximumUndergroundVerticalSize, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_VERTICAL_SIZE, (slider, value) -> {
+			biomeShape.undergroundBiomeVerticalSize = (int) slider.scaleValue(value);
+			return value;
+		});
+		this.undergroundBiomeCoverage = PresetWidgets.createFloatSlider(biomeShape.undergroundBiomeCoverage, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_COVERAGE, (slider, value) -> {
+			biomeShape.undergroundBiomeCoverage = (float) slider.scaleValue(value);
+			return value;
+		});
+		this.undergroundBiomeClimateInfluence = PresetWidgets.createFloatSlider(biomeShape.undergroundBiomeClimateInfluence, 0.0F, 1.0F, RTFTranslationKeys.GUI_SLIDER_UNDERGROUND_BIOME_CLIMATE_INFLUENCE, (slider, value) -> {
+			biomeShape.undergroundBiomeClimateInfluence = (float) slider.scaleValue(value);
+			return value;
+		});
+		this.undergroundBiomeBanding = PresetWidgets.createToggle(biomeShape.undergroundBiomeBanding, RTFTranslationKeys.GUI_BUTTON_UNDERGROUND_BIOME_BANDING, (button, value) -> {
+			biomeShape.undergroundBiomeBanding = value;
+		});
+
 		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_NOISE_CAVES));
 		this.left.addWidget(this.entranceCaveProbability);
 		this.left.addWidget(this.cheeseCaveDepthOffset);
@@ -74,6 +113,13 @@ public class CaveSettingsPage extends PresetEditorPage {
 		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_CARVERS));
 		this.left.addWidget(this.ravineProbability);
 		this.left.addWidget(this.largeOreVeins);
+
+		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_UNDERGROUND_BIOMES));
+		this.left.addWidget(this.undergroundBiomeSize);
+		this.left.addWidget(this.undergroundBiomeVerticalSize);
+		this.left.addWidget(this.undergroundBiomeCoverage);
+		this.left.addWidget(this.undergroundBiomeClimateInfluence);
+		this.left.addWidget(this.undergroundBiomeBanding);
 	}
 	
 	@Override

--- a/common/src/main/resources/assets/reterraforged/lang/en_us.json
+++ b/common/src/main/resources/assets/reterraforged/lang/en_us.json
@@ -86,7 +86,7 @@
   "reterraforged.gui.button.river.flow.particles.tooltip": "Allow rivers to spawn particles that show flow direction",
   "reterraforged.gui.button.boat.flow.dynamics.tooltip": "Allow river water flow direction to apply force to boats",
   "reterraforged.gui.button.boat.navigable.waterfalls.tooltip": "Prevent boats sinking while they are on rivers allowing waterfalls to be climbed",
-  "reterraforged.gui.caveSettings.title": "Cave Settings",
+  "reterraforged.gui.undergroundSettings.title": "Underground Settings",
   "reterraforged.gui.climateSettings.title": "Climate Settings",
   "reterraforged.gui.filterSettings.title": "Filter Settings",
   "reterraforged.gui.islandSettings.title": "Island Settings",


### PR DESCRIPTION
fixes https://github.com/ETcodehome/FreeTerraForged/issues/119
... by removing the features that were no longer wired to anything since 1.18 changed the entire way cave systems were generated.

---

Relocated the underground settings to be colocated alongside the other settings, and renamed the tab to underground settings rather than cave settings.

---

<img width="1258" height="1223" alt="image" src="https://github.com/user-attachments/assets/37f08780-09d1-4c8a-a299-2f0303210193" />

