### PR TITLE
fix: prevent UI scale sliders feeling bad for uplift continents

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/ClimateSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/ClimateSettingsPage.java
@@ -10,7 +10,9 @@ import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetListPage.Pr
 import raccoonman.reterraforged.client.gui.widget.Slider;
 import raccoonman.reterraforged.client.gui.widget.ValueButton;
 import raccoonman.reterraforged.data.worldgen.preset.settings.ClimateSettings;
+import raccoonman.reterraforged.data.worldgen.preset.settings.ContinentType;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
+import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
 
 class ClimateSettingsPage extends PresetEditorPage {
 	private ValueButton<Integer> temperatureSeedOffset;

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/ClimateSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/ClimateSettingsPage.java
@@ -10,9 +10,7 @@ import raccoonman.reterraforged.client.gui.screen.presetconfig.PresetListPage.Pr
 import raccoonman.reterraforged.client.gui.widget.Slider;
 import raccoonman.reterraforged.client.gui.widget.ValueButton;
 import raccoonman.reterraforged.data.worldgen.preset.settings.ClimateSettings;
-import raccoonman.reterraforged.data.worldgen.preset.settings.ContinentType;
 import raccoonman.reterraforged.data.worldgen.preset.settings.Preset;
-import raccoonman.reterraforged.data.worldgen.preset.settings.WorldSettings;
 
 class ClimateSettingsPage extends PresetEditorPage {
 	private ValueButton<Integer> temperatureSeedOffset;

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/TerrainSettingsPage.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/screen/presetconfig/TerrainSettingsPage.java
@@ -86,6 +86,8 @@ public class TerrainSettingsPage extends PresetEditorPage {
 		Preset preset = this.preset.getPreset();
 		TerrainSettings terrain = preset.terrain();
 		General general = terrain.general;
+		boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
+		float flooredLowRange = isUpliftContinent ? 1.0F : 0.01F;
 		
 		this.terrainSeedOffset = PresetWidgets.createRandomButton(RTFTranslationKeys.GUI_BUTTON_TERRAIN_SEED_OFFSET, general.terrainSeedOffset, (value) -> {
 			general.terrainSeedOffset = value;
@@ -96,14 +98,13 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			this.regenerate();
 			return value;
 		});
-		this.globalVerticalScale = PresetWidgets.createFloatSlider(general.globalVerticalScale, 0.01F, 1.0F, RTFTranslationKeys.GUI_SLIDER_GLOBAL_VERTICAL_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
+		this.globalVerticalScale = PresetWidgets.createFloatSlider(general.globalVerticalScale, flooredLowRange, 1.0F, RTFTranslationKeys.GUI_SLIDER_GLOBAL_VERTICAL_SCALE, (slider, value) -> {
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(1.0F), value) : value;
 			general.globalVerticalScale = (float) slider.scaleValue(value);
 			this.regenerate();
 			return value;
 		});
-		this.globalHorizontalScale = PresetWidgets.createFloatSlider(general.globalHorizontalScale, 0.01F, 5.0F, RTFTranslationKeys.GUI_SLIDER_GLOBAL_HORIZONTAL_SCALE, (slider, value) -> {
+		this.globalHorizontalScale = PresetWidgets.createFloatSlider(general.globalHorizontalScale, 0.01F, 8.0F, RTFTranslationKeys.GUI_SLIDER_GLOBAL_HORIZONTAL_SCALE, (slider, value) -> {
 			general.globalHorizontalScale = (float) slider.scaleValue(value);
 			this.regenerate();
 			return value;
@@ -121,7 +122,6 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			this.regenerate();
 			return value;
 		});
-
 		Terrain steppe = terrain.steppe;
 		this.steppeWeight = PresetWidgets.createFloatSlider(steppe.weight, 0.0F, 10.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_WEIGHT, (slider, value) -> {
 			steppe.weight = (float) slider.scaleValue(value);
@@ -129,7 +129,6 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			return value;
 		});
 		this.steppeBaseScale = PresetWidgets.createFloatSlider(steppe.baseScale, 0.0F, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(2.0F), value) : value;
 			steppe.baseScale = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -153,7 +152,6 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			return value;
 		});
 		this.plainsBaseScale = PresetWidgets.createFloatSlider(plains.baseScale, 0.0F, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(2.0F), value) : value;
 			plains.baseScale = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -177,7 +175,6 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			return value;
 		});
 		this.hillsBaseScale = PresetWidgets.createFloatSlider(hills.baseScale, 0.0F, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(1.0F), value) : value;
 			hills.baseScale = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -200,8 +197,7 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			this.regenerate();
 			return value;
 		});
-		this.dalesBaseScale = PresetWidgets.createFloatSlider(dales.baseScale, 0.0F, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
+		this.dalesBaseScale = PresetWidgets.createFloatSlider(dales.baseScale, flooredLowRange, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(1.0F), value) : value;
 			dales.baseScale = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -224,8 +220,7 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			this.regenerate();
 			return value;
 		});
-		this.plateauBaseScale = PresetWidgets.createFloatSlider(plateau.baseScale, 0.0F, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
+		this.plateauBaseScale = PresetWidgets.createFloatSlider(plateau.baseScale, flooredLowRange, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(1.0F), value) : value;
 			plateau.baseScale = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -248,8 +243,7 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			this.regenerate();
 			return value;
 		});
-		this.badlandsBaseScale = PresetWidgets.createFloatSlider(badlands.baseScale, 0.0F, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
+		this.badlandsBaseScale = PresetWidgets.createFloatSlider(badlands.baseScale, flooredLowRange, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(1.0F), value) : value;
 			badlands.baseScale = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -289,8 +283,7 @@ public class TerrainSettingsPage extends PresetEditorPage {
 		});
 		
 		Terrain mountains = terrain.mountains;
-		this.mountainsWeight = PresetWidgets.createFloatSlider(mountains.weight, 0.0F, 10.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_WEIGHT, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
+		this.mountainsWeight = PresetWidgets.createFloatSlider(mountains.weight, flooredLowRange, 10.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_WEIGHT, (slider, value) -> {
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(1.0F), value) : value;
 			mountains.weight = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -318,8 +311,7 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			this.regenerate();
 			return value;
 		});
-		this.volcanoBaseScale = PresetWidgets.createFloatSlider(volcano.baseScale, 0.0F, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
-			boolean isUpliftContinent = preset.world().continent.continentType == ContinentType.UPLIFT;
+		this.volcanoBaseScale = PresetWidgets.createFloatSlider(volcano.baseScale, flooredLowRange, 2.0F, RTFTranslationKeys.GUI_SLIDER_TERRAIN_BASE_SCALE, (slider, value) -> {
 			value = isUpliftContinent ? Math.max(slider.getSliderValue(1.0F), value) : value;
 			volcano.baseScale = (float) slider.scaleValue(value);
 			this.regenerate();
@@ -335,6 +327,11 @@ public class TerrainSettingsPage extends PresetEditorPage {
 			this.regenerate();
 			return value;
 		});
+
+		this.globalVerticalScale.active = !isUpliftContinent;
+		this.steppeBaseScale.active = !isUpliftContinent;
+		this.plainsBaseScale.active = !isUpliftContinent;
+		this.hillsBaseScale.active = !isUpliftContinent;
 		
 		this.left.addWidget(PresetWidgets.createLabel(RTFTranslationKeys.GUI_LABEL_GENERAL));
 		this.left.addWidget(this.terrainSeedOffset);

--- a/common/src/main/java/raccoonman/reterraforged/client/gui/widget/Slider.java
+++ b/common/src/main/java/raccoonman/reterraforged/client/gui/widget/Slider.java
@@ -9,32 +9,31 @@ import net.minecraft.util.Mth;
 
 //TODO this should be cleaned up
 public class Slider extends AbstractSliderButton {
-    private double min;
-    private double max;
+	private double min;
+	private double max;
 	private Component name;
 	private Format format;
 	@Nullable
 	private Callback callback;
 
-    public Slider(int x, int y, int width, int height, float initialValue, float min, float max, Component name, Format format, @Nullable Callback callback) {
-        super(x, y, width, height, CommonComponents.EMPTY, 0.0);
-        this.name = name;
-        this.format = format;
-        this.min = min;
-        this.max = max;
-        this.value = this.getSliderValue(initialValue);
-        this.callback = callback;
-        this.updateMessage();
-    }
+	public Slider(int x, int y, int width, int height, float initialValue, float min, float max, Component name, Format format, @Nullable Callback callback) {
+		super(x, y, width, height, CommonComponents.EMPTY, 0.0);
+		this.name = name;
+		this.format = format;
+		this.min = min;
+		this.max = max;
+		this.callback = callback;
+		this.setValue(this.getSliderValue(initialValue));
+	}
 
-    public void setValue(double value) {
-    	this.value = value;
+	public void setValue(double value) {
+		this.value = Double.isNaN(value) ? 0.0 : Mth.clamp(value, 0.0, 1.0);
 		this.updateMessage();
-    }
+	}
 
-    public double getValue() {
-    	return this.value;
-    }
+	public double getValue() {
+		return this.value;
+	}
 
 	public double getMin() {
 		return this.min;
@@ -45,43 +44,46 @@ public class Slider extends AbstractSliderButton {
 	}
 
 	public void setRange(double min, double max) {
-		double current = this.lerpValue(this.value);
+		double current = this.getLerpedValue();
 		this.min = min;
 		this.max = max;
-		this.value = this.getSliderValue((float) current);
-		this.updateMessage();
+		this.setValue(this.getSliderValue((float) current));
 	}
 
-    public double getSliderValue(float value) {
-    	return (Mth.clamp(value, this.min, this.max) - this.min) / (this.max - this.min);
-    }
+	public double getSliderValue(float value) {
+		double range = this.max - this.min;
+		if (range <= 0.0) {
+			return 0.0;
+		}
+		return (Mth.clamp(value, (float) this.min, (float) this.max) - this.min) / range;
+	}
 
-    public double getLerpedValue() {
-    	return this.lerpValue(this.value);
-    }
+	public double getLerpedValue() {
+		return this.lerpValue(this.value);
+	}
 
-    public double lerpValue(double value) {
-    	return Mth.lerp(value, this.min, this.max);
-    }
+	public double lerpValue(double value) {
+		return Mth.lerp(Mth.clamp(value, 0.0, 1.0), this.min, this.max);
+	}
 
-    public double scaleValue(double value) {
-        return this.format.scale(this.lerpValue(value));
-    }
+	public double scaleValue(double value) {
+		return this.format.scale(this.lerpValue(value));
+	}
 
-    @Override
-    public void applyValue() {
-    	if(this.callback != null) {
-        	this.value = this.callback.apply(this, this.value);
-    	}
-    }
+	@Override
+	public void applyValue() {
+		if (this.callback != null) {
+			this.setValue(this.callback.apply(this, this.value));
+		}
+	}
 
-    @Override
-    protected void updateMessage() {
-        this.setMessage(CommonComponents.optionNameValue(this.name, Component.literal(this.format.getMessage(this.scaleValue((float) this.value)))));
-    }
+	@Override
+	protected void updateMessage() {
+		this.setMessage(CommonComponents.optionNameValue(this.name, Component.literal(this.format.getMessage(this.scaleValue(this.value)))));
+	}
 
-    public static enum Format {
-    	INT {
+	public static enum Format {
+		INT {
 			@Override
 			public double scale(double input) {
 				return (int) input;
@@ -92,7 +94,7 @@ public class Slider extends AbstractSliderButton {
 				return String.valueOf((int) input);
 			}
 		},
-    	FLOAT {
+		FLOAT {
 			@Override
 			public double scale(double input) {
 				return input;
@@ -104,12 +106,12 @@ public class Slider extends AbstractSliderButton {
 			}
 		};
 
-    	public abstract double scale(double input);
+		public abstract double scale(double input);
 
-    	public abstract String getMessage(double input);
-    }
+		public abstract String getMessage(double input);
+	}
 
-    public interface Callback {
-    	double apply(Slider slider, double value);
-    }
+	public interface Callback {
+		double apply(Slider slider, double value);
+	}
 }

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/CaveSettings.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/CaveSettings.java
@@ -27,9 +27,6 @@ public class CaveSettings {
 	public float ravineCarverProbability;
 	public boolean largeOreVeins;
 	public boolean legacyCarverDistribution;
-	
-	//TODO
-	public boolean minCaveBiomeDepth;
 
 	public CaveSettings(float entranceCaveProbability, float cheeseCaveDepthOffset, float cheeseCaveProbability, float spaghettiCaveProbability, float noodleCaveProbability, float caveCarverProbability, float deepCaveCarverProbability, float ravineProbability, boolean largeOreVeins, boolean legacyCarverDistribution) {
 		this.entranceCaveProbability = entranceCaveProbability;


### PR DESCRIPTION
When we added uplift continent types (a long while ago now) I locked some slider values that generated subtractive carving results.

This wasn't obvious in the UI and felt bad, like the base scale was unresponsive. This PR fixes that issue so that we don't have users feeling the UI is broken. It's also reranged some values that weren't disabled but were range restricted so it feels more correct / intuitive. Global horizontal scale range was expanded because many users exceed the existing range anyway via manual edits and the engine handles it fine.

- [x] Tested values display sensibly
- [x] Tested manual out of range values aren't edited if untouched in the menu
- [x] Tested sliders still persist their values correctly
- [x] Verified slider active state now handled correctly when uplifting
- [x] Verified slider state handled correctly when not uplifting