### PR TITLE
Fix: Headless Preset Generation with Fabric

### DIFF
--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/Datapacks.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/Datapacks.java
@@ -58,10 +58,10 @@ public class Datapacks {
 		return dataGenerator;
 	}
 
-	public static DataGenerator makePreset(Preset preset, RegistryAccess registryAccess, Path dataGenPath, Path dataGenOutputPath, String presetName) {
+	public static DataGenerator makePreset(Preset preset, HolderLookup.Provider registries, Path dataGenPath, Path dataGenOutputPath, String presetName) {
 		DataGenerator dataGenerator = new DataGenerator(dataGenPath, SharedConstants.getCurrentVersion(), true);
 		PackGenerator packGenerator = dataGenerator.new PackGenerator(true, presetName, new PackOutput(dataGenOutputPath));
-		CompletableFuture<HolderLookup.Provider> lookup = CompletableFuture.supplyAsync(() -> preset.buildPatch(registryAccess));
+		CompletableFuture<HolderLookup.Provider> lookup = CompletableFuture.supplyAsync(() -> preset.buildPatch(registries));
 		
 		packGenerator.addProvider((output) -> {
 			return DataGenUtil.createRegistryProvider(output, lookup);

--- a/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
+++ b/common/src/main/java/raccoonman/reterraforged/data/worldgen/preset/settings/Preset.java
@@ -57,7 +57,7 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 		return new Preset(this.world.copy(), this.surface.copy(), this.caves.copy(), this.climate.copy(), this.terrain.copy(), this.rivers.copy(), this.flow.copy(), this.island.copy(), this.filters.copy(), this.structures.copy(), this.miscellaneous.copy(), this.presentation.copy());
 	}
 
-	public HolderLookup.Provider buildPatch(RegistryAccess registries) {
+	public HolderLookup.Provider buildPatch(HolderLookup.Provider registries) {
 		return this.buildPatchedRegistries(registries).patches();
 	}
 
@@ -76,7 +76,7 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 		return provider;
 	}
 
-	private RegistrySetBuilder.PatchedRegistries buildPatchedRegistries(RegistryAccess registries) {
+	private RegistrySetBuilder.PatchedRegistries buildPatchedRegistries(HolderLookup.Provider registries) {
 		RegistrySetBuilder builder = new RegistrySetBuilder();
 
 		// 1. Setup Patches
@@ -120,7 +120,7 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 		// 5. Wrap registries in a safety shield
 		// This ensures the cloner only sees registries we explicitly gave it a codec for.
 		// Unarmed registries (like mixed_litter) will be ignored safely.
-		RegistryAccess safeSource = this.filterToArmedOnly(registries, armedRegistries);
+		HolderLookup.Provider safeSource = this.filterToArmedOnly(registries, armedRegistries);
 
 		return builder.buildPatch(
 				RegistryAccess.fromRegistryOfRegistries(BuiltInRegistries.REGISTRY),
@@ -137,27 +137,16 @@ public record Preset(WorldSettings world, SurfaceSettings surface, CaveSettings 
 		set.add(key);
 	}
 
-	/**
-	 * Creates a virtual view of the RegistryAccess that hides any folders we don't have a cloner for.
-	 */
-	private RegistryAccess filterToArmedOnly(RegistryAccess original, Set<ResourceKey<? extends Registry<?>>> armed) {
-		return new RegistryAccess() {
+	private HolderLookup.Provider filterToArmedOnly(HolderLookup.Provider original, Set<ResourceKey<? extends Registry<?>>> armed) {
+		return new HolderLookup.Provider() {
 			@Override
-			public <T> Optional<Registry<T>> registry(ResourceKey<? extends Registry<? extends T>> key) {
-				// ONLY allow the registry if we have explicitly armed it with a cloner.
-				// This prevents third-party registries injected into the 'minecraft' namespace from crashing us.
-				if (armed.contains(key)) {
-					return original.registry(key);
-				}
-
-				// Hide everything else to keep the cloner happy
-				return Optional.empty();
+			public <T> Optional<HolderLookup.RegistryLookup<T>> lookup(ResourceKey<? extends Registry<? extends T>> key) {
+				return armed.contains(key) ? original.lookup(key) : Optional.empty();
 			}
 
 			@Override
-			public Stream<RegistryEntry<?>> registries() {
-				// Filter out any registry that hasn't been explicitly armed
-				return original.registries().filter(entry -> armed.contains(entry.key()));
+			public Stream<ResourceKey<? extends Registry<?>>> listRegistries() {
+				return original.listRegistries().filter(armed::contains);
 			}
 		};
 	}


### PR DESCRIPTION
> [!IMPORTANT]
> **TL;DR:** 
>
> Its already possible to do headless preset generation programmatically, but it only worked for Neoforge and not Fabric. The PR makes it possible to do so on Fabric now.

## The Problem

Fabric headless datagen gives back a `HolderLookup.Provider`, not a `RegistryAccess`, so callers like `PresetFixtureMain` couldn't use the preset generation API

## The Solution

`RegistrySetBuilder.buildPatch` already accepts `HolderLookup.Provider`, which was very convenient. The issue was that the methods above it just had unnecessarily narrow parameter type. The solution just allows them to pass the parameter types needed for both Fabric and Neoforge.