### PR TITLE
Guard against RTF / FTF parallelism

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -35,7 +35,8 @@
     "minecraft": ">=1.21.1"
   },
   "breaks": {
-    "biolith": "<3.0.14"
+    "biolith": "<3.0.14",
+    "reterraforged": "*"
   },
   "mixins": [
     "freeterraforged-common.mixins.json",

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -40,3 +40,11 @@ license="MIT"
     versionRange = "[3.0.14,)"
     ordering = "AFTER"
     side = "BOTH"
+
+[[dependencies.your_mod_id]]
+modId = "reterraforged"
+type = "incompatible"
+reason = "RTF is an ancestor of FTF and as such cannot be used in parallel with it."
+versionRange = "*"
+ordering = "NONE"
+side = "BOTH"


### PR DESCRIPTION
Adds an explicit conflict for the modloaders about RTF/FTF.

Having both RTF and FTF side by side causes redirect method conflicts before any mod loader level validation is run, so this is a little academic, but I think it's worth being explicit. 