### PR TITLE
Fix: Trail Ruins Burial

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
+++ b/common/src/main/java/raccoonman/reterraforged/mixin/MixinJigsawStructure.java
@@ -1,6 +1,8 @@
 package raccoonman.reterraforged.mixin;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.mojang.datafixers.util.Either;
@@ -29,6 +31,7 @@ import net.minecraft.world.level.levelgen.WorldGenerationContext;
 import net.minecraft.world.level.levelgen.heightproviders.HeightProvider;
 import net.minecraft.world.level.levelgen.structure.BoundingBox;
 import net.minecraft.world.level.levelgen.structure.BuiltinStructures;
+import net.minecraft.world.level.levelgen.structure.PoolElementStructurePiece;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.pieces.StructurePiecesBuilder;
 import net.minecraft.world.level.levelgen.structure.pools.DimensionPadding;
@@ -45,24 +48,31 @@ import raccoonman.reterraforged.world.worldgen.RTFRandomState;
 import raccoonman.reterraforged.world.worldgen.cell.rivermap.river.RiverCarverSettings;
 import raccoonman.reterraforged.world.worldgen.densityfunction.tile.Tile;
 
-/**
- * 1) Keeps Trial Chamber and Ancient City jigsaw starts within a terrain-bounded vertical window, then validates the
- *    generated pieces against the dimension floor and the lowest surface over the resulting structure footprint.
- * 2) Retries Village placement with random offsets if the candidate origin lands on a river cell, or if the outer
- *    boundary perimeter of the resulting structure footprint intersects a river.
- */
 @Mixin(JigsawStructure.class)
 public class MixinJigsawStructure {
+	@Unique
+	private static final byte rtf$TARGET_UNCHECKED = 0;
+	@Unique
+	private static final byte rtf$TARGET_SUBTERRANEAN = 1;
+	@Unique
+	private static final byte rtf$TARGET_VILLAGE = 2;
+	@Unique
+	private static final byte rtf$TARGET_TRAIL_RUINS = 3;
+	@Unique
+	private static final byte rtf$TARGET_UNHANDLED = 4;
 	@Unique
 	private static final int rtf$MARGIN = 10;
 	@Unique
 	private static final int rtf$BOUNDARY_TOLERANCE = 8;
 	@Unique
 	private static final int rtf$GRID_STEPS_PER_SIDE = 3;
-
-	// 0 = unchecked, 1 = subterranean (Trial Chambers / Ancient City), 2 = village, 3 = unhandled structure
 	@Unique
-	private byte rtf$targetStatus;
+	private static final int rtf$BURY_RADIUS = 6;
+	@Unique
+	private static final int rtf$TRAIL_RUINS_MAX_ATTEMPTS = 16;
+
+	@Unique
+	private byte rtf$targetStatus = rtf$TARGET_UNCHECKED;
 
 	@Shadow
 	@Final
@@ -97,11 +107,12 @@ public class MixinJigsawStructure {
 
 	@Inject(method = "findGenerationPoint", at = @At("HEAD"), cancellable = true)
 	private void rtf$correctOrSkip(Structure.GenerationContext generationContext, CallbackInfoReturnable<Optional<Structure.GenerationStub>> cir) {
-		if (this.rtf$targetStatus == 0) {
+		if (this.rtf$targetStatus == rtf$TARGET_UNCHECKED) {
 			Structure self = (Structure) (Object) this;
 			var registry = generationContext.registryAccess().registryOrThrow(Registries.STRUCTURE);
 			Structure trialChambers = registry.get(BuiltinStructures.TRIAL_CHAMBERS);
 			Structure ancientCity = registry.get(BuiltinStructures.ANCIENT_CITY);
+			Structure trailRuins = registry.get(BuiltinStructures.TRAIL_RUINS);
 
 			boolean isVillage = registry.getResourceKey(self)
 					.flatMap(registry::getHolder)
@@ -109,24 +120,149 @@ public class MixinJigsawStructure {
 					.orElse(false);
 
 			if (self == trialChambers || self == ancientCity) {
-				this.rtf$targetStatus = (byte) 1;
+				this.rtf$targetStatus = rtf$TARGET_SUBTERRANEAN;
 			} else if (isVillage) {
-				this.rtf$targetStatus = (byte) 2;
+				this.rtf$targetStatus = rtf$TARGET_VILLAGE;
+			} else if (self == trailRuins) {
+				this.rtf$targetStatus = rtf$TARGET_TRAIL_RUINS;
 			} else {
-				this.rtf$targetStatus = (byte) 3;
+				this.rtf$targetStatus = rtf$TARGET_UNHANDLED;
 			}
 		}
 
-		if (this.rtf$targetStatus == 3) {
+		if (this.rtf$targetStatus == rtf$TARGET_UNHANDLED) {
+			return;
+		}
+		if (this.rtf$targetStatus == rtf$TARGET_TRAIL_RUINS) {
+			GeneratorContext generatorContext = rtf$generatorContext(generationContext.randomState());
+			if (generatorContext != null) {
+				rtf$handleTrailRuinsPlacement(generationContext, generatorContext, cir);
+			}
 			return;
 		}
 
-		if (this.rtf$targetStatus == 2) {
+		if (this.rtf$targetStatus == rtf$TARGET_VILLAGE) {
 			rtf$handleVillageRetryPlacement(generationContext, cir);
 			return;
 		}
 
 		rtf$handleSubterraneanPlacement(generationContext, cir);
+	}
+
+	@Unique
+	private void rtf$handleTrailRuinsPlacement(
+		Structure.GenerationContext generationContext,
+		GeneratorContext generatorContext,
+		CallbackInfoReturnable<Optional<Structure.GenerationStub>> cir
+	) {
+		ChunkPos chunkPos = generationContext.chunkPos();
+		int originX = chunkPos.getMinBlockX();
+		int originZ = chunkPos.getMinBlockZ();
+		RandomSource random = generationContext.random();
+		WorldGenerationContext heightContext = new WorldGenerationContext(
+			generationContext.chunkGenerator(),
+			generationContext.heightAccessor()
+		);
+
+		for (int attempt = 0; attempt < rtf$TRAIL_RUINS_MAX_ATTEMPTS; attempt++) {
+			int offsetX = attempt == 0 ? 0 : random.nextIntBetweenInclusive(-32, 32);
+			int offsetZ = attempt == 0 ? 0 : random.nextIntBetweenInclusive(-32, 32);
+			int sampledY = this.startHeight.sample(random, heightContext);
+			BlockPos placementPos = new BlockPos(originX + offsetX, sampledY, originZ + offsetZ);
+
+			Optional<Structure.GenerationStub> result = JigsawPlacement.addPieces(
+				generationContext, this.startPool, this.startJigsawName, this.maxDepth, placementPos,
+				this.useExpansionHack, this.projectStartToHeightmap, this.maxDistanceFromCenter,
+				PoolAliasLookup.create(this.poolAliases, placementPos, generationContext.seed()),
+				this.dimensionPadding, this.liquidSettings
+			);
+			if (result.isEmpty()) {
+				continue;
+			}
+
+			Structure.GenerationStub stub = result.get();
+			if (!rtf$isValidBiome(generationContext, stub.position())) {
+				continue;
+			}
+			StructurePiecesBuilder builder = stub.getPiecesBuilder();
+			int maxSuspension = rtf$maxBuryPlaneSuspension(builder, generatorContext);
+			if (maxSuspension > 0) {
+				continue;
+			}
+
+			cir.setReturnValue(Optional.of(new Structure.GenerationStub(stub.position(), Either.right(builder))));
+			cir.cancel();
+			return;
+		}
+
+		cir.setReturnValue(Optional.empty());
+		cir.cancel();
+	}
+
+	@Unique
+	private boolean rtf$isValidBiome(Structure.GenerationContext generationContext, BlockPos position) {
+		Holder<Biome> biome = generationContext.chunkGenerator()
+			.getBiomeSource()
+			.getNoiseBiome(
+				QuartPos.fromBlock(position.getX()),
+				QuartPos.fromBlock(position.getY()),
+				QuartPos.fromBlock(position.getZ()),
+				generationContext.randomState().sampler()
+			);
+		return generationContext.validBiome().test(biome);
+	}
+
+	@Unique
+	private int rtf$maxBuryPlaneSuspension(
+		StructurePiecesBuilder builder,
+		GeneratorContext generatorContext
+	) {
+		Map<Long, Tile.Chunk> chunks = new HashMap<>();
+		int maxSuspension = Integer.MIN_VALUE;
+		for (var piece : builder.build().pieces()) {
+			if (!(piece instanceof PoolElementStructurePiece poolPiece)) {
+				continue;
+			}
+			if (poolPiece.getElement().getProjection() != StructureTemplatePool.Projection.RIGID) {
+				continue;
+			}
+
+			BoundingBox box = poolPiece.getBoundingBox();
+			int groundPlane = box.minY() + poolPiece.getGroundLevelDelta();
+			for (int x = box.minX() - rtf$BURY_RADIUS + 1; x <= box.maxX() + rtf$BURY_RADIUS - 1; x++) {
+				for (int z = box.minZ() - rtf$BURY_RADIUS + 1; z <= box.maxZ() + rtf$BURY_RADIUS - 1; z++) {
+					if (!rtf$isInsideBurySupport(box, x, z)) {
+						continue;
+					}
+					int chunkX = SectionPos.blockToSectionCoord(x);
+					int chunkZ = SectionPos.blockToSectionCoord(z);
+					long chunkKey = ChunkPos.asLong(chunkX, chunkZ);
+					Tile.Chunk chunk = chunks.computeIfAbsent(chunkKey, ignored ->
+						generatorContext.cache.provideAtChunk(chunkX, chunkZ).getChunkReader(chunkX, chunkZ)
+					);
+					maxSuspension = Math.max(
+						maxSuspension,
+						groundPlane - generatorContext.levels.scale(chunk.getCell(x, z).height)
+					);
+				}
+			}
+		}
+		return maxSuspension == Integer.MIN_VALUE ? 0 : maxSuspension;
+	}
+
+	@Unique
+	private static boolean rtf$isInsideBurySupport(BoundingBox box, int x, int z) {
+		int dx = Math.max(0, Math.max(box.minX() - x, x - box.maxX()));
+		int dz = Math.max(0, Math.max(box.minZ() - z, z - box.maxZ()));
+		return dx * dx + dz * dz < rtf$BURY_RADIUS * rtf$BURY_RADIUS;
+	}
+
+	@Unique
+	private static GeneratorContext rtf$generatorContext(RandomState randomState) {
+		if ((Object) randomState instanceof RTFRandomState rtfRandomState) {
+			return rtfRandomState.generatorContext();
+		}
+		return null;
 	}
 
 	@Unique
@@ -146,15 +282,12 @@ public class MixinJigsawStructure {
 			int candidateX = originX + offsetX;
 			int candidateZ = originZ + offsetZ;
 
-			// Quick 2D Cell pre-check: skip immediately if the center origin lands on river terrain
 			if (rtf$isRiverCell(candidateX, candidateZ, generationContext.randomState())) {
 				continue;
 			}
 
-			// Sample raw startHeight (returns 0 for villages)
 			int sampledY = this.startHeight.sample(random, new WorldGenerationContext(generationContext.chunkGenerator(), generationContext.heightAccessor()));
 
-			// Calculate actual surface Y ONLY for biome validation
 			int surfaceY = sampledY;
 			if (this.projectStartToHeightmap.isPresent()) {
 				surfaceY += generationContext.chunkGenerator().getFirstOccupiedHeight(
@@ -163,7 +296,6 @@ public class MixinJigsawStructure {
 				);
 			}
 
-			// Query noise biome at ground level
 			Holder<Biome> biome = generationContext.chunkGenerator()
 					.getBiomeSource()
 					.getNoiseBiome(
@@ -177,7 +309,6 @@ public class MixinJigsawStructure {
 				continue;
 			}
 
-			// Pass sampledY (0) to JigsawPlacement so its internal heightmap addition doesn't double-count surfaceY
 			BlockPos placementPos = new BlockPos(candidateX, sampledY, candidateZ);
 
 			Optional<Structure.GenerationStub> result = JigsawPlacement.addPieces(
@@ -194,12 +325,10 @@ public class MixinJigsawStructure {
 			Structure.GenerationStub stub = result.get();
 			StructurePiecesBuilder builder = stub.getPiecesBuilder();
 
-			// Reject if it generated too few pieces
 			if (builder.build().pieces().size() < minRequiredPieces) {
 				continue;
 			}
 
-			// Outer boundary check: ensure the resulting structure's perimeter does not intersect a river
 			if (rtf$footprintIntersectsRiver(builder.getBoundingBox(), generationContext.randomState())) {
 				continue;
 			}
@@ -209,7 +338,6 @@ public class MixinJigsawStructure {
 			return;
 		}
 
-		// Discard structure if all attempts land on rivers or produce desolate pieces
 		cir.setReturnValue(Optional.empty());
 		cir.cancel();
 	}
@@ -283,24 +411,20 @@ public class MixinJigsawStructure {
 		int minZ = box.minZ();
 		int maxZ = box.maxZ();
 
-		// 1. Scan northern (minZ) and southern (maxZ) perimeter edges along X
 		for (int x = minX; x <= maxX; x += step) {
 			if (rtf$isRiverCell(x, minZ, randomState) || rtf$isRiverCell(x, maxZ, randomState)) {
 				return true;
 			}
 		}
-		// Explicit check for the exact eastern corner bounds if (maxX - minX) isn't divisible by 3
 		if (rtf$isRiverCell(maxX, minZ, randomState) || rtf$isRiverCell(maxX, maxZ, randomState)) {
 			return true;
 		}
 
-		// 2. Scan western (minX) and eastern (maxX) perimeter edges along Z
 		for (int z = minZ; z <= maxZ; z += step) {
 			if (rtf$isRiverCell(minX, z, randomState) || rtf$isRiverCell(maxX, z, randomState)) {
 				return true;
 			}
 		}
-		// Explicit check for the exact southern corner bounds if (maxZ - minZ) isn't divisible by 3
 		if (rtf$isRiverCell(minX, maxZ, randomState) || rtf$isRiverCell(maxX, maxZ, randomState)) {
 			return true;
 		}


### PR DESCRIPTION
 > [!IMPORTANT]
> **TL;DR**:
> Fixes bad placement of Trail Ruins, so they no longer obviously jut above the surface/outside of steep terrain.

## The Problem

It's been a longstanding TerraForged/RTF issue where Trail Ruins could jut out of mountainsides or create unsightly and unnatural platforms. This was due to, yet again, vanilla Minecraft limitations with structure placement:
- In vanilla, the burial depth of the structure was calculated from only one point. 
- That point could be buried, but then due to FTF's more realistic and steep terrain in mountains/hilly areas, the rest of the structure would be protruding out from the ground.

<table align="center" width="100%">
  <tbody>
    <tr>
      <td align="center" width="100%"><kbd><img src="https://github.com/user-attachments/assets/f664b1ab-efd6-4905-a6eb-603d04a3cddd" width="98%"></kbd></td>
    </tr>
    <tr>
      <td align="center"><em>One of the earliest screenshots I could find in the RTF Discord. From 2024-01-21, courtesy of CaveMan</em></td>
    </tr>
  </tbody>
</table>

## The Solution

FTF now checks the entire ruin and, when necessary, tries a nearby location where it can remain properly buried. Breakdown of the logic:
1. Assemble a Trail Ruin normally, via vanilla mechanics.
1. Then checks the terrain beneath every section of the completed structure (as opposed to just the starting point). Three possible outcomes:
     - If its already safe, place the structure like normal
     - If any section would be suspended above a slope and create an unnatural platform, reject that placement and try another nearby position.
     - If no suitable position can be found after up to 16 attempts, the ruin is not generated there. Worst case scenario this only adds about 1 second longer in the placement attempt of a trail ruin. Most ruins place successfully well before then, and since these structures generate rarely anyways the impact is negligible. 

> [!NOTE]
> Trail Ruins can still have small, intentional surface-visible sections. Even in vanilla there should be occasional evidence of where a trail ruin might be. What this fix does is prevent large artificial platforms rather than completely concealing every ruin.

## Demonstration

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="100%">BEFORE THE FIX</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="100%"><kbd><img src="https://github.com/user-attachments/assets/b423e80d-cbee-4215-a0ed-1d67dcc173f7" width="98%"></kbd></td>
    </tr>
    <tr>
      <td align="center"><em>A trail ruin protrudes out of a cliff face, thus harshing the vibe</em></td>
    </tr>
  </tbody>
</table>

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="100%">AFTER THE FIX (Part 1)</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="100%"><kbd><img src="https://github.com/user-attachments/assets/bbd66bae-d898-4a7c-a88f-217220d2dbe2" width="98%"></kbd></td>
    </tr>
    <tr>
      <td align="center"><em>The same spot is rejected for trail ruin placement, and the cliff face is restored to its former glory</em></td>
    </tr>
  </tbody>
</table>

<table align="center" width="100%">
  <thead>
    <tr>
      <th width="100%">AFTER THE FIX (Part 2)</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td align="center" width="100%"><kbd><img src="https://github.com/user-attachments/assets/df5e28f6-5ec5-4c99-8e9e-195322cca3f6" width="98%"></kbd></td>
    </tr>
    <tr>
      <td align="center"><em>The trail ruin is placed nearby in a spot where it can be properly buried</em></td>
    </tr>
  </tbody>
</table>